### PR TITLE
[Feature] support compressed-tensors w4a16 quantization

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,14 @@ By utilizing the vLLM Kunlun plugin, popular open-source models, including Trans
       <td class="status-support">✅</td>
       <td></td>
     </tr>
+    <tr>
+      <td class="model-name">Kimi-K2</td>
+      <td class="status-support">✅</td>
+      <td class="status-support">✅</td>
+      <td></td>
+      <td class="status-support">✅</td>
+      <td></td>
+    </tr>
   </tbody>
 </table>
 

--- a/docs/source/user_guide/feature_guide/quantization.md
+++ b/docs/source/user_guide/feature_guide/quantization.md
@@ -8,22 +8,23 @@ Like vLLM, we now support quantization methods such as compressed-tensors, AWQ, 
 <table border="1" style="border-collapse: collapse; width: auto; margin: 0 0 0 0; text-align: center;">
   <thead>
     <tr>
-      <td colspan="2" style="padding: 10px; font-weight: bold; border: 1px solid #000;">Compressed-Tensor (w8a8)</td>
+      <td colspan="2" style="padding: 10px; font-weight: bold; border: 1px solid #000;">Compressed-Tensors (w8a8-Int8)</td>
       <td colspan="4" style="padding: 10px; font-weight: bold; border: 1px solid #000;">Weight only (w4a16/w8a16)</td>
     </tr>
     <tr>
       <td style="padding: 10px; border: 1px solid #000;">Dynamic</td>
       <td style="padding: 10px; border: 1px solid #000;">Static</td>
-      <td colspan="2" style="padding: 10px; border: 1px solid #000;">AWQ (w4a16)</td>
+      <td colspan="1" style="padding: 10px; border: 1px solid #000;">AWQ (w4a16)</td>
       <td colspan="2" style="padding: 10px; border: 1px solid #000;">GPTQ (w4a16/w8a16)</td>
+       <td colspan="1" style="padding: 10px; border: 1px solid #000;">Compressed-Tensors (w4a16)</td>
     </tr>
     <tr>
       <td style="padding: 10px; border: 1px solid #000;">Dense/MoE</td>
       <td style="padding: 10px; border: 1px solid #000;">Dense/MoE</td>
+      <td style="padding: 10px; border: 1px solid #000;">Dense/MoE</td>
       <td style="padding: 10px; border: 1px solid #000;">Dense</td>
       <td style="padding: 10px; border: 1px solid #000;">MoE</td>
-      <td style="padding: 10px; border: 1px solid #000;">Dense</td>
-      <td style="padding: 10px; border: 1px solid #000;">MoE</td>
+      <td style="padding: 10px; border: 1px solid #000;">Dense/MoE</td>
     </tr>
   </thead>
   <tbody>
@@ -32,14 +33,16 @@ Like vLLM, we now support quantization methods such as compressed-tensors, AWQ, 
       <td style="padding: 10px; border: 1px solid #000;">✅</td>
       <td style="padding: 10px; border: 1px solid #000;">✅</td>
       <td style="padding: 10px; border: 1px solid #000;">✅</td>
-      <td style="padding: 10px; border: 1px solid #000;">✅</td>
       <td style="padding: 10px; border: 1px solid #000;">WIP</td>
+      <td style="padding: 10px; border: 1px solid #000;">✅</td>
     </tr>
   </tbody>
 </table>
 
-+ W8A8 dynamic and static quantization are now supported for all LLMs and VLMs.
-+ AWQ/GPTQ quantization is supported for all dense models.
++ Compressed-Tensors w8a8-Int8 dynamic and static quantization are supported for all LLMs and VLMs.
++ Compressed-Tensors w4a16 are supported for all LLMs and VLMs.
++ AWQ(w4a16) quantization is supported for all LLMs and VLMs.
++ GPTQ (w4a16/w8a16) quantization is supported for all dense models.
 
 ## Usages
 

--- a/vllm_kunlun/ops/__init__.py
+++ b/vllm_kunlun/ops/__init__.py
@@ -15,13 +15,20 @@
 # This file is a part of the vllm-ascend project.
 #
 
