### PR TITLE
[Update] 1/N for v0.15.1 Optimize utils, remove the VLLM_USE_V1 check in the code, and correct the dependency sources and names

### DIFF
--- a/vllm_kunlun/models/__init__.py
+++ b/vllm_kunlun/models/__init__.py
@@ -2,96 +2,97 @@ from vllm import ModelRegistry
 
 
 def register_model():
+
+    # TODO Remove all of models registration below
+
     # from .demo_model import DemoModel  # noqa: F401
-    from .qwen2_vl import Qwen2VLForConditionalGeneration #noqa: F401
-    from .qwen2_5_vl import Qwen2_5_VLForConditionalGeneration #noqa: F401
-    from .qwen3_moe import Qwen3MoeForCausalLM #noqa: F401
-    from .qwen3_vl import Qwen3VLForConditionalGeneration
-    from .qwen3_vl_moe import Qwen3VLMoeForConditionalGeneration
-    from .qwen3_omni_moe_thinker import Qwen3OmniMoeThinkerForConditionalGeneration
-    # from .llama4 import Llama4ForCausalLM #noqa: F401
-    # from .mllama4 import Llama4ForConditionalGeneration #noqa: F401
-    # from .deepseek_v2 import KunlunDeepseekV2MoE
-    
+
     # ModelRegistry.register_model(
     #     "DemoModel",
     #     "vllm_kunlun.model_executor.models.demo_model:DemoModel")
 
     ModelRegistry.register_model(
         "Qwen2VLForConditionalGeneration",
-        "vllm_kunlun.models.qwen2_vl:Qwen2VLForConditionalGeneration")
+        "vllm_kunlun.models.qwen2_vl:Qwen2VLForConditionalGeneration",
+    )
 
     ModelRegistry.register_model(
         "Qwen2_5_VLForConditionalGeneration",
-        "vllm_kunlun.models.qwen2_5_vl:Qwen2_5_VLForConditionalGeneration")
+        "vllm_kunlun.models.qwen2_5_vl:Qwen2_5_VLForConditionalGeneration",
+    )
+
+    # Remove in v0.15.1
+    # ModelRegistry.register_model(
+    #     "Qwen3ForCausalLM",
+    #     "vllm_kunlun.models.qwen3:Qwen3ForCausalLM")
+
+    # ModelRegistry.register_model(
+    #     "Qwen3MoeForCausalLM",
+    #     "vllm_kunlun.models.qwen3_moe:Qwen3MoeForCausalLM")
 
     ModelRegistry.register_model(
-        "Qwen3ForCausalLM",
-        "vllm_kunlun.models.qwen3:Qwen3ForCausalLM")
+        "Qwen3NextForCausalLM", "vllm_kunlun.models.qwen3_next:Qwen3NextForCausalLM"
+    )
 
     ModelRegistry.register_model(
-        "Qwen3MoeForCausalLM",
-        "vllm_kunlun.models.qwen3_moe:Qwen3MoeForCausalLM")
+        "GptOssForCausalLM", "vllm_kunlun.models.gpt_oss:GptOssForCausalLM"
+    )
 
     ModelRegistry.register_model(
-        "Qwen3NextForCausalLM",
-        "vllm_kunlun.models.qwen3_next:Qwen3NextForCausalLM")
+        "InternLM2ForCausalLM", "vllm_kunlun.models.internlm2:InternLM2ForCausalLM"
+    )
 
     ModelRegistry.register_model(
-        "GptOssForCausalLM",
-        "vllm_kunlun.models.gpt_oss:GptOssForCausalLM")  
-
-    ModelRegistry.register_model(
-        "InternLM2ForCausalLM",
-        "vllm_kunlun.models.internlm2:InternLM2ForCausalLM")
-    
-    ModelRegistry.register_model(
-        "InternVLChatModel",
-        "vllm_kunlun.models.internvl:InternVLChatModel")
+        "InternVLChatModel", "vllm_kunlun.models.internvl:InternVLChatModel"
+    )
 
     ModelRegistry.register_model(
         "InternS1ForConditionalGeneration",
-        "vllm_kunlun.models.interns1:InternS1ForConditionalGeneration")
-    
-    ModelRegistry.register_model(
-        "Qwen3VLForConditionalGeneration",
-        "vllm_kunlun.models.qwen3_vl:Qwen3VLForConditionalGeneration")
-    
-    ModelRegistry.register_model(
-        "Qwen3VLMoeForConditionalGeneration",
-        "vllm_kunlun.models.qwen3_vl_moe:Qwen3VLMoeForConditionalGeneration")
+        "vllm_kunlun.models.interns1:InternS1ForConditionalGeneration",
+    )
+
+    # Remove in v0.15.1
+    # ModelRegistry.register_model(
+    #     "Qwen3VLForConditionalGeneration",
+    #     "vllm_kunlun.models.qwen3_vl:Qwen3VLForConditionalGeneration")
+
+    # ModelRegistry.register_model(
+    #     "Qwen3VLMoeForConditionalGeneration",
+    #     "vllm_kunlun.models.qwen3_vl_moe:Qwen3VLMoeForConditionalGeneration")
+
+    # ModelRegistry.register_model(
+    #     "Qwen3OmniMoeForConditionalGeneration",
+    #     "vllm_kunlun.models.qwen3_omni_moe_thinker:Qwen3OmniMoeThinkerForConditionalGeneration")
 
     ModelRegistry.register_model(
-        "Qwen3OmniMoeForConditionalGeneration",
-        "vllm_kunlun.models.qwen3_omni_moe_thinker:Qwen3OmniMoeThinkerForConditionalGeneration")
-
-    ModelRegistry.register_model(
-        "SeedOssForCausalLM",
-        "vllm_kunlun.models.seed_oss:SeedOssForCausalLM")
+        "SeedOssForCausalLM", "vllm_kunlun.models.seed_oss:SeedOssForCausalLM"
+    )
 
     ModelRegistry.register_model(
         "MiMoV2FlashForCausalLM",
-        "vllm_kunlun.models.mimo_v2_flash:MiMoV2FlashForCausalLM")
+        "vllm_kunlun.models.mimo_v2_flash:MiMoV2FlashForCausalLM",
+    )
 
     ModelRegistry.register_model(
-        "GptOssForCausalLM",
-        "vllm_kunlun.models.gpt_oss:GptOssForCausalLM")   
+        "GptOssForCausalLM", "vllm_kunlun.models.gpt_oss:GptOssForCausalLM"
+    )
 
     ModelRegistry.register_model(
-        "DeepseekV3ForCausalLM",
-        "vllm_kunlun.models.deepseek_v2:DeepseekV3ForCausalLM")
+        "DeepseekV3ForCausalLM", "vllm_kunlun.models.deepseek_v2:DeepseekV3ForCausalLM"
+    )
 
     ModelRegistry.register_model(
-        "DeepseekV32ForCausalLM",
-        "vllm_kunlun.models.deepseek_v2:DeepseekV3ForCausalLM")
-    
-    ModelRegistry.register_model(
-        "DeepSeekMTPModel",
-        "vllm_kunlun.models.deepseek_mtp:DeepSeekMTP")
+        "DeepseekV32ForCausalLM", "vllm_kunlun.models.deepseek_v2:DeepseekV3ForCausalLM"
+    )
 
     ModelRegistry.register_model(
-        "GlmMoeDsaForCausalLM",
-        "vllm_kunlun.models.deepseek_v2:GlmMoeDsaForCausalLM")
+        "DeepSeekMTPModel", "vllm_kunlun.models.deepseek_mtp:DeepSeekMTP"
+    )
+
+    ModelRegistry.register_model(
+        "GlmMoeDsaForCausalLM", "vllm_kunlun.models.deepseek_v2:GlmMoeDsaForCausalLM"
+    )
+
 
 def register_quant_method():
     """to do"""

