### PR TITLE
[Bugfix] Qwen3NextAttention is missing the rotary_dim attribute

### DIFF
--- a/vllm_kunlun/models/qwen3_next.py
+++ b/vllm_kunlun/models/qwen3_next.py
@@ -840,6 +840,7 @@ class Qwen3NextAttention(nn.Module):
             rope_parameters=config.rope_parameters,
             dual_chunk_attention_config=self.dual_chunk_attention_config,
         )
+        self.rotary_dim = self.rotary_emb.rotary_dim
 
         self.attn = Attention(
             self.num_heads,


### PR DESCRIPTION
## PR Description

Models involved:
- Qwen3-Coder-Next
- Qwen3-Next-80B-A3B

### Phenomenon

Qwen3-Coder-Next model reports an error when starting the inference service:

```
File "/opt/vllm_kunlun/lib/python3.10/site-packages/vllm_kunlun/models/qwen3_next.py", line 1127, in forward
    hidden_states, residual = layer(

AttributeError: 'Qwen3NextAttention' object has no attribute 'rotary_dim'. Did you mean: 'rotary_emb'?
```

### root cause

In the fused path of `forward`, `self.rotary_dim` is directly referenced when calling `xspeedgate_ops.split_norm_rope_neox`, but never defined:

```python
# qwen3_next.py line 898-911:
q, k, v, gate = torch.ops.xspeedgate_ops.split_norm_rope_neox(
    ...
    rotary_dim=self.rotary_dim,   # <-- undefined
    ...
)
```

### solution

 After creating `self.rotary_emb` in `__init__`, directly take the already computed `rotary_dim` from the rope object:

```python
self.rotary_emb = get_rope(
    head_size=self.head_dim,
    max_position=config.max_position_embeddings,
    rope_parameters=config.rope_parameters,
    dual_chunk_attention_config=self.dual_chunk_attention_config,
)
self.rotary_dim = self.rotary_emb.rotary_dim
```

`get_rope` already calculates `rotary_dim = int(head_size * partial_rotary_factor)` based on `partial_rotary_factor` internally and stores it in the returned `RotaryEmbedding` instance; reuse it directly without redundant calculation or hardcoding.

### Tested and working

---

## Checklist (Required)

Before submitting this PR, please ensure that all the following items are completed:

- [ ] All code changes pass the [`pre-commit`](https://github.com/baidu/vLLM-Kunlun/blob/main/CONTRIBUTING.md) checks.
- [ ] Commits are signed off using `git commit -s`.
- [ ] The PR title is properly classified (see below).

---

## PR Type

Please prefix the PR title with one or more of the following labels to help reviewers quickly understand the nature of the change:

- `[Feature]` – New features or enhancements (e.g. Attention, Communicator, Kernel, Worker, etc.)
- `[Bugfix]` – Bug fixes
- `[CI/Build]` – CI, build system, or infrastructure improvements
- `[Doc]` – Documentation updates or fixes
- `[Misc]` – Other changes that do not fit the above categories (use sparingly)

> **Note:** If the PR spans multiple categories, include all relevant prefixes.

---

<details>
<summary><b>Detailed Checklist (Click to Expand)</b></summary>

<p>Thank you for contributing to <b>vLLM Kunlun</b>!  
To help us maintain high code quality and streamline the review process, please ensure your PR meets the following requirements.</p>

<h3>1. Code Quality</h3>

<ul>
    <li>All linting and formatting checks pass (<code>pre-commit</code>).</li>
    <li>The code is well-structured and sufficiently documented.</li>
    <li>The change is designed with maintainability and readability in mind.</li>
</ul>

<h3>2. Testing</h3>

<ul>
    <li>Relevant unit tests are added or updated.</li>
    <li>Integration tests are included when applicable.</li>
    <li>Existing tests continue to pass.</li>
</ul>

<h3>3. DCO Compliance</h3>

<p>This project follows the
<a href="https://github.com/vllm-project/vllm/blob/main/DCO">Developer Certificate of Origin (DCO)</a>.</p>

<ul>
    <li>All commits include a <code>Signed-off-by:</code> line.</li>
    <li>Use <code>git commit -s</code> to automatically add the sign-off.</li>
</ul>

<h3>4. Review Expectations</h3>

<p>During the review process, maintainers may:</p>

<ul>
    <li>Request code refactoring or additional tests.</li>
    <li>Ask for clarifications on design decisions.</li>
    <li>Suggest performance, stability, or maintainability improvements.</li>
</ul>

<p>We appreciate your patience and collaboration throughout the review process!</p>

</details>
