### PR TITLE
[Update] 1/N for v0.15.1 Update-Fixed the issue in v0.15.1 where the Kunlun plugin failed to initialize due to circular references

### DIFF
--- a/vllm_kunlun/schema.py
+++ b/vllm_kunlun/schema.py
@@ -1,0 +1,98 @@
+import inspect
+import typing
+from typing import Callable, List, Optional, get_args, get_origin
+
+import torch
+import vllm.utils.torch_utils as torch_utils_orig
+from torch.library import Library
+
+
+def supports_custom_op() -> bool:
+    """supports_custom_op"""
+    return hasattr(torch.library, "custom_op")
+
+
+vllm_lib = Library("vllm", "FRAGMENT")  # noqa
+
+
+def direct_register_custom_op(
+    op_name: str,
+    op_func: Callable,
+    mutates_args: Optional[list[str]] = None,
+    fake_impl: Optional[Callable] = None,
+    target_lib: Optional[Library] = None,
+    dispatch_key: str = "CUDA",
+    tags: tuple[torch.Tag, ...] = (),
+):
+    """
+    `torch.library.custom_op` can have significant overhead because it
+    needs to consider complicated dispatching logic. This function
+    directly registers a custom op and dispatches it to the CUDA backend.
+    See https://gist.github.com/youkaichao/ecbea9ec9fc79a45d2adce1784d7a9a5
+    for more details.
+
+    By default, the custom op is registered to the vLLM library. If you
+    want to register it to a different library, you can pass the library
+    object to the `target_lib` argument.
+
+    IMPORTANT: the lifetime of the operator is tied to the lifetime of the
+    library object. If you want to bind the operator to a different library,
+    make sure the library object is alive when the operator is used.
+    """
+    if not supports_custom_op():
+        from vllm.platforms import current_platform
+
+        assert not current_platform.is_cuda_alike(), (
+            "cuda platform needs torch>=2.4 to support custom op, "
+            "chances are you are using an old version of pytorch "
+            "or a custom build of pytorch. It is recommended to "
+            "use vLLM in a fresh new environment and let it install "
+            "the required dependencies."
+        )
+        return
+    if mutates_args is None:
+        mutates_args = []
+    import torch.library
+
+    if hasattr(torch.library, "infer_schema"):
+        patch_annotations_for_schema(op_func)
+        schema_str = torch.library.infer_schema(op_func, mutates_args=mutates_args)
+    else:
+        # for pytorch 2.4
+        import torch._custom_op.impl
+
+        schema_str = torch._custom_op.impl.infer_schema(op_func, mutates_args)
+    my_lib = target_lib or vllm_lib
+    my_lib.define(op_name + schema_str, tags=tags)
+    my_lib.impl(op_name, op_func, dispatch_key=dispatch_key)
+    if fake_impl is not None:
+        my_lib._register_fake(op_name, fake_impl)
+
+
+def patch_annotations_for_schema(func):
+    """patch_annotations_for_schema"""
+    sig = inspect.signature(func)
+    new_params = []
+
+    for name, param in sig.parameters.items():
+        ann = param.annotation
+
+        if get_origin(ann) is typing.Union and type(None) in get_args(ann):
+            inner_type = [a for a in get_args(ann) if a is not type(None)][0]
+            if get_origin(inner_type) is list:  # Optional[list[int]]
+                inner_args = get_args(inner_type)
+                new_ann = Optional[List[inner_args[0] if inner_args else typing.Any]]
+                param = param.replace(annotation=new_ann)
+
+        elif get_origin(ann) is list:
+            args = get_args(ann)
+            new_ann = List[args[0] if args else typing.Any]
+            param = param.replace(annotation=new_ann)
+
+        new_params.append(param)
+
+    func.__signature__ = sig.replace(parameters=new_params)
+    return func
+
+
+torch_utils_orig.direct_register_custom_op = direct_register_custom_op


### PR DESCRIPTION
## PR Description

<!--
Please provide a clear and concise description of this PR:
- What problem does it solve?
- Why is this change needed?
- What is the overall approach?
-->

### Summary

This PR fixes a critical initialization failure in vLLM v0.15.1 where the Kunlun plugin could not start due to **circular import references**. The root cause was that `direct_register_custom_op`, `patch_annotations_for_schema`, and related utilities were defined in `vllm_utils_wrapper.py`, which had heavy transitive imports creating a circular dependency chain during plugin registration. The fix extracts these utilities into a dedicated, lightweight `schema.py` module and restructures the `register()` entry point with proper error handling and logging.

### Problem

When upgrading to vLLM v0.15.1, the Kunlun plugin failed to initialize with a circular import error. The dependency chain was:

```
vllm_kunlun.__init__.register()
  → imports from vllm_utils_wrapper.py
    → imports vllm.utils (weak_ref_tensor, etc.)
      → triggers vllm internal imports
        → attempts to load platform plugin (vllm_kunlun)
          → circular reference back to vllm_kunlun.__init__
```

### Solution

#### 1. Extract custom op utilities into a new `vllm_kunlun/schema.py`

Moved `direct_register_custom_op`, `patch_annotations_for_schema`, `supports_custom_op`, and `vllm_lib` out of `vllm_utils_wrapper.py` into a new standalone module `schema.py`. This module has minimal dependencies and can be safely imported during early plugin registration without triggering circular imports.

Key change in `schema.py`:
```python
import vllm.utils.torch_utils as torch_utils_orig
# ...
torch_utils_orig.direct_register_custom_op = direct_register_custom_op
```
This patches `direct_register_custom_op` directly into `vllm.utils.torch_utils` at import time, ensuring all downstream vLLM code uses the Kunlun-compatible version.

