### PR TITLE
[Update] 1/N Partially supports torch compile

### DIFF
--- a/vllm_kunlun/ops/fused_moe/layer.py
+++ b/vllm_kunlun/ops/fused_moe/layer.py
@@ -3,8 +3,6 @@ Kunlun optimized FusedMoE - replaces UnquantizedFusedMoEMethod
 Uses monolithic mode to receive router_logits directly and call KunlunOps.fused_moe
 """
 
-from typing import Callable
-
 import torch
 from vllm.model_executor.custom_op import CustomOp
 from vllm.model_executor.layers.fused_moe.fused_moe_method_base import (
@@ -81,17 +79,3 @@ class KunlunUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod):
                 w1_bias=getattr(layer, "w13_bias", None),
                 w2_bias=getattr(layer, "w2_bias", None),
             )
-
-    # On KunlunPlatform (_enum=PlatformEnum.CUDA), dispatch_forward selects
-    # forward_cuda. In monolithic mode, apply_monolithic is called directly
-    # by FusedMoE.forward_impl, but we still override forward_cuda and
-    # forward_native as a fallback in case they are invoked.
-    def forward_cuda(
-        self,
-        layer,
-        x: torch.Tensor,
-        router_logits: torch.Tensor,
-    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
-        return self.apply_monolithic(layer, x, router_logits)
-
-    forward_native: Callable = forward_cuda

--- a/vllm_kunlun/platforms/kunlun.py
+++ b/vllm_kunlun/platforms/kunlun.py
@@ -21,7 +21,7 @@ logger = init_logger(__name__)
 class KunlunPlatform(Platform):
     """KunlunPlatform"""
 
-    _enum = PlatformEnum.CUDA
+    _enum = PlatformEnum.OOT
     dist_backend: str = "nccl"
     ray_device_key: str = "GPU"
     device_name: str = "xpu"
@@ -37,7 +37,7 @@ class KunlunPlatform(Platform):
 
     def is_kunlun(self) -> bool:
         """is_kunlun"""
-        return self._enum == PlatformEnum.CUDA
+        return self._enum == PlatformEnum.OOT
 
     def is_cuda(self) -> bool:
         """is_cuda"""


### PR DESCRIPTION
<!--
Please provide a clear and concise description of this PR:
- What problem does it solve?
- Why is this change needed?
- What is the overall approach?
-->

## PR Description

This is **1/N** in a series of PRs to progressively enable `torch.compile` support on the Kunlun XPU platform (vLLM-Kunlun v0.15.1).

### Background

The upstream vLLM compilation infrastructure (`TorchCompileWithNoGuardsWrapper`) was written with the assumption that `torch.compile` options (including `guard_filter_fn`) can always be safely passed regardless of the backend type. However, on **PyTorch 2.5**, passing a non-empty `options` dict to `torch.compile` with a **callable backend** (e.g., `VllmBackend`) causes PyTorch to forward the entire `options` dict as `**kwargs` into `backend.__call__()`, resulting in a `TypeError`. Additionally, `guard_filter_fn` is a **PyTorch ≥ 2.6** feature and must not be used on older versions.

This PR resolves these compatibility issues to unblock `torch.compile` on the Kunlun XPU.

---

### Changes

#### `vllm_kunlun/compilation/wrapper.py`

- **Removed `TorchCompileWrapperWithCustomDispatcher`**: This class was Kunlun-specific and is no longer needed in v0.15.1. Its bytecode-hook-based custom dispatch mechanism has been superseded by `TorchCompileWithNoGuardsWrapper`.
- **Fixed `TorchCompileWithNoGuardsWrapper` for PyTorch 2.5 compatibility**:
  - `options` (including `guard_filter_fn`) is now **only populated when the backend is a plain string** (e.g., `"inductor"`), never when the backend is a callable (e.g., `VllmBackend`).
  - `guard_filter_fn` injection is now guarded with `isinstance(backend, str)`, preventing it from being forwarded as a keyword argument to callable backends on PyTorch 2.5.
  - `torch.compile(..., options=options if options else None)` is used to avoid passing an empty dict, which could also trigger the same forwarding bug.
  - Updated docstring and inline comments to clearly document the PyTorch version constraints.
- Minor code cleanup: removed dead code, redundant comments, and overly verbose docstrings.

#### `vllm_kunlun/ops/fused_moe/layer.py`

- **Removed `forward_cuda` and `forward_native` overrides** from the Kunlun FusedMoE method class. These were previously added as a fallback when `KunlunPlatform._enum` was set to `PlatformEnum.CUDA`, causing `dispatch_forward` to route to `forward_cuda`. Since `_enum` is now changed to `PlatformEnum.OOT` (see below), these overrides are no longer on the dispatch path and have been removed to avoid confusion.

#### `vllm_kunlun/platforms/kunlun.py`

- **Changed `KunlunPlatform._enum` from `PlatformEnum.CUDA` to `PlatformEnum.OOT`**: This correctly identifies Kunlun as an out-of-tree (OOT) platform rather than masquerading as CUDA, which is a prerequisite for `torch.compile` to follow the correct dispatch path on Kunlun XPU.

---

### Known Limitations (follow-up work)

- This is a **partial** (`1/N`) implementation. Full end-to-end `torch.compile` support on Kunlun XPU will require additional follow-up PRs.
- Further work is needed to validate `torch.compile` behavior with `VllmBackend` on PyTorch 2.5 with Kunlun-specific kernels (e.g., FusedMoE, Attention).

---

### PyTorch Version Compatibility

| Feature | PyTorch 2.5 | PyTorch ≥ 2.6 |
|---|---|---|
| `options` with callable backend | ❌ Forwarded as `**kwargs` → `TypeError` | ✅ Handled correctly |
| `guard_filter_fn` | ❌ Not supported | ✅ Supported |

This PR ensures `torch.compile` does not crash on PyTorch 2.5 with a callable backend.
<!-- Link the existing issue(s) this PR resolves, e.g.:
FIX #1234
-->

---

## Checklist (Required)

Before submitting this PR, please ensure that all the following items are completed:

- [x] All code changes pass the [`pre-commit`](https://github.com/baidu/vLLM-Kunlun/blob/main/CONTRIBUTING.md) checks.
- [x] Commits are signed off using `git commit -s`.
- [x] The PR title is properly classified (see below).

---

## PR Type

Please prefix the PR title with one or more of the following labels to help reviewers quickly understand the nature of the change:

- `[Feature]` – New features or enhancements (e.g. Attention, Communicator, Kernel, Worker, etc.)
- `[Bugfix]` – Bug fixes
- `[CI/Build]` – CI, build system, or infrastructure improvements
- `[Doc]` – Documentation updates or fixes
- `[Misc]` – Other changes that do not fit the above categories (use sparingly)

> **Note:** If the PR spans multiple categories, include all relevant prefixes.

---

<details>
<summary><b>Detailed Checklist (Click to Expand)</b></summary>

<p>Thank you for contributing to <b>vLLM Kunlun</b>!  
To help us maintain high code quality and streamline the review process, please ensure your PR meets the following requirements.</p>

<h3>1. Code Quality</h3>

<ul>
    <li>All linting and formatting checks pass (<code>pre-commit</code>).</li>
    <li>The code is well-structured and sufficiently documented.</li>
    <li>The change is designed with maintainability and readability in mind.</li>
</ul>

<h3>2. Testing</h3>

<ul>
    <li>Relevant unit tests are added or updated.</li>
    <li>Integration tests are included when applicable.</li>
    <li>Existing tests continue to pass.</li>
</ul>

<h3>3. DCO Compliance</h3>

<p>This project follows the
<a href="https://github.com/vllm-project/vllm/blob/main/DCO">Developer Certificate of Origin (DCO)</a>.</p>

<ul>
    <li>All commits include a <code>Signed-off-by:</code> line.</li>
    <li>Use <code>git commit -s</code> to automatically add the sign-off.</li>
</ul>

<h3>4. Review Expectations</h3>

<p>During the review process, maintainers may:</p>

<ul>
    <li>Request code refactoring or additional tests.</li>
    <li>Ask for clarifications on design decisions.</li>
    <li>Suggest performance, stability, or maintainability improvements.</li>
</ul>

<p>We appreciate your patience and collaboration throughout the review process!</p>

</details>