--- a/vllm_kunlun/ops/__init__.py
+++ b/vllm_kunlun/ops/__init__.py
@@ -21,16 +21,20 @@ import vllm_kunlun.ops.fused_moe.layer
 import vllm_kunlun.ops.layernorm
 import vllm_kunlun.ops.linear
 
-# quantization
-import vllm_kunlun.ops.quantization.awq
-import vllm_kunlun.ops.quantization.compressed_tensors.compressed_tensors
-import vllm_kunlun.ops.quantization.compressed_tensors.compressed_tensors_moe
-import vllm_kunlun.ops.quantization.gptq
-import vllm_kunlun.ops.quantization.kernels.kunlun_exllama_linear
-import vllm_kunlun.ops.quantization.kernels.kunlun_scale_mm
-import vllm_kunlun.ops.quantization.moe_wna16
-
 # embedding
 import vllm_kunlun.ops.rotary_embedding
 import vllm_kunlun.ops.vocab_parallel_embedding
-import vllm_kunlun.v1.sample.spec_decode.eagle
+import vllm_kunlun.v1.sample.spec_decode.eagle  # noqa: F401
+
+# TODO @xyDong0223 remove v0.16.0
+# import vllm_kunlun.ops.mla
+
+# quantization
+# TODO @liwei109 enable quantization in v0.16.0
+# import vllm_kunlun.ops.quantization.awq
+# import vllm_kunlun.ops.quantization.compressed_tensors.compressed_tensors
+# import vllm_kunlun.ops.quantization.compressed_tensors.compressed_tensors_moe
+# import vllm_kunlun.ops.quantization.gptq
+# import vllm_kunlun.ops.quantization.kernels.kunlun_exllama_linear
+# import vllm_kunlun.ops.quantization.kernels.kunlun_scale_mm
+# import vllm_kunlun.ops.quantization.moe_wna16

