### PR TITLE
[Bugfix]Resolve LoRA API compatibility issues in v0.15.1

### DIFF
--- a/vllm_kunlun/lora/punica_wrapper/punica_kunlun.py
+++ b/vllm_kunlun/lora/punica_wrapper/punica_kunlun.py
@@ -404,7 +404,6 @@ class PunicaWrapperKunlun(PunicaWrapperBase):
         x: torch.Tensor,
         lora_a_stacked: Tuple[torch.Tensor, ...],
         lora_b_stacked: Tuple[torch.Tensor, ...],
-        lora_bias_stacked: Optional[Tuple[torch.Tensor, ...]],
         scale: float,
         output_slices: Tuple[int, ...],
         *,
@@ -421,18 +420,21 @@ class PunicaWrapperKunlun(PunicaWrapperBase):
                     @ lora_a_stacked[indices[i], layer_idx, :, :]
                     @ lora_b_stacked[indices[i], layer_idx, :, :]
                     * scale
-                    ).squeeze(0)+lora_bias_stacked[i]
+                    ).squeeze(0)
 
         Args:
             y (torch.Tensor): Output tensor. Will be changed in-place.
             x (torch.Tensor): Input tensor
             lora_a_stacked (Tuple[torch.Tensor, ...]): lora_a's weight.
             lora_b_stacked (Tuple[torch.Tensor, ...]): lora_b's weight.
-            lora_bias_stacked (Optional[Tuple[torch.Tensor, ...]]): lora's bias.
             scale (float): Scaling factor.
             output_slices (Tuple[int, ...]): Every slice's size.
             buffer (Optional[Tuple[torch.Tensor, ...]]): Defaults to None.
         """
+        # 从 kwargs 中获取 lora_bias_stacked（如果有）
+        lora_bias_stacked: Optional[Tuple[torch.Tensor, ...]] = kwargs.get(
+            "lora_bias_stacked", None
+        )
 
         if self.no_lora:
             return


### PR DESCRIPTION
## PR Description
This PR enables the LoRA functionality under version 0.15.1 and completes validation with qwen3-8b.

## Changes
### vLLM-Kunlun/vllm_kunlun/lora/punica_wrapper/punica_kunlun.py
Removed the lora_bias_stacked parameter from the add_lora_linear function and fetch it from kwargs. The root cause is that the lora_bias_stacked parameter was removed from the add_lora_linear function in version 0.15.1.
https://github.com/vllm-project/vllm/blob/v0.11.0/vllm/lora/punica_wrapper/punica_base.py#L394-L412
https://github.com/vllm-project/vllm/blob/v0.15.1/vllm/lora/punica_wrapper/punica_base.py#L383-L402  

## Checklist (Required)

Before submitting this PR, please ensure that all the following items are completed:

- [x] All code changes pass the [`pre-commit`](https://github.com/baidu/vLLM-Kunlun/blob/main/CONTRIBUTING.md) checks.
- [x] Commits are signed off using `git commit -s`.
- [x] The PR title is properly classified (see below).

---

<details>
<summary><b>Detailed Checklist (Click to Expand)</b></summary>

<p>Thank you for contributing to <b>vLLM Kunlun</b>!  
To help us maintain high code quality and streamline the review process, please ensure your PR meets the following requirements.</p>

<h3>1. Code Quality</h3>

<ul>
    <li>All linting and formatting checks pass (<code>pre-commit</code>).</li>
    <li>The code is well-structured and sufficiently documented.</li>
    <li>The change is designed with maintainability and readability in mind.</li>
</ul>

<h3>2. Testing</h3>

<ul>
    <li>Relevant unit tests are added or updated.</li>
    <li>Integration tests are included when applicable.</li>
    <li>Existing tests continue to pass.</li>
</ul>

<h3>3. DCO Compliance</h3>

<p>This project follows the
<a href="https://github.com/vllm-project/vllm/blob/main/DCO">Developer Certificate of Origin (DCO)</a>.</p>

<ul>
    <li>All commits include a <code>Signed-off-by:</code> line.</li>
    <li>Use <code>git commit -s</code> to automatically add the sign-off.</li>
</ul>

<h3>4. Review Expectations</h3>

<p>During the review process, maintainers may:</p>

<ul>
    <li>Request code refactoring or additional tests.</li>
    <li>Ask for clarifications on design decisions.</li>
    <li>Suggest performance, stability, or maintainability improvements.</li>
</ul>

<p>We appreciate your patience and collaboration throughout the review process!</p>

</details>
