### PR TITLE
[Bugfix] Fix cache indices problem for Qwen3.5-Moe

### DIFF
--- a/vllm_kunlun/models/qwen3_next.py
+++ b/vllm_kunlun/models/qwen3_next.py
@@ -5,7 +5,6 @@
 from collections.abc import Iterable
 from itertools import islice
 
-import kunlun_ops
 import torch
 from einops import rearrange
 from torch import nn
@@ -329,15 +328,6 @@ class Qwen3NextGatedDeltaNet(nn.Module, MambaBase):
         self.conv1d.weight.data = self.conv1d.weight.data.unsqueeze(1)
 
         # projection of the input hidden states
-        # self.projection_size_qkvz = self.key_dim * 2 + self.value_dim * 2
-        # self.projection_size_ba = self.num_v_heads * 2
-        # self.in_proj_qkvz = ColumnParallelLinear(
-        #     input_size=self.hidden_size,
-        #     output_size=self.projection_size_qkvz,
-        #     bias=False,
-        #     quant_config=quant_config,
-        #     prefix=f"{prefix}.in_proj_qkvz",
-        # )
         self.in_proj_qkvz = self.create_qkvz_proj(
             hidden_size=self.hidden_size,
             key_dim=self.key_dim,
@@ -353,7 +343,7 @@ class Qwen3NextGatedDeltaNet(nn.Module, MambaBase):
             quant_config=quant_config,
             prefix=f"{prefix}.in_proj_ba",
         )
-        
+
         query_key_settings = (self.key_dim, 0, False)
         value_settings = (self.value_dim, 0, False)
 
@@ -651,10 +641,10 @@ class Qwen3NextGatedDeltaNet(nn.Module, MambaBase):
                 self.conv1d.bias,
                 self.activation,
                 conv_state_indices=non_spec_state_indices_tensor[
-                    : attn_metadata.num_actual_tokens
+                    : attn_metadata.num_decodes
                 ],
                 conv_state_indices_cpu=non_spec_state_indices_tensor_cpu[
-                    : attn_metadata.num_actual_tokens
+                    : attn_metadata.num_decodes
                 ],
                 validate_data=True,
             )
@@ -710,38 +700,9 @@ class Qwen3NextGatedDeltaNet(nn.Module, MambaBase):
 
         # 2.2: Process the remaining part
         if attn_metadata.num_prefills > 0:
-            slot_mapping = torch.full(
-                (ssm_state.shape[0],), -1, dtype=torch.int32, device="cuda"
-            )
-            slot_mapping[non_spec_state_indices_tensor] = torch.arange(
-                len(non_spec_state_indices_tensor), dtype=torch.int32, device="cuda"
-            )
-
-            initial_state_shape = (
-                non_spec_state_indices_tensor.shape + ssm_state.shape[1:]
-            )
-            initial_state = torch.empty(
-                initial_state_shape, dtype=ssm_state.dtype, device=ssm_state.device
-            )
-            initial_state = initial_state.view(
-                initial_state.shape[0], 1, -1, initial_state.shape[-1]
-            )
-            cast_ssm_state = ssm_state.view(ssm_state.shape[0], -1, ssm_state.shape[-1])
-
-            kunlun_ops.reshape_and_cache_flash(
-                cast_ssm_state,
-                cast_ssm_state,
-                initial_state,
-                initial_state,
-                slot_mapping,
-            )
-            initial_state = initial_state.view(initial_state_shape)
-
-            initial_state = initial_state * has_initial_state.view(
-                has_initial_state.shape[0], 1, 1, 1
-            )
+            initial_state = ssm_state[non_spec_state_indices_tensor].contiguous()
+            initial_state[~has_initial_state, ...] = 0
             initial_state = initial_state.transpose(-1, -2).contiguous()
-
             (
                 core_attn_out_non_spec,
                 last_recurrent_state,
@@ -761,18 +722,9 @@ class Qwen3NextGatedDeltaNet(nn.Module, MambaBase):
                 last_recurrent_state.transpose(-1, -2)
                 .contiguous()
                 .to(ssm_state.dtype)
-                .view(last_recurrent_state.shape[0], -1, last_recurrent_state.shape[-1])
             )