--- a/vllm_kunlun/platforms/kunlun.py
+++ b/vllm_kunlun/platforms/kunlun.py
@@ -1,29 +1,42 @@
 """kunlun"""
+
+from typing import TYPE_CHECKING, Optional
+
 import psutil
 import torch
-
-from vllm.platforms.interface import DeviceCapability, Platform, PlatformEnum, _Backend
-from typing import Optional, Union
 import vllm.envs as envs
+from vllm.config import ModelConfig, VllmConfig
 from vllm.logger import init_logger
+from vllm.platforms.interface import DeviceCapability, Platform, PlatformEnum
+from vllm.v1.attention.backends.registry import AttentionBackendEnum
+
+if TYPE_CHECKING:
+    from vllm.config import VllmConfig
+    from vllm.v1.attention.selector import AttentionSelectorConfig
+else:
+    VllmConfig = None
 
 
 logger = init_logger(__name__)
 
+
 class KunlunPlatform(Platform):
     """KunlunPlatform"""
-    _enum = PlatformEnum.CUDA 
-    dist_backend:str = "nccl"
+
+    _enum = PlatformEnum.CUDA
+    dist_backend: str = "nccl"
     ray_device_key: str = "GPU"
     device_name: str = "xpu"
 
     @property
     def device_type(self):
         """
-        返回设备类型，固定为'cuda'。
+        Return the device type.
+
+        The device type is always ``"cuda"``.
         """
         return "cuda"
-    
+
     def is_kunlun(self) -> bool:
         """is_kunlun"""
         return self._enum == PlatformEnum.CUDA
@@ -71,13 +84,17 @@ class KunlunPlatform(Platform):
     @classmethod
     def get_device_name(cls, device_id: int = 0) -> str:
         """
-            获取设备名称，默认返回 "kunlun"。
-        
+        Return the device name.
+
+        The device name is always reported as ``"kunlun"``.
+
         Args:
-            device_id (int, optional): 设备ID，默认为0. Ignored in this method. Defaults to 0.
-        
+            device_id (int, optional):
+                The device index. This argument is ignored. Defaults to ``0``.
+
         Returns:
-            str: 设备名称，固定返回 "kunlun".
+            str:
+                Always ``"kunlun"``.
         """
         return "kunlun"
 
@@ -92,25 +109,33 @@ class KunlunPlatform(Platform):
     @classmethod
     def get_device_total_memory(cls, device_id: int = 0) -> int:
         """
-            获取设备总内存大小，单位为字节（B）。默认返回第一个设备的总内存大小。
-        如果传入参数`device_id`不是整数或者超出了可用设备范围，将会引发ValueError异常。
-        
+        Return the total memory capacity of a device in bytes.
+
+        By default, the memory size of device ``0`` is returned. A ``ValueError``
+        is raised if ``device_id`` is not an integer or falls outside the range
+        of available devices.
+
         Args:
-            device_id (int, optional): 设备ID，默认为0. Defaults to 0.
-        
+            device_id (int, optional):
+                The device index. Defaults to ``0``.
+
         Raises:
-            ValueError: 当传入的`device_id`不是整数或者超出了可用设备范围时引发此异常。
-        
+            ValueError:
+                If ``device_id`` is not an integer or is out of range.
+
         Returns:
-            int: 设备总内存大小，单位为字节（B）。
+            int:
+                Total device memory in bytes.
         """
         return psutil.virtual_memory().total
 
     @classmethod
     def inference_mode(cls):
         """
-            进入推理模式，禁止计算梯度。
-        返回：torch.no_grad()，一个上下文管理器，用于禁止计算梯度。
+        Enter inference mode by disabling gradient computation.
+
+        Returns:
+            torch.no_grad: A context manager that disables gradient computation.
         """
         return torch.no_grad()
 
@@ -119,54 +144,51 @@ class KunlunPlatform(Platform):
         """get_device_capability"""
         major, minor = torch.cuda.get_device_capability()
         return DeviceCapability(major=major, minor=minor)