+# embedding
 import vllm_kunlun.ops.rotary_embedding
-import vllm_kunlun.ops.layernorm
+import vllm_kunlun.ops.vocab_parallel_embedding
+
+# quantization
 import vllm_kunlun.ops.quantization.awq
 import vllm_kunlun.ops.quantization.gptq
 import vllm_kunlun.ops.quantization.moe_wna16
-import vllm_kunlun.ops.vocab_parallel_embedding
-import vllm_kunlun.ops.linear
-import vllm_kunlun.ops.fused_moe.layer
+import vllm_kunlun.ops.quantization.compressed_tensors.compressed_tensors
 import vllm_kunlun.ops.quantization.compressed_tensors.compressed_tensors_moe
 import vllm_kunlun.ops.quantization.kernels.kunlun_scale_mm
+import vllm_kunlun.ops.quantization.kernels.kunlun_exllama_linear
+
+# base layers
+import vllm_kunlun.ops.layernorm
+import vllm_kunlun.ops.linear
+import vllm_kunlun.ops.fused_moe.layer

--- a/vllm_kunlun/ops/quantization/compressed_tensors/compressed_tensors.py
+++ b/vllm_kunlun/ops/quantization/compressed_tensors/compressed_tensors.py
@@ -1,0 +1,86 @@
+#
+# Copyright (c) 2026 Baidu, Inc. All Rights Reserved.
+# Author: Li Wei, Tang Shiwen
+# Email: liwei157@baidu.com, tangshiwen@baidu.com
+# This file is a part of the vllm-kunlun project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Optional
+import torch
+from vllm.model_executor.layers.quantization.base_config import QuantizeMethodBase
+from vllm.model_executor.layers.fused_moe import FusedMoE
+from vllm.model_executor.layers.linear import (
+    LinearBase,
+    LinearMethodBase,
+    UnquantizedLinearMethod,
+)
+from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tensors import (
+    CompressedTensorsConfig,
+    CompressedTensorsLinearMethod,
+    CompressedTensorsKVCacheMethod,
+    CompressedTensorsLinearTransformMethod,
+    get_linear_transform_schemes,
+)
+from vllm_kunlun.ops.quantization.compressed_tensors.compressed_tensors_moe import (
+    KunlunCompressedTensorsMoEMethod,
+)
+
+
+class KunlunCompressedTensorsConfig(CompressedTensorsConfig):
+    def get_quant_method(
+        self,
+        layer: torch.nn.Module,
+        prefix: str,
+    ) -> Optional["QuantizeMethodBase"]:
+        from vllm.attention.layer import Attention  # Avoid circular import
+
+        if isinstance(layer, LinearBase):
+            # collect schemes
+            quant_scheme = self.get_scheme(layer=layer, layer_name=prefix)
+            input_tfms, output_tfms = get_linear_transform_schemes(
+                layer, prefix, self.transform_config, self.packed_modules_mapping
+            )
+
+            # choose quantization method
+            quant_method: LinearMethodBase = UnquantizedLinearMethod()
+            if quant_scheme is not None:
+                layer.scheme = quant_scheme
+                quant_method = CompressedTensorsLinearMethod(self)
+
+            # choose transform method
+            if any((input_tfms, output_tfms)):
+                return CompressedTensorsLinearTransformMethod.from_schemes(
+                    quant_method, quant_scheme, input_tfms, output_tfms
+                )
+
+            else:
+                return quant_method
+
+        if isinstance(layer, Attention):
+            return CompressedTensorsKVCacheMethod(self)
+        if isinstance(layer, FusedMoE):
+            return KunlunCompressedTensorsMoEMethod.get_moe_method(self, layer)
+        return None
+
+
+# monkey patch
+from vllm.model_executor.layers.quantization.compressed_tensors import (
+    compressed_tensors,
+)
+
+compressed_tensors.CompressedTensorsConfig = KunlunCompressedTensorsConfig
+print(
+    "[Monkey Patch Applied] >>> vllm.model_executor.layers.quantization.compressed_tensors.compressed_tensors.CompressedTensorsConfig \
+      --> vllm_kunlun.ops.quantization.compressed_tensors.KunlunCompressedTensorsConfig"
+)

