### PR TITLE
[Kernel] Enable fast random sample on Kunlun3 Platform

### DIFF
--- a/vllm_kunlun/v1/sample/ops/topk_topp_sampler.py
+++ b/vllm_kunlun/v1/sample/ops/topk_topp_sampler.py
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 from typing import Optional
-
+import os
 import torch
 import torch.nn as nn
 from packaging import version


### PR DESCRIPTION
When temperature sampling is enabled with a large topk setting, the P800 experiences performance degradation during the random sampling phase. Therefore, a fast_sample switch has been added to enable a faster algorithm.