-    
 
     @classmethod
     def check_and_update_config(cls, vllm_config: "VllmConfig") -> None:
         """
-            根据配置更新各个部分的默认值。
-        如果未指定，则根据某些条件自动选择worker类。
-        如果缓存配置中没有设置块大小，则将其设置为16。
-        如果使用MLA，并且`VLLM_ATTENTION_BACKEND`未设置或设置为"FLASHMLA"，
-        则将缓存块大小设置为64。
-        如果在DeepEP高吞吐量后端、数据并行大于1和CUDA图形模式下运行，则强制
-        强制执行即时模式，因为DP + DeepEP高吞吐量内核不是CUDA图形兼容的，而且
-        使用DeepEP低延迟内核可以解决这个问题。
-        
+        TODO Update here for v0.15.1
+
+        Update default values across different config sections.
+
+        If certain fields are not specified, this function will automatically
+        choose appropriate defaults based on runtime conditions.
+
+        - If the cache block size is not set, it defaults to 16.
+        - If MLA is enabled and `VLLM_ATTENTION_BACKEND` is not set or is set
+        to "FLASHMLA", the cache block size will be updated to 64.
+        - When running with the DeepEP high-throughput backend, data parallelism
+        greater than 1, and CUDA graph mode, eager execution will be enforced.
+        This is because DP + DeepEP high-throughput kernels are not compatible
+        with CUDA graphs. The DeepEP low-latency kernels should be used instead.
+
         Args:
-            vllm_config (VllmConfig): VLLM配置对象。
-        
+            vllm_config (VllmConfig): The vLLM configuration object.
+
         Raises:
-            NotImplementedError: 如果在vLLM V1上使用多步调度，则会引发NotImplementedError。
-            请从命令行中删除--num-scheduler-steps参数。
-            NotImplementedError: 如果在vLLM V1上使用MLA，则会引发NotImplementedError。
-            请确保在使用MLA之前设置了`VLLM_ATTENTION_BACKEND`环境变量。
-        
+            NotImplementedError:
+                If multi-step scheduling is used in vLLM V1.
+                Please remove the `--num-scheduler-steps` argument.
+            NotImplementedError:
+                If MLA is used in vLLM V1 without setting the
+                `VLLM_ATTENTION_BACKEND` environment variable.
+
         Returns:
-            None: 无返回值。
+            None.
         """
-        parallel_config = vllm_config.parallel_config
-        scheduler_config = vllm_config.scheduler_config
+        parallel_config = vllm_config.parallel_config  # Not use scheduler_config
+        # scheduler_config = vllm_config.scheduler_config
         model_config = vllm_config.model_config
 
         if parallel_config.worker_cls == "auto":
+            # v0.15.1 do not support v0.15.1, remove the if condition
             if vllm_config.speculative_config:
-                if envs.VLLM_USE_V1:
-                    parallel_config.worker_cls = \
-                            "vllm.v1.worker.gpu_worker.Worker"
-                else:
-                    parallel_config.worker_cls = \
-                        "vllm.spec_decode.spec_decode_worker.create_spec_worker"
-                    parallel_config.sd_worker_cls = \
-                        "vllm.worker.worker.Worker"
+                # if envs.VLLM_USE_V1:
+                parallel_config.worker_cls = "vllm.v1.worker.gpu_worker.Worker"
             else:
-                print(f"envs.VLLM_USE_V1 = {envs.VLLM_USE_V1}")
-                if envs.VLLM_USE_V1:
-                    parallel_config.worker_cls = \
-                            "vllm.v1.worker.gpu_worker.Worker"
-                else:
-                    parallel_config.worker_cls = "vllm.worker.worker.Worker"
-        
+                parallel_config.worker_cls = "vllm.v1.worker.gpu_worker.Worker"
+
         cache_config = vllm_config.cache_config
         if cache_config and cache_config.block_size is None:
             cache_config.block_size = 16
@@ -177,48 +199,58 @@ class KunlunPlatform(Platform):
             # if `VLLM_ATTENTION_BACKEND` is not set and we are using MLA, then
             # we default to FlashMLA backend, so we need to force the blocksize
             # here
-            use_sparse = hasattr(vllm_config.model_config.hf_config,
-                                 "index_topk")
-            use_flashmla = (envs.VLLM_ATTENTION_BACKEND is None \
-                or envs.VLLM_ATTENTION_BACKEND == "FLASHMLA")
+            use_sparse = hasattr(vllm_config.model_config.hf_config, "index_topk")
+            use_flashmla = (
+                envs.VLLM_ATTENTION_BACKEND is None
+                or envs.VLLM_ATTENTION_BACKEND == "FLASHMLA"
+            )
             from vllm.attention.ops.flashmla import is_flashmla_supported