-            cast_ssm_state = ssm_state.view(
-                ssm_state.shape[0], 1, -1, ssm_state.shape[-1]
-            )
-
-            kunlun_ops.reshape_and_cache_flash(
-                last_recurrent_state,
-                last_recurrent_state,
-                cast_ssm_state,
-                cast_ssm_state,
-                non_spec_state_indices_tensor,
+            ssm_state[non_spec_state_indices_tensor] = last_recurrent_state.to(
+                ssm_state.dtype
             )
         elif attn_metadata.num_decodes > 0:
             core_attn_out_non_spec, last_recurrent_state = (


### PR DESCRIPTION
## PR Description

### Summary

This PR fixes a cache state correctness issue in the `Qwen3NextGatedDeltaNet` (SSM layer) within `vllm_kunlun/models/qwen3_next.py`, which caused incorrect behavior when running `Qwen3.5-MoE` inference on Kunlun XPU.


---

### Problem

The previous implementation used `kunlun_ops.reshape_and_cache_flash` to read/write the SSM recurrent state (`ssm_state`) during both prefill and decode phases. Two issues were identified:

1. **Incorrect state indices during decode**: The conv state indices were sliced using `attn_metadata.num_actual_tokens` instead of `attn_metadata.num_decodes`, causing the wrong set of sequence states to be selected during the decode phase.

2. **Precision issue in `kunlun_ops.reshape_and_cache_flash`**: A minor numerical precision problem was observed in the XPU kernel when used for SSM state scatter/gather during the prefill path, leading to subtle output correctness issues in `Qwen3.5-MoE`.

---

### Fix

To restore correctness in the short term, the `kunlun_ops.reshape_and_cache_flash`-based path in the prefill phase is temporarily replaced with equivalent direct tensor indexing:

- **Reading initial state (prefill):**
  ```python
  # Before (faster, but currently has precision issue)
  kunlun_ops.reshape_and_cache_flash(cast_ssm_state, ..., initial_state, ..., slot_mapping)

  # After (correct, used as temporary workaround)
  initial_state = ssm_state[non_spec_state_indices_tensor].contiguous()
  initial_state[~has_initial_state, ...] = 0
  ```

- **Writing back updated state (prefill):**
  ```python
  # Before (faster, but currently has precision issue)
  kunlun_ops.reshape_and_cache_flash(last_recurrent_state, ..., cast_ssm_state, ..., non_spec_state_indices_tensor)

  # After (correct, used as temporary workaround)
  ssm_state[non_spec_state_indices_tensor] = last_recurrent_state.to(ssm_state.dtype)
  ```

- **Decode conv state slice**: Fixed `num_actual_tokens` → `num_decodes` to correctly select only the decode-phase sequences.

---

### Note

The `kunlun_ops.reshape_and_cache_flash` kernel is capable of accelerating the SSM state read/write operations and is the intended long-term approach. It is temporarily removed here only to work around the current precision issue. Once the precision problem in the kernel is resolved, the accelerated path will be reintroduced.

---

### Impact

- Fixes incorrect SSM cache state reads/writes for `Qwen3.5-MoE` during prefill and decode.
- Temporarily replaces the XPU-accelerated SSM state scatter/gather with direct tensor indexing as a correctness workaround.
- No changes to attention, MoE, or other model components.

---

## Checklist (Required)

Before submitting this PR, please ensure that all the following items are completed:

- [x] All code changes pass the [`pre-commit`](https://github.com/baidu/vLLM-Kunlun/blob/main/CONTRIBUTING.md) checks.
- [x] Commits are signed off using `git commit -s`.
- [x] The PR title is properly classified (see below).

---

## PR Type

Please prefix the PR title with one or more of the following labels to help reviewers quickly understand the nature of the change:

- `[Feature]` – New features or enhancements (e.g. Attention, Communicator, Kernel, Worker, etc.)
- `[Bugfix]` – Bug fixes
- `[CI/Build]` – CI, build system, or infrastructure improvements
- `[Doc]` – Documentation updates or fixes
- `[Misc]` – Other changes that do not fit the above categories (use sparingly)

> **Note:** If the PR spans multiple categories, include all relevant prefixes.

---

<details>
<summary><b>Detailed Checklist (Click to Expand)</b></summary>

<p>Thank you for contributing to <b>vLLM Kunlun</b>!  
To help us maintain high code quality and streamline the review process, please ensure your PR meets the following requirements.</p>

<h3>1. Code Quality</h3>

<ul>
    <li>All linting and formatting checks pass (<code>pre-commit</code>).</li>
    <li>The code is well-structured and sufficiently documented.</li>
    <li>The change is designed with maintainability and readability in mind.</li>
</ul>

<h3>2. Testing</h3>

<ul>
    <li>Relevant unit tests are added or updated.</li>
    <li>Integration tests are included when applicable.</li>
    <li>Existing tests continue to pass.</li>
</ul>

<h3>3. DCO Compliance</h3>

<p>This project follows the
<a href="https://github.com/vllm-project/vllm/blob/main/DCO">Developer Certificate of Origin (DCO)</a>.</p>

<ul>
    <li>All commits include a <code>Signed-off-by:</code> line.</li>
    <li>Use <code>git commit -s</code> to automatically add the sign-off.</li>
</ul>

<h3>4. Review Expectations</h3>

<p>During the review process, maintainers may:</p>

<ul>
    <li>Request code refactoring or additional tests.</li>
    <li>Ask for clarifications on design decisions.</li>
    <li>Suggest performance, stability, or maintainability improvements.</li>
</ul>

<p>We appreciate your patience and collaboration throughout the review process!</p>

</details>
