### PR TITLE
[Bugfix] fix logger not printing to terminal

### DIFF
--- a/vllm_kunlun/__init__.py
+++ b/vllm_kunlun/__init__.py
@@ -61,7 +61,6 @@ def register():
     """Register the Kunlun platform"""
 
     logger = _configure_kunlun_logger()
-    logger = logging.getLogger("vllm_kunlun")
     logger.info("[KunlunPlugin] register() pid=%s", os.getpid())
 
     # --- load native extension to register torch.ops._C.weak_ref_tensor ---


### PR DESCRIPTION
## PR Description

## Phenomenon

Logs in vllm_kunlun/__init__.py were not printed to the terminal during service startup.

## Root Cause

vLLM's dictConfig() only configures handlers for the "vllm" logger tree. The "vllm_kunlun" logger is a sibling namespace, not a child of "vllm", so it does not inherit vLLM's handlers. It propagates to the Python root logger instead, which has no INFO-level handler configured — causing all vllm_kunlun.* INFO logs to be silently dropped.

## Solution

At vllm_kunlun package initialization, explicitly copy the "vllm" logger's handlers and level to the "vllm_kunlun" root logger, with propagate=False. This ensures all vllm_kunlun.* loggers reuse vLLM's logging format and respect VLLM_LOGGING_LEVEL, without renaming any existing loggers.

## Test

Tested and working

```
[RAW SERVER] INFO 03-16 02:38:29 [__init__.py:64] [KunlunPlugin] register() pid=52233
[RAW SERVER] INFO 03-16 02:38:29 [__init__.py:70] [KunlunPlugin] _kunlun native extension loaded
[RAW SERVER] INFO 03-16 02:38:29 [__init__.py:79] [KunlunPlugin] vllm_utils_wrapper loaded and patched
[RAW SERVER] INFO 03-16 02:38:29 [__init__.py:104] [KunlunPlugin] import_hook() ok
[RAW SERVER] INFO 03-16 02:38:29 [__init__.py:124] [KunlunPlugin] registered Qwen3ReasoningParser override (lazy)
...
[RAW SERVER] ^[[0;36m(APIServer pid=52233)^[[0;0m INFO 03-16 02:38:34 [layernorm.py:179] [KunlunOOT] Registered KunlunRMSNorm and KunlunGemmaRMSNorm via CustomOp.register_oot
[RAW SERVER] ^[[0;36m(APIServer pid=52233)^[[0;0m INFO 03-16 02:38:34 [rotary_embedding.py:253] [KunlunOOT] Registered KunlunRotaryEmbedding, KunlunMRotaryEmbedding, KunlunDeepseekScalingRotaryEmbedding via CustomOp.register_oot
[RAW SERVER] ^[[0;36m(APIServer pid=52233)^[[0;0m INFO 03-16 02:38:34 [vocab_parallel_embedding.py:122] [KunlunOOT] Registered KunlunVocabParallelEmbedding via CustomOp.register_oot
```

---

## Checklist (Required)

Before submitting this PR, please ensure that all the following items are completed:

- [ ] All code changes pass the [`pre-commit`](https://github.com/baidu/vLLM-Kunlun/blob/main/CONTRIBUTING.md) checks.
- [ ] Commits are signed off using `git commit -s`.
- [ ] The PR title is properly classified (see below).

---

## PR Type

Please prefix the PR title with one or more of the following labels to help reviewers quickly understand the nature of the change:

- `[Feature]` – New features or enhancements (e.g. Attention, Communicator, Kernel, Worker, etc.)
- `[Bugfix]` – Bug fixes
- `[CI/Build]` – CI, build system, or infrastructure improvements
- `[Doc]` – Documentation updates or fixes
- `[Misc]` – Other changes that do not fit the above categories (use sparingly)

> **Note:** If the PR spans multiple categories, include all relevant prefixes.

---

<details>
<summary><b>Detailed Checklist (Click to Expand)</b></summary>

<p>Thank you for contributing to <b>vLLM Kunlun</b>!  
To help us maintain high code quality and streamline the review process, please ensure your PR meets the following requirements.</p>

<h3>1. Code Quality</h3>

<ul>
    <li>All linting and formatting checks pass (<code>pre-commit</code>).</li>
    <li>The code is well-structured and sufficiently documented.</li>
    <li>The change is designed with maintainability and readability in mind.</li>
</ul>

<h3>2. Testing</h3>

<ul>
    <li>Relevant unit tests are added or updated.</li>
    <li>Integration tests are included when applicable.</li>
    <li>Existing tests continue to pass.</li>
</ul>

<h3>3. DCO Compliance</h3>

<p>This project follows the
<a href="https://github.com/vllm-project/vllm/blob/main/DCO">Developer Certificate of Origin (DCO)</a>.</p>

<ul>
    <li>All commits include a <code>Signed-off-by:</code> line.</li>
    <li>Use <code>git commit -s</code> to automatically add the sign-off.</li>
</ul>

<h3>4. Review Expectations</h3>

<p>During the review process, maintainers may:</p>

<ul>
    <li>Request code refactoring or additional tests.</li>
    <li>Ask for clarifications on design decisions.</li>
    <li>Suggest performance, stability, or maintainability improvements.</li>
</ul>

<p>We appreciate your patience and collaboration throughout the review process!</p>

</details>