-            if use_flashmla and is_flashmla_supported()[0] \
-                and cache_config.block_size != 64:
+
+            if (
+                use_flashmla
+                and is_flashmla_supported()[0]
+                and cache_config.block_size != 64
+            ):
                 cache_config.block_size = 64
-                logger.info(
-                    "Forcing kv cache block size to 64 for FlashMLA backend.")
+                logger.info("Forcing kv cache block size to 64 for FlashMLA backend.")
             if use_sparse and cache_config.block_size != 64:
                 cache_config.block_size = 64
                 logger.info(
-                    "Forcing kv cache block size to 64 for FlashMLASparse "
-                    "backend.")
+                    "Forcing kv cache block size to 64 for FlashMLASparse " "backend."
+                )
 
-        if (envs.VLLM_ALL2ALL_BACKEND == "deepep_high_throughput"
-                and parallel_config.data_parallel_size > 1
-                and vllm_config.compilation_config.use_cudagraph):
+        if (
+            envs.VLLM_ALL2ALL_BACKEND == "deepep_high_throughput"
+            and parallel_config.data_parallel_size > 1
+            and vllm_config.compilation_config.use_cudagraph
+        ):
             logger.info(
                 "Data Parallel: Forcing enforce eager to be True since DP "
                 "with DeepEP high-throughput kernels are not CUDA Graph "
                 "compatible. The DeepEP low-latency kernels are CUDA Graph "
                 "compatible. Set the all_to_all backend to deepep_low_latency "
-                "to use those kernels instead.")
+                "to use those kernels instead."
+            )
             vllm_config.compilation_config.use_cudagraph = False
             vllm_config.model_config.enforce_eager = True
             # TODO (varun): Turning this ON gives incorrect results for the
             # Deepseek-V2-lite model.
             vllm_config.compilation_config.use_inductor = False
-        if vllm_config.compilation_config.use_cudagraph and envs.VLLM_USE_V1:
-            vllm_config.compilation_config.custom_ops = ["all"]
-            vllm_config.compilation_config.pass_config.enable_fusion = False
-            vllm_config.compilation_config.use_inductor = False
-
+        # v0.15.1 do not support v0.15.1, remove the if condition
+        # if vllm_config.compilation_config.use_cudagraph:
+        #     vllm_config.compilation_config.custom_ops = ["all"]
+        #     vllm_config.compilation_config.pass_config.enable_fusion = False
+        #     vllm_config.compilation_config.use_inductor = False
 
     @classmethod
-    def get_attn_backend_cls(cls, selected_backend, head_size, dtype,
-                             kv_cache_dtype, block_size, use_v1, use_mla,use_sink, use_sparse=False):
+    def get_attn_backend_cls(
+        cls,
+        selected_backend: "AttentionBackendEnum",
+        attn_selector_config: "AttentionSelectorConfig",
+    ) -> str:
         """
             Returns the class of attention backend based on the selected backend and other parameters.
-        
+
         Args:
             selected_backend (str): Selected backend name. Currently supported backends are 'kunlun' and 'default'.
             head_size (int): Size of the attention heads.
@@ -227,41 +259,47 @@ class KunlunPlatform(Platform):
             block_size (int): Block size used in the attention computation.
             use_v1 (bool, optional): Whether to use v1 version of the backend. Defaults to False.
             use_mla (bool, optional): Whether to use MLA version of the backend. Defaults to False.
-        
+
         Returns:
             str: Class name of the attention backend.
         """
-        if use_mla:
-            if use_sparse:
+        if attn_selector_config.use_mla:
+            if attn_selector_config.use_sparse:
                 logger.info_once("Using Sparse MLA backend on V1 engine.")
-                # return ("vllm.v1.attention.backends.mla.flashmla_sparse."
-                #         "FlashMLASparseBackend")
-                return ("vllm_kunlun.v1.attention.backends.mla.flashmla_sparse."
-                        "FlashMLASparseBackend")
+                return (
+                    "vllm_kunlun.v1.attention.backends.mla.flashmla_sparse."
+                    "FlashMLASparseBackend"
+                )
             return "vllm_kunlun.v1.attention.backends.mla.flashmla.FlashMLABackend"
-        if use_v1:
-            return "vllm_kunlun.v1.attention.backends.kunlun_attn.KunlunAttentionBackend"
-        elif not use_mla:                     
-            return "vllm_kunlun.ops.attention.backends.kunlun_attn.KunlunAttentionBackend"
+        elif not attn_selector_config.use_mla:
+            return (
+                "vllm_kunlun.v1.attention.backends.kunlun_attn.KunlunAttentionBackend"
+            )
         else:
