### PR TITLE
[Kernel] Optimize the performance of Qwen3-Next

### DIFF
--- a/vllm_kunlun/ops/fla/fused_recurrent.py
+++ b/vllm_kunlun/ops/fla/fused_recurrent.py
@@ -44,6 +44,7 @@ class FusedRecurrentFunction(torch.autograd.Function):
             h0_indices=ssm_state_indices,
             num_accepted_tokens=num_accepted_tokens,
             use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
+            is_h0_transposed=True
         )
         return o, final_state
 


### PR DESCRIPTION
Optimize the performance of Qwen3-Next, including:

- optimize the performance of fused_recurrent_gated_delta_rule.
- fix the bug of flash attention in prefill when using Qwen3-Next.
- optimize the performance of the operation for ssm state.