#### 2. Restructure `vllm_kunlun/__init__.py` — break the circular chain

- **Removed eager top-level imports** that triggered circular dependencies:
  - `from .platforms import current_platform` (removed)
  - `from .utils import redirect_output` (removed from `register()`)
  - `from .vllm_utils_wrapper import direct_register_custom_op, patch_annotations_for_schema` → replaced with `from .schema import ...`
  - `import vllm.envs as envs` (removed)
- **Added structured error handling** with `try/except` blocks and `logging` throughout `register()` for better debuggability
- **Temporarily disabled** GLM5 config patch and `ModelConfig.is_deepseek_mla` patch (marked with `TODO`) as they also trigger circular imports in v0.15.1
- **Removed duplicate entry** in `module_mappings` (`vllm.v1.sample.ops.topk_topp_sampler` was listed twice)

#### 3. Clean up `vllm_utils_wrapper.py`

- Removed ~95 lines of `direct_register_custom_op`, `patch_annotations_for_schema`, `supports_custom_op`, and `vllm_lib` (now in `schema.py`)
- Removed `_wrapped.direct_register_custom_op = direct_register_custom_op` from the `SimpleNamespace` wrapper since patching is now handled in `schema.py`
- Cleaned up unused imports (`inspect`, `typing`, `Callable`, `get_args`, `get_origin`, `Library`)

#### 4. Update `vllm_kunlun/utils.py` — import path fix & logging

- Fixed import path: `from vllm.utils import weak_ref_tensor` → `from vllm.utils.torch_utils import weak_ref_tensor` (aligned with v0.15.1 module restructuring)
- Added `logging` and `time` imports for initialization diagnostics
- Code style cleanup: normalized imports order, whitespace, and trailing commas

### Files Changed

| File | Additions | Deletions | Description |
|------|-----------|-----------|-------------|
| `vllm_kunlun/__init__.py` | +54 | -27 | Restructured `register()` to avoid circular imports; added logging and error handling |
| `vllm_kunlun/schema.py` | +98 | 0 | **New file** — extracted custom op registration utilities with minimal dependencies |
| `vllm_kunlun/utils.py` | +90 | -51 | Fixed `weak_ref_tensor` import path; added logging; code style cleanup |
| `vllm_kunlun/vllm_utils_wrapper.py` | +2 | -95 | Removed custom op utilities (moved to `schema.py`); cleaned up unused imports |

### Impact

- ✅ **Fixes critical bug**: Kunlun plugin now initializes successfully on vLLM v0.15.1 without circular import errors
- ✅ **Better separation of concerns**: Custom op registration logic is isolated in `schema.py` with minimal dependencies
- ✅ **Improved debuggability**: `register()` now has structured `try/except` blocks and `logging` output for each initialization step
- ✅ **Net code reduction**: -173 lines deleted, +244 lines added (net +71), but ~95 lines were moved rather than newly written
- ⚠️ **Known TODOs**: GLM5 config patch and `ModelConfig.is_deepseek_mla` patch are temporarily disabled pending further v0.15.1 compatibility fixes (tracked as `TODO @xyDong0223`)
<!-- Link the existing issue(s) this PR resolves, e.g.:
FIX #1234
-->

---

## Checklist (Required)

Before submitting this PR, please ensure that all the following items are completed:

- [x] All code changes pass the [`pre-commit`](https://github.com/baidu/vLLM-Kunlun/blob/main/CONTRIBUTING.md) checks.
- [x] Commits are signed off using `git commit -s`.
- [x] The PR title is properly classified (see below).

---

## PR Type

Please prefix the PR title with one or more of the following labels to help reviewers quickly understand the nature of the change:

- `[Feature]` – New features or enhancements (e.g. Attention, Communicator, Kernel, Worker, etc.)
- `[Bugfix]` – Bug fixes
- `[CI/Build]` – CI, build system, or infrastructure improvements
- `[Doc]` – Documentation updates or fixes
- `[Misc]` – Other changes that do not fit the above categories (use sparingly)

> **Note:** If the PR spans multiple categories, include all relevant prefixes.

---

<details>
<summary><b>Detailed Checklist (Click to Expand)</b></summary>

<p>Thank you for contributing to <b>vLLM Kunlun</b>!  
To help us maintain high code quality and streamline the review process, please ensure your PR meets the following requirements.</p>

<h3>1. Code Quality</h3>

<ul>
    <li>All linting and formatting checks pass (<code>pre-commit</code>).</li>
    <li>The code is well-structured and sufficiently documented.</li>
    <li>The change is designed with maintainability and readability in mind.</li>
</ul>

<h3>2. Testing</h3>

<ul>
    <li>Relevant unit tests are added or updated.</li>
    <li>Integration tests are included when applicable.</li>
    <li>Existing tests continue to pass.</li>
</ul>

<h3>3. DCO Compliance</h3>

<p>This project follows the
<a href="https://github.com/vllm-project/vllm/blob/main/DCO">Developer Certificate of Origin (DCO)</a>.</p>

<ul>
    <li>All commits include a <code>Signed-off-by:</code> line.</li>
    <li>Use <code>git commit -s</code> to automatically add the sign-off.</li>
</ul>

<h3>4. Review Expectations</h3>

<p>During the review process, maintainers may:</p>

<ul>
    <li>Request code refactoring or additional tests.</li>
    <li>Ask for clarifications on design decisions.</li>
    <li>Suggest performance, stability, or maintainability improvements.</li>
</ul>

<p>We appreciate your patience and collaboration throughout the review process!</p>

</details>