-            return "vllm_kunlun.attention.backends.kunlun_mla.KunlunMLAAttentionBackend"
+            return (
+                "vllm_kunlun.v1.attention.backends.kunlun_mla.KunlunMLAAttentionBackend"
+            )
 
     @classmethod
-    def get_current_memory_usage(cls,
-                                 device: Optional[torch.types.Device] = None
-                                 ) -> float:
+    def get_current_memory_usage(
+        cls, device: Optional[torch.types.Device] = None
+    ) -> float:
         """
-        获取当前设备的内存使用情况，包括已分配和最大分配。
-            如果未指定设备，则默认为当前上下文中的设备。
-        
-            Args:
-                device (Optional[torch.types.Device], optional): 可选的设备对象，默认为None。默认为当前上下文中的设备。
-        
-            Returns:
-                float: 返回一个浮点数，表示当前设备的内存使用情况，单位是字节（bytes）。
-        
-            Raises:
-                None.
+        Get the memory usage statistics of the target device, including
+        the currently allocated memory and the peak allocation.
+
+        If no device is specified, the device in the current context is used.
+
+        Args:
+            device (Optional[torch.types.Device], optional):
+                The device to query. Defaults to the current active device.
+
+        Returns:
+            float:
+                The memory usage of the device in bytes.
+
+        Raises:
+            None.
         """
         torch.cuda.reset_peak_memory_stats(device)
         return torch.cuda.max_memory_allocated(device)
@@ -269,27 +307,30 @@ class KunlunPlatform(Platform):
     @classmethod
     def is_async_output_supported(cls, enforce_eager: Optional[bool]) -> bool:
         """
-            判断是否支持异步输出。
-        默认情况下，Kunlun 不支持异步输出。
-        
+        Return whether asynchronous output is supported.
+
+        By default, Kunlun does not support async output.
+
         Args:
-            enforce_eager (Optional[bool], optional): 是否强制使用 eager execution. Defaults to None.
-                None 表示不强制使用 eager execution，而是根据当前环境自动选择。
-        
+            enforce_eager (Optional[bool], optional):
+                Whether to force eager execution. If set to ``None``, the runtime
+                will decide automatically based on the current environment.
+
         Returns:
-            bool: True 表示支持异步输出，False 表示不支持异步输出。
+            bool:
+                ``True`` if async output is supported, otherwise ``False``.
         """
-        # 假设 Kunlun 不支持异步输出
+        # Assume Kunlun does not support async output.
         return False
 
     @classmethod
     def supports_v1(cls, model_config: "ModelConfig") -> bool:
         """
             Check if the model config is supported by this class in v1.
-        
+
         Args:
             model_config (ModelConfig): Model configuration to be checked.
-        
+
         Returns:
             bool: Whether the model config is supported in v1. Always returns True for this class.
         """
@@ -304,23 +345,23 @@ class KunlunPlatform(Platform):
 
     @classmethod
     def get_device_communicator_cls(cls) -> str:
-       '''
-       communicator
-       '''
-       return "vllm_kunlun.distributed.kunlun_communicator.KunlunCommunicator"
+        """
+        communicator
+        """
+        return "vllm_kunlun.distributed.kunlun_communicator.KunlunCommunicator"
 
     @classmethod
     def get_punica_wrapper(cls):