--- a/vllm_kunlun/ops/quantization/kernels/kunlun_exllama_linear.py
+++ b/vllm_kunlun/ops/quantization/kernels/kunlun_exllama_linear.py
@@ -1,0 +1,57 @@
+#
+# Copyright (c) 2026 Baidu, Inc. All Rights Reserved.
+# Author: Li Wei
+# Email: liwei157@baidu.com
+# This file is a part of the vllm-kunlun project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Optional
+
+import torch
+import xspeedgate_ops
+from vllm.model_executor.layers.quantization.kernels.mixed_precision import (
+    ExllamaLinearKernel,
+    _POSSIBLE_KERNELS,
+)
+
+
+class KunlunExllamaLinearKernel(ExllamaLinearKernel):
+
+    def apply_weights(
+        self,
+        layer: torch.nn.Module,
+        x: torch.Tensor,
+        bias: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        c = self.config
+
+        x_2d = x.reshape(-1, x.shape[-1])
+        out_shape = x.shape[:-1] + (c.partition_weight_shape[1],)
+
+        w_q, w_s, w_zp, w_g_idx = self._get_weight_params(layer)
+
+        assert w_zp is not None, "Zero points are required by Exllama"
+        assert w_g_idx is not None, "Group index is required by Exllama"
+        output = torch.ops.xspeedgate_ops.gptq_gemm(
+            x_2d, w_q, w_zp, w_s, w_g_idx, True, c.weight_type.size_bits
+        )
+
+        if bias is not None:
+            output.add_(bias)
+        return output.reshape(out_shape)
+
+
+# remove ExllamaLinearKernel and add KunlunExllamaLinearKernel
+_POSSIBLE_KERNELS.remove(ExllamaLinearKernel)
+_POSSIBLE_KERNELS.append(KunlunExllamaLinearKernel)

--- a/vllm_kunlun/ops/quantization/kernels/kunlun_scale_mm.py
+++ b/vllm_kunlun/ops/quantization/kernels/kunlun_scale_mm.py
@@ -99,12 +99,5 @@ class KunlunScaledMMLinearKernel(CutlassScaledMMLinearKernel):
             # )
 
 
-# monkey patch
+# replace CutlassScaledMMLinearKernel with KunlunScaledMMLinearKernel
 _POSSIBLE_KERNELS[PlatformEnum.CUDA] = [KunlunScaledMMLinearKernel]
-from vllm.model_executor.layers.quantization.kernels.scaled_mm import cutlass
-
-cutlass.CutlassScaledMMLinearKernel = KunlunScaledMMLinearKernel
-print(
-    "[Monkey Patch Applied] >>> vllm.model_executor.layers.quantization.kernels.scaled_mm.cutlass.CutlassScaledMMLinearKernel \
-      --> vllm_kunlun.ops.quantization.kernels.kunlun_scale_mm.KunlunScaledMMLinearKernel"
-)

--- a/vllm_kunlun/vllm_utils_wrapper.py
+++ b/vllm_kunlun/vllm_utils_wrapper.py
@@ -2275,7 +2275,7 @@ fwd_kvcache_mla.register_fake(_fake_fwd_kvcache_mla)
 
 
 ##################################################
-# --------------- dequant_int4 -----------------
+# --------------- dequant_int4 -------------------
 ##################################################
 @custom_op("_C::dequant_int4", mutates_args=())
 def dequant_int4(


### PR DESCRIPTION
## PR Description
Native int4 Kimi-K2 model inference is supported:
<img width="1040" height="298" alt="d889bdcf2a83fcfb691c60356ed6941d" src="https://github.com/user-attachments/assets/77664300-dc46-4d5d-b466-7b29f3f5010c" />

Note: performance will be optimized soon.