-        ''' 
+        """
         kunlun wrapper
-        '''
+        """
         return "vllm_kunlun.lora.punica_wrapper.punica_kunlun.PunicaWrapperKunlun"
-    
+
     @classmethod
     def check_if_supports_dtype(cls, torch_dtype: torch.dtype):
-        '''
-        Kunlun3平台支持的数据类型
-        '''
+        """
+        Data Types Supported on the Kunlun3 Platform
+        """
         supported_dtypes = {
             torch.float32,
             torch.float16,
@@ -332,13 +373,13 @@ class KunlunPlatform(Platform):
                 f"Kunlun platform does not support dtype {torch_dtype}. "
                 "Supported dtypes are: fp32, fp16, bf16, int8."
             )
-       
+
     def opaque_attention_op(cls) -> bool:
-        '''
-        确保V1 Graph在Kunlun3平台使用vllm.unified_attention_with_output_kunlun作为split ops 
-        '''
+        """
+        Ensure that V1 Graph uses `vllm.unified_attention_with_output_kunlun` as the split op on the Kunlun3 platform.
+        """
         return True
-    
+
     @classmethod
     def support_hybrid_kv_cache(cls) -> bool:
         return True


### PR DESCRIPTION
## PR Description

<!--
Please provide a clear and concise description of this PR:
- What problem does it solve?
- Why is this change needed?
- What is the overall approach?
-->

### Summary

This PR performs a broad alignment of the vLLM-Kunlun plugin codebase with vLLM v0.15.1 API changes. The three main themes are:

1. **Enhanced `patch_annotations_for_schema`** — added support for PEP 604 union syntax (`T | None`) and return-annotation patching.
2. **Removed all `VLLM_USE_V1` conditional checks** — vLLM v0.15.1 is V1-only, so the V0/V1 branching logic is no longer needed.
3. **Corrected import paths and dependency names** to match the v0.15.1 module restructuring.

### Changes

#### 1. `vllm_kunlun/schema.py` — Upgraded `patch_annotations_for_schema`

- **Added `_normalize_ann()` helper**: converts PEP 604 `T | None` (`types.UnionType` in Python 3.10+) to `typing.Union[T, None]`, which is required by `torch.library.infer_schema`.
- **Return annotation patching**: the function now also normalizes the return annotation of the function signature, not just parameters.
- **Cleaner flow**: refactored the parameter-loop to call `_normalize_ann()` first, then handle `Optional[list[T]]` → `Optional[List[T]]` and `list[T]` → `List[T]` conversions in a unified manner.

#### 2. `vllm_kunlun/platforms/kunlun.py` — Remove `VLLM_USE_V1` checks and update APIs

- **Removed all `envs.VLLM_USE_V1` conditionals**: since vLLM v0.15.1 is V1-only, worker class selection now always resolves to `vllm.v1.worker.gpu_worker.Worker` without branching.
- **Removed debug `print()` statements**: e.g., `print(f"envs.VLLM_USE_V1 = {envs.VLLM_USE_V1}")`.
- **Updated `get_attn_backend_cls()` signature**: changed from positional parameters (`head_size, dtype, kv_cache_dtype, block_size, use_v1, use_mla, use_sink, use_sparse`) to the new vLLM v0.15.1 API using `AttentionBackendEnum` and `AttentionSelectorConfig`. Removed the `use_v1` branch in the method body.
- **Updated imports**: added `AttentionBackendEnum`, `AttentionSelectorConfig` (under `TYPE_CHECKING`), `ModelConfig`, `VllmConfig`; removed unused `_Backend` and `Union`.
- **Translated all Chinese docstrings to English** for consistency across the codebase.
- **Temporarily disabled** the `use_cudagraph` custom_ops override (marked with TODO) pending further v0.15.1 validation.

#### 3. `vllm_kunlun/compilation/wrapper.py` — Add `TorchCompileWithNoGuardsWrapper`

- **Added the full `TorchCompileWithNoGuardsWrapper` class** (~120 lines) from vLLM v0.15.1, which provides guard-free `torch.compile` execution. This wrapper:
  - Drops all Dynamo guards when `CompilationMode != STOCK_TORCH_COMPILE`, ensuring single-shot compilation.
  - Supports AOT compilation, bytecode hooks, and NVTX tracing integration.
  - Validates constraints for unbacked dynamic shapes and `VLLM_USE_BYTECODE_HOOK`.
  - Includes a CUDA graph compatibility check that raises `RuntimeError` if nn.Module buffers are modified during forward pass.
- **Code style cleanup** in the existing `TorchCompileWrapperWithCustomDispatcher`: normalized formatting, improved error logging in `bytecode_hook`, removed commented-out dead code.

#### 4. `vllm_kunlun/v1/attention/backends/kunlun_attn.py` — Fix import paths

- **Updated attention abstractions import**: changed from `vllm.attention.backends.abstract` to `vllm.v1.attention.backend` (the new v0.15.1 location for `AttentionBackend`, `AttentionImpl`, `AttentionLayer`, `AttentionMetadata`, `AttentionType`, `AttentionCGSupport`, `CommonAttentionMetadata`).
- **Fixed utility imports**: `cdiv` moved from `vllm.utils` to `vllm.utils.math_utils`; `split_decodes_and_prefills` now imported separately from `vllm.v1.attention.backends.utils`.
- **Changed backend name**: `get_name()` now returns `"CUSTOM"` instead of `"Kunlun_v1"` to align with the `AttentionBackendEnum.CUSTOM` registry in v0.15.1.
- **Removed dead commented-out code**: `get_state_cls()` stub.

#### 5. `vllm_kunlun/models/__init__.py` — Deregister models now supported upstream

- **Commented out** model registrations for `Qwen3ForCausalLM`, `Qwen3MoeForCausalLM`, `Qwen3VLForConditionalGeneration`, `Qwen3VLMoeForConditionalGeneration`, and `Qwen3OmniMoeForConditionalGeneration`. These models are now natively supported in vLLM v0.15.1, so custom registrations would cause conflicts.
- **Removed eager model imports** at the top of `register_model()` (e.g., `from .qwen3_moe import ...`) that were unused after commenting out registrations.

#### 6. `vllm_kunlun/ops/__init__.py` — Temporarily disable quantization and MLA ops

- **Commented out all quantization module imports** (`awq`, `compressed_tensors`, `gptq`, `exllama_linear`, `scale_mm`, `moe_wna16`) — marked with `TODO @liwei109 enable quantization in v0.16.0`.
- **Commented out MLA ops import** — marked with `TODO @xyDong0223 remove v0.16.0`.
- These modules have API incompatibilities with v0.15.1 and will be re-enabled after adaptation.

### Files Changed

| File | +/- | Description |
|------|-----|-------------|
| `vllm_kunlun/schema.py` | +33 / -14 | PEP 604 union support; return annotation patching |
| `vllm_kunlun/platforms/kunlun.py` | +173 / -132 | Remove `VLLM_USE_V1`; update `get_attn_backend_cls` API; translate docstrings |
| `vllm_kunlun/compilation/wrapper.py` | +279 / -29 | Add `TorchCompileWithNoGuardsWrapper`; clean up existing wrapper |
| `vllm_kunlun/v1/attention/backends/kunlun_attn.py` | +18 / -16 | Fix import paths to v0.15.1 locations; rename backend to `CUSTOM` |
| `vllm_kunlun/models/__init__.py` | +54 / -53 | Disable upstream-supported model registrations |
| `vllm_kunlun/ops/__init__.py` | +14 / -10 | Temporarily disable quantization and MLA module imports |

### Impact

- ✅ **V0/V1 ambiguity eliminated**: All `VLLM_USE_V1` conditionals removed; the plugin now targets V1-only execution.
- ✅ **API alignment**: Import paths, function signatures, and backend names match vLLM v0.15.1.
- ✅ **Schema inference robustness**: `patch_annotations_for_schema` now handles PEP 604 syntax and return annotations, preventing `torch.library.infer_schema` failures with modern Python type hints.
- ✅ **Forward-compatible compilation**: `TorchCompileWithNoGuardsWrapper` added for future use.
- ⚠️ **Known TODOs**: Quantization ops and MLA ops are temporarily disabled (tracked for v0.16.0).


---

## Checklist (Required)

Before submitting this PR, please ensure that all the following items are completed:

- [x] All code changes pass the [`pre-commit`](https://github.com/baidu/vLLM-Kunlun/blob/main/CONTRIBUTING.md) checks.
- [x] Commits are signed off using `git commit -s`.
- [x] The PR title is properly classified (see below).

---

## PR Type

Please prefix the PR title with one or more of the following labels to help reviewers quickly understand the nature of the change:

- `[Feature]` – New features or enhancements (e.g. Attention, Communicator, Kernel, Worker, etc.)
- `[Bugfix]` – Bug fixes
- `[CI/Build]` – CI, build system, or infrastructure improvements
- `[Doc]` – Documentation updates or fixes
- `[Misc]` – Other changes that do not fit the above categories (use sparingly)

> **Note:** If the PR spans multiple categories, include all relevant prefixes.

---

<details>
<summary><b>Detailed Checklist (Click to Expand)</b></summary>

<p>Thank you for contributing to <b>vLLM Kunlun</b>!  
To help us maintain high code quality and streamline the review process, please ensure your PR meets the following requirements.</p>

<h3>1. Code Quality</h3>

<ul>
    <li>All linting and formatting checks pass (<code>pre-commit</code>).</li>
    <li>The code is well-structured and sufficiently documented.</li>
    <li>The change is designed with maintainability and readability in mind.</li>
</ul>

<h3>2. Testing</h3>

<ul>
    <li>Relevant unit tests are added or updated.</li>
    <li>Integration tests are included when applicable.</li>
    <li>Existing tests continue to pass.</li>
</ul>

<h3>3. DCO Compliance</h3>

<p>This project follows the
<a href="https://github.com/vllm-project/vllm/blob/main/DCO">Developer Certificate of Origin (DCO)</a>.</p>

<ul>
    <li>All commits include a <code>Signed-off-by:</code> line.</li>
    <li>Use <code>git commit -s</code> to automatically add the sign-off.</li>
</ul>

<h3>4. Review Expectations</h3>

<p>During the review process, maintainers may:</p>

<ul>
    <li>Request code refactoring or additional tests.</li>
    <li>Ask for clarifications on design decisions.</li>
    <li>Suggest performance, stability, or maintainability improvements.</li>
</ul>

<p>We appreciate your patience and collaboration throughout the review process!</p>

</details>
