### PR TITLE
[Model]Support Kimi-K2.5 and Kimi-K2-Thinking model

### DIFF
--- a/vllm_kunlun/__init__.py
+++ b/vllm_kunlun/__init__.py
@@ -49,10 +49,15 @@ def register():
     from .utils import redirect_output
     from .vllm_utils_wrapper import direct_register_custom_op, patch_annotations_for_schema
     
-    # Change for GLM5
-    if "vllm.transformers_utils.config" in sys.modules:
-        from .transformer_utils.config import _XPU_CONFIG_REGISTRY
-        sys.modules["vllm.transformers_utils.config"]._CONFIG_REGISTRY = _XPU_CONFIG_REGISTRY
+    # Change for GLM5 and custom model configs.
+    import vllm.transformers_utils.config as config_module
+    from .transformer_utils.config import _XPU_CONFIG_REGISTRY
+    config_module._CONFIG_REGISTRY = _XPU_CONFIG_REGISTRY
+
+    import vllm.transformers_utils.configs as configs_module
+    from .transformer_utils.kimi_k25 import KimiK25Config, KimiK25VisionConfig
+    setattr(configs_module, "KimiK25Config", KimiK25Config)
+    setattr(configs_module, "KimiK25VisionConfig", KimiK25VisionConfig)
     
     import vllm.config.model as model_module
     from .config.model import is_deepseek_mla

--- a/vllm_kunlun/models/__init__.py
+++ b/vllm_kunlun/models/__init__.py
@@ -3,6 +3,7 @@ from vllm import ModelRegistry
 
 def register_model():
     # from .demo_model import DemoModel  # noqa: F401
+    from .kimi_k25 import KimiK25ForConditionalGeneration  # noqa: F401
     from .qwen2_5_vl import Qwen2_5_VLForConditionalGeneration  # noqa: F401
     from .qwen2_vl import Qwen2VLForConditionalGeneration  # noqa: F401
     from .qwen3_moe import Qwen3MoeForCausalLM  # noqa: F401
@@ -64,6 +65,16 @@ def register_model():
     ModelRegistry.register_model(
         "InternS1ForConditionalGeneration",
         "vllm_kunlun.models.interns1:InternS1ForConditionalGeneration",
+    )
+
+    ModelRegistry.register_model(
+        "KimiK25ForConditionalGeneration",
+        "vllm_kunlun.models.kimi_k25:KimiK25ForConditionalGeneration",
+    )
+
+    ModelRegistry.register_model(
+        "KimiK2_5ForConditionalGeneration",
+        "vllm_kunlun.models.kimi_k25:KimiK25ForConditionalGeneration",
     )
 
     ModelRegistry.register_model(

--- a/vllm_kunlun/models/kimi_k25.py
+++ b/vllm_kunlun/models/kimi_k25.py
@@ -1,0 +1,441 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# ruff: noqa: E501
+"""
+Kimi-K2.5 model implementation for vLLM-Kunlun.
+
+Kimi-K2.5 extends Kimi-K2 (DeepseekV3) with vision support using
+a MoonViT 3D vision tower and temporal pooling patch merger.
+"""
+
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from typing import Annotated, Any, Literal, Optional, Union
+
+import torch
+from torch import nn
+from transformers import BatchFeature
+from transformers.processing_utils import ProcessorMixin
+from vllm.config import VllmConfig
+from vllm.logger import init_logger
+from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tensors import (
+    CompressedTensorsConfig,
+)
+from vllm.model_executor.models.interfaces import (
+    SupportsMultiModal,
+    SupportsPP,
+    SupportsQuant,
+)
+from vllm.model_executor.models.utils import (
+    AutoWeightsLoader,
+    WeightsMapper,
+    init_vllm_registered_model,
+    maybe_prefix,
+    merge_multimodal_embeddings,
+)
+from vllm.multimodal import MULTIMODAL_REGISTRY
+from vllm.multimodal.inputs import (
+    MultiModalDataDict,
+    MultiModalFieldConfig,
+    MultiModalKwargs,
+    NestedTensors,
+)
+from vllm.multimodal.parse import ImageProcessorItems, MultiModalDataItems
+from vllm.multimodal.processing import (
+    BaseMultiModalProcessor,
+    BaseProcessingInfo,
+    PromptReplacement,
+    PromptUpdate,
+)
+from vllm.multimodal.profiling import BaseDummyInputsBuilder
+from vllm.platforms import current_platform
+from vllm.sequence import IntermediateTensors
+from vllm.transformers_utils.processor import cached_get_image_processor
+from vllm.utils.tensor_schema import TensorSchema, TensorShape
+
+from vllm_kunlun.transformer_utils.kimi_k25 import KimiK25Config
+
+from .kimi_k25_vit import (
+    KimiK25MultiModalProjector,
+    MoonViT3dPretrainedModel,
+    vision_tower_forward,
+)
+
+logger = init_logger(__name__)
+
+
+@dataclass
+class MaxImageTokenMeta:
+    width: int = 3000
+    height: int = 3000
+
+
+class KimiK25MediaPixelInputs(TensorSchema):
+    type: Literal["pixel_values"] = "pixel_values"
+    pixel_values: Annotated[
+        Union[torch.Tensor, list],
+        TensorShape("np", 3, "ps", "ps"),
+    ]
+    grid_thws: Annotated[torch.Tensor, TensorShape("nm", 3)]
+
+
+class MoonshotKimiVAutoProcessor(ProcessorMixin):
+    attributes = ["tokenizer"]
+    tokenizer_class = "AutoTokenizer"
+
+    def __init__(self, media_processor=None, tokenizer=None, media_token_id=None):
+        super().__init__(tokenizer)
+        self.media_processor = media_processor
+        self.media_token_id = media_token_id
+        assert self.media_token_id is not None
+
+    def __call__(
+        self,
+        text=None,
+        images=None,
+        videos=None,
+        vision_chunks=None,
+        **kwargs,
+    ) -> BatchFeature:
+        # Build vision_chunks from vLLM standard `images`/`videos` kwargs
+        # if vision_chunks is not provided directly.
+        if vision_chunks is None:
+            vision_chunks = []
+            if images is not None:
+                if not isinstance(images, (list, tuple)):
+                    images = [images]
+                for img in images:
+                    vision_chunks.append({"type": "image", "image": img})
+            if videos is not None:
+                if not isinstance(videos, (list, tuple)):
+                    videos = [videos]
+                for video in videos:
+                    if isinstance(video, (list, tuple)):
+                        # Already a list of frames
+                        vision_chunks.append(
+                            {
+                                "type": "video_chunk",
+                                "video_chunk": list(video),
+                            }
+                        )
+                    else:
+                        vision_chunks.append(
+                            {
+                                "type": "image",
+                                "image": video,
+                            }
+                        )
+
+        mm_inputs = {}
+        input_ids = self.tokenizer.encode(text) if isinstance(text, str) else text
+        if vision_chunks:
+            mm_inputs = self.media_processor.preprocess(vision_chunks)
+
+            num_tokens_per_chunk = [
+                self.media_processor.media_tokens_calculator(chunk)
+                for chunk in vision_chunks
+            ]
+
+            new_input_ids = []
+            for token in input_ids:
+                if token == self.media_token_id:
+                    new_input_ids.extend(
+                        [self.media_token_id] * num_tokens_per_chunk.pop(0)
+                    )
+                else:
+                    new_input_ids.append(token)
+            input_ids = new_input_ids
+
+        return BatchFeature(
+            data={
+                "input_ids": torch.tensor([input_ids]),
+                **mm_inputs,
+            }
+        )
+
+
+class KimiK25ProcessingInfo(BaseProcessingInfo):
+    def __init__(self, ctx) -> None:
+        super().__init__(ctx)
+        self.hf_config = self.get_hf_config()
+        self.media_token_id = self.hf_config.media_placeholder_token_id
+        self.media_processor = cached_get_image_processor(
+            self.ctx.model_config.model,
+            trust_remote_code=self.ctx.model_config.trust_remote_code,
+        )
+        self.hf_processor = MoonshotKimiVAutoProcessor(
+            media_processor=self.media_processor,
+            tokenizer=self.get_tokenizer(),
+            media_token_id=self.media_token_id,
+        )
+        self.media_tokens_calculator = self.media_processor.media_tokens_calculator
+
+    def get_hf_processor(self):
+        return self.hf_processor
+
+    def get_hf_config(self):
+        return self.ctx.get_hf_config(KimiK25Config)
+
+    def get_supported_mm_limits(self) -> Mapping[str, Optional[int]]:
+        return {"image": None}
+
+
+class KimiK25DummyInputsBuilder(BaseDummyInputsBuilder):
+    def __init__(self, info: KimiK25ProcessingInfo) -> None:
+        super().__init__(info)
+        self.media_token_id = self.info.media_token_id
+        self.frame_per_chunk = getattr(
+            self.info.media_processor, "num_frames_per_chunk", 4
+        )
+
+    def get_dummy_text(self, mm_counts: Mapping[str, int]) -> str:
+        num_media = mm_counts.get("image", 0)
+        return "<|media_pad|>" * num_media
+
+    def get_dummy_mm_data(
+        self,
+        seq_len: int,
+        mm_counts: Mapping[str, int],
+    ) -> MultiModalDataDict:
+        num_images = mm_counts.get("image", 0)
+        mm_data: MultiModalDataDict = {}
+        if num_images > 0:
+            mm_data["image"] = self._get_dummy_images(
+                width=MaxImageTokenMeta.width,
+                height=MaxImageTokenMeta.height,
+                num_images=num_images,
+            )
+        return mm_data
+
+
+class KimiK25MultiModalProcessor(BaseMultiModalProcessor):
+    def _get_mm_fields_config(
+        self,
+        hf_inputs: BatchFeature,
+        hf_processor_mm_kwargs: Mapping[str, object],
+    ) -> Mapping[str, MultiModalFieldConfig]:
+        grid_thws = hf_inputs.get("grid_thws", torch.empty((0, 3)))
+        grid_sizes = grid_thws.prod(-1)
+
+        return dict(
+            pixel_values=MultiModalFieldConfig.flat_from_sizes("image", grid_sizes),
+            grid_thws=MultiModalFieldConfig.batched("image"),
+        )
+
+    def _get_prompt_updates(
+        self,
+        mm_items: MultiModalDataItems,
+        hf_processor_mm_kwargs: Mapping[str, Any],
+        out_mm_kwargs: MultiModalKwargs,
+    ) -> Sequence[PromptUpdate]:
+        media_token_id = self.info.get_hf_config().media_placeholder_token_id
+
+        def get_replacement(item_idx: int):
+            media = mm_items.get_items("image", ImageProcessorItems)
+            media_item = {"type": "image", "image": media[item_idx]}
+            try:
+                num_media_token = self.info.media_tokens_calculator(media_item)
+            except Exception:
+                logger.warning(
+                    "media_tokens_calculator failed for image item %d, "
+                    "using fallback estimation",
+                    item_idx,
+                )
+                num_media_token = 1
+            return [media_token_id] * num_media_token
+
+        updates = []
+        if mm_items.get_count("image", strict=False) > 0:
+            updates.append(
+                PromptReplacement(
+                    modality="image",
+                    target=[media_token_id],
+                    replacement=get_replacement,
+                )
+            )
+        return updates
+
+    def split_video_chunks(self, video):
+        return self.info.media_processor.split_video_chunks(video)
+
+
+@MULTIMODAL_REGISTRY.register_processor(
+    KimiK25MultiModalProcessor,
+    info=KimiK25ProcessingInfo,
+    dummy_inputs=KimiK25DummyInputsBuilder,
+)
+class KimiK25ForConditionalGeneration(
+    nn.Module,
+    SupportsMultiModal,
+    SupportsPP,
+    SupportsQuant,
+):
+    supports_encoder_tp_data = True
+
+    hf_to_vllm_mapper = WeightsMapper(
+        orig_to_new_prefix={
+            "language_model.layers.": "language_model.model.layers.",
+            "mm_projector.proj.0": "mm_projector.linear_1",
+            "mm_projector.proj.2": "mm_projector.linear_2",
+        }
+    )
+
+    @classmethod
+    def get_placeholder_str(cls, modality: str, i: int) -> Optional[str]:
+        if modality == "image":
+            return "<|media_begin|>image<|media_content|><|media_pad|><|media_end|>"
+        if modality == "video":
+            return "<|kimi_k25_video_placeholder|>"
+        raise ValueError(f"Unsupported modality: {modality}")
+
+    def __init__(
+        self,
+        *,
+        vllm_config: VllmConfig,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        model_config = vllm_config.model_config
+        config: KimiK25Config = model_config.hf_config
+        self.config = config
+        quant_config = vllm_config.quant_config
+
+        self.use_data_parallel = (
+            model_config.multimodal_config.mm_encoder_tp_mode == "data"
+        )
+        self.hidden_size = config.text_config.hidden_size
+        self.device = current_platform.current_device()
+
+        # Vision tower
+        self.vision_tower = MoonViT3dPretrainedModel(
+            config.vision_config,
+            quant_config=self._maybe_ignore_quant_config(quant_config),
+            prefix=maybe_prefix(prefix, "vision_tower"),
+            use_data_parallel=self.use_data_parallel,
+        ).to(device=self.device, dtype=model_config.dtype)
+
+        # MM projector
+        self.mm_projector = KimiK25MultiModalProjector(
+            config=config.vision_config,
+            use_data_parallel=self.use_data_parallel,
+            quant_config=self._maybe_ignore_quant_config(quant_config),
+            prefix=maybe_prefix(prefix, "mm_projector"),
+        ).to(device=self.device, dtype=model_config.dtype)
+
+        # Language model (DeepseekV3)
+        self.quant_config = quant_config
+        self.language_model = init_vllm_registered_model(
+            vllm_config=vllm_config,
+            hf_config=config.text_config,
+            architectures=["DeepseekV3ForCausalLM"],
+            prefix=maybe_prefix(prefix, "language_model"),
+        )
+        self.make_empty_intermediate_tensors = (
+            self.language_model.make_empty_intermediate_tensors
+        )
+        self.media_placeholder: int = self.config.media_placeholder_token_id
+
+    def _maybe_ignore_quant_config(self, quant_config):
+        if isinstance(quant_config, CompressedTensorsConfig):
+            return None
+        return quant_config
+
+    def _parse_and_validate_media_input(
+        self, **kwargs: object
+    ) -> Optional[KimiK25MediaPixelInputs]:
+        pixel_values = kwargs.pop("pixel_values", None)
+        grid_thws = kwargs.pop("grid_thws", None)
+        if pixel_values is None:
+            return None
+
+        if isinstance(pixel_values, list):
+            pixel_values = torch.cat(pixel_values, dim=0)
+
+        if len(pixel_values.shape) in (3, 5):
+            pixel_values = pixel_values.reshape(
+                pixel_values.shape[0] * pixel_values.shape[1], *pixel_values.shape[2:]
+            )
+
+        target_dtype = next(self.vision_tower.parameters()).dtype
+        pixel_values = pixel_values.to(target_dtype)
+
+        assert isinstance(
+            grid_thws, torch.Tensor
+        ), f"expect grid_thws to be a tensor, get {type(grid_thws)}"
+        grid_thws = grid_thws.reshape(-1, grid_thws.shape[-1])
+        assert (
+            grid_thws.ndim == 2 and grid_thws.size(1) == 3
+        ), f"unexpected shape for grid_thws: {grid_thws.shape}"
+
+        return KimiK25MediaPixelInputs(
+            type="pixel_values",
+            pixel_values=pixel_values,
+            grid_thws=grid_thws,
+        )
+
+    def _process_media_input(self, media_input: KimiK25MediaPixelInputs) -> list:
+        return vision_tower_forward(
+            self.vision_tower,
+            media_input["pixel_values"],
+            media_input["grid_thws"],
+            mm_projector=self.mm_projector,
+            use_data_parallel=self.use_data_parallel,
+        )
+
+    def get_language_model(self) -> torch.nn.Module:
+        return self.language_model
+
+    def get_multimodal_embeddings(self, **kwargs: object) -> NestedTensors:
+        media_input = self._parse_and_validate_media_input(**kwargs)
+        if media_input is None:
+            return []
+        return self._process_media_input(media_input)
+
+    def get_input_embeddings(
+        self,
+        input_ids: torch.Tensor,
+        multimodal_embeddings=None,
+    ) -> torch.Tensor:
+        inputs_embeds = self.language_model.get_input_embeddings(input_ids)
+        if multimodal_embeddings is not None and len(multimodal_embeddings) != 0:
+            inputs_embeds = merge_multimodal_embeddings(
+                input_ids,
+                inputs_embeds,
+                multimodal_embeddings,
+                placeholder_token_id=self.media_placeholder,
+            )
+        return inputs_embeds
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        intermediate_tensors: Optional[IntermediateTensors] = None,
+        inputs_embeds: Optional[torch.Tensor] = None,
+        **kwargs: object,
+    ) -> Union[torch.Tensor, IntermediateTensors]:
+        if intermediate_tensors is not None:
+            input_ids = None
+            inputs_embeds = None
+        elif inputs_embeds is None:
+            multimodal_embeddings = self.get_multimodal_embeddings(**kwargs)
+            if multimodal_embeddings:
+                inputs_embeds = self.get_input_embeddings(
+                    input_ids, multimodal_embeddings
+                )
+                input_ids = None
+
+        hidden_states = self.language_model.model(
+            input_ids=input_ids,
+            positions=positions,
+            intermediate_tensors=intermediate_tensors,
+            inputs_embeds=inputs_embeds,
+        )
+        return hidden_states
+
+    def compute_logits(self, hidden_states: torch.Tensor, **kwargs) -> torch.Tensor:
+        return self.language_model.compute_logits(hidden_states)
+
+    def load_weights(self, weights: Iterable[tuple]) -> set:
+        loader = AutoWeightsLoader(self)
+        return loader.load_weights(weights, mapper=self.hf_to_vllm_mapper)

--- a/vllm_kunlun/models/kimi_k25_vit.py
+++ b/vllm_kunlun/models/kimi_k25_vit.py
@@ -1,0 +1,573 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Vision tower implementation for Kimi-K2.5 model (Kunlun adaptation).
+"""
+
+from collections.abc import Sequence
+from copy import deepcopy
+from typing import Any
+
+import numpy as np
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from transformers.activations import GELUActivation
+from vllm.distributed import divide, get_tensor_model_parallel_world_size
+from vllm.logger import init_logger
+from vllm.model_executor.layers.activation import get_act_fn
+from vllm.model_executor.layers.linear import (
+    ColumnParallelLinear,
+    QKVParallelLinear,
+    ReplicatedLinear,
+    RowParallelLinear,
+)
+from vllm.model_executor.models.utils import maybe_prefix
+
+from vllm_kunlun.ops.attention.layer import MultiHeadAttention
+from vllm_kunlun.transformer_utils.kimi_k25 import KimiK25VisionConfig
+
+logger = init_logger(__name__)
+
+
+def _apply_rope_input_validation(x: torch.Tensor, freqs_cis: torch.Tensor):
+    assert x.ndim == freqs_cis.ndim + 1, (x.shape, freqs_cis.shape)
+    assert x.shape[:-2] == freqs_cis.shape[:-1], (x.shape, freqs_cis.shape)
+    assert x.shape[-1] == 2 * freqs_cis.shape[-1], (x.shape, freqs_cis.shape)
+    assert freqs_cis.dtype == torch.complex64, freqs_cis.dtype
+
+
+def get_rope_shape(org: torch.Tensor, interpolation_mode: str, shape: tuple):
+    return (
+        F.interpolate(
+            org.permute((2, 0, 1)).unsqueeze(0),
+            size=shape,
+            mode=interpolation_mode,
+        )
+        .squeeze(0)
+        .permute((1, 2, 0))
+        .flatten(end_dim=1)
+    )
+
+
+def apply_rope(xq: torch.Tensor, xk: torch.Tensor, freqs_cis: torch.Tensor) -> tuple:
+    _apply_rope_input_validation(xq, freqs_cis)
+    _apply_rope_input_validation(xk, freqs_cis)
+
+    freqs_cis = freqs_cis.unsqueeze(-2)
+    xq_ = torch.view_as_complex(xq.float().view(*xq.shape[:-1], -1, 2))
+    xk_ = torch.view_as_complex(xk.float().view(*xq.shape[:-1], -1, 2))
+    xq_out = torch.view_as_real(xq_ * freqs_cis).flatten(-2)
+    xk_out = torch.view_as_real(xk_ * freqs_cis).flatten(-2)
+    return xq_out.type_as(xq), xk_out.type_as(xk)
+
+
+def get_1d_sincos_pos_embed_from_grid(embed_dim: int, pos: np.ndarray):
+    assert embed_dim % 2 == 0
+    omega = np.arange(embed_dim // 2, dtype=np.float32)
+    omega /= embed_dim / 2.0
+    omega = 1.0 / 10000**omega
+
+    pos = pos.reshape(-1)
+    out = np.einsum("m,d->md", pos, omega)
+
+    emb_sin = np.sin(out)
+    emb_cos = np.cos(out)
+    return np.concatenate([emb_sin, emb_cos], axis=1)
+
+
+def get_1d_sincos_pos_embed(embed_dim: int, t_size: int, cls_token: bool = False):
+    grid_t = np.arange(t_size, dtype=np.float32)
+    pos_embed = get_1d_sincos_pos_embed_from_grid(embed_dim, grid_t)
+    if cls_token:
+        pos_embed = np.concatenate([np.zeros([1, embed_dim]), pos_embed], axis=0)
+    return pos_embed
+
+
+class Learnable2DInterpPosEmbDividedFixed(nn.Module):
+    def __init__(
+        self,
+        height: int,
+        width: int,
+        num_frames: int,
+        dim: int,
+        interpolation_mode: str = "bicubic",
+    ) -> None:
+        super().__init__()
+        self.height = height
+        self.width = width
+        self.num_frames = num_frames
+        self.dim = dim
+        self.interpolation_mode = interpolation_mode
+        self.weight = nn.Parameter(torch.empty(height, width, dim))
+        self.register_buffer(
+            "time_weight",
+            torch.from_numpy(get_1d_sincos_pos_embed(self.dim, self.num_frames))
+            .float()
+            .unsqueeze(1),
+            persistent=False,
+        )
+        self.reset_parameters()
+
+    def reset_parameters(self):
+        nn.init.normal_(self.weight)
+
+    def forward(self, x: torch.Tensor, grid_thws: torch.Tensor) -> torch.Tensor:
+        pos_embs = []
+        for t, h, w in grid_thws.tolist():
+            assert t <= self.num_frames, f"t:{t} > self.num_frames:{self.num_frames}"
+            if (h, w) == self.weight.shape[:-1]:
+                pos_emb_2d = self.weight.flatten(end_dim=1)
+            else:
+                pos_emb_2d = get_rope_shape(
+                    self.weight,
+                    interpolation_mode=self.interpolation_mode,
+                    shape=(h, w),
+                )
+
+            if t == 1:
+                pos_emb_3d = pos_emb_2d
+            else:
+                pos_emb_3d = (
+                    pos_emb_2d.unsqueeze(0).repeat(t, 1, 1) + self.time_weight[:t]
+                )
+            pos_embs.append(pos_emb_3d.reshape(-1, pos_emb_3d.shape[-1]))
+
+        return x + torch.cat(pos_embs)
+
+
+class MoonVision3dPatchEmbed(nn.Module):
+    def __init__(
+        self,
+        out_dim: int,
+        in_dim: int = 3,
+        patch_size=14,
+        pos_emb_height: int = 14,
+        pos_emb_width: int = 14,
+        pos_emb_time: int = 4,
+        pos_emb_type: str = "divided_fixed",
+    ):
+        super().__init__()
+        if isinstance(patch_size, int):
+            patch_size = (patch_size, patch_size)
+        assert isinstance(patch_size, Sequence)
+        assert len(patch_size) == 2
+        self.patch_size = patch_size
+
+        self.proj = nn.Conv2d(
+            in_dim, out_dim, kernel_size=patch_size, stride=patch_size
+        )
+
+        if pos_emb_type != "divided_fixed":
+            raise NotImplementedError(f"Not support pos_emb_type: {pos_emb_type}")
+        self.pos_emb = Learnable2DInterpPosEmbDividedFixed(
+            height=pos_emb_height,
+            width=pos_emb_width,
+            num_frames=pos_emb_time,
+            dim=out_dim,
+        )
+
+    def forward(self, x: torch.Tensor, grid_thws: torch.Tensor) -> torch.Tensor:
+        x = self.proj(x).view(x.size(0), -1)
+        return self.pos_emb(x, grid_thws)
+
+
+class Rope2DPosEmbRepeated(nn.Module):
+    def __init__(self, dim: int, max_height: int, max_width: int, theta_base=10000):
+        super().__init__()
+        self.dim = dim
+        assert self.dim % 4 == 0, "dim must be divisible by 4"
+        self.max_height = max_height
+        self.max_width = max_width
+        self.theta_base = theta_base
+
+    def _precompute_freqs_cis(self, device: torch.device) -> torch.Tensor:
+        total_positions = self.max_height * self.max_width
+        flat_pos = torch.arange(0, total_positions, device=device).float()
+        x_pos = flat_pos % self.max_width
+        y_pos = flat_pos // self.max_width
+        dim_range = torch.arange(0, self.dim, 4, device=device).float()[: self.dim // 4]
+        freqs = 1.0 / (self.theta_base ** (dim_range / self.dim))
+        x_freqs = torch.outer(x_pos, freqs).float()
+        y_freqs = torch.outer(y_pos, freqs).float()
+        x_cis = torch.polar(torch.ones_like(x_freqs), x_freqs)
+        y_cis = torch.polar(torch.ones_like(y_freqs), y_freqs)
+        freqs_cis = torch.cat(
+            [x_cis.unsqueeze(dim=-1), y_cis.unsqueeze(dim=-1)], dim=-1
+        )
+        return freqs_cis.reshape(self.max_height, self.max_width, -1)
+
+    def get_freqs_cis(
+        self, grid_thws: torch.Tensor, device: torch.device
+    ) -> torch.Tensor:
+        if not hasattr(self, "freqs_cis"):
+            self.register_buffer(
+                "freqs_cis", self._precompute_freqs_cis(device), persistent=False
+            )
+
+        shapes = grid_thws.tolist()
+        assert all(
+            1 <= h <= self.max_height and 1 <= w <= self.max_width for _, h, w in shapes
+        ), (shapes, self.max_height, self.max_width)
+
+        return torch.cat(
+            [
+                self.freqs_cis[:h, :w].reshape(-1, self.dim // 2).repeat(t, 1)
+                for t, h, w in shapes
+            ],
+            dim=0,
+        )
+
+
+class MLP2(nn.Module):
+    def __init__(
+        self,
+        dims: list,
+        activation,
+        bias: bool = True,
+        quant_config=None,
+        prefix: str = "",
+        use_data_parallel: bool = False,
+    ):
+        super().__init__()
+        assert len(dims) == 3
+        self.use_data_parallel = use_data_parallel
+        self.fc0 = ColumnParallelLinear(
+            dims[0],
+            dims[1],
+            bias=bias,
+            quant_config=quant_config,
+            prefix=maybe_prefix(prefix, "fc0"),
+            disable_tp=self.use_data_parallel,
+        )
+        self.fc1 = RowParallelLinear(
+            dims[1],
+            dims[2],
+            bias=bias,
+            quant_config=quant_config,
+            prefix=maybe_prefix(prefix, "fc1"),
+            disable_tp=self.use_data_parallel,
+        )
+        self.activation = activation
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x, _ = self.fc0(x)
+        x = self.activation(x)
+        x, _ = self.fc1(x)
+        return x
+
+
+class MoonViTEncoderLayer(nn.Module):
+    def __init__(
+        self,
+        num_heads: int,
+        hidden_dim: int,
+        mlp_dim: int,
+        quant_config=None,
+        prefix: str = "",
+        *,
+        activation=F.gelu,
+        attn_bias: bool = False,
+        use_data_parallel: bool = False,
+    ):
+        super().__init__()
+        self.use_data_parallel = use_data_parallel
+        self.num_heads = num_heads
+        self.hidden_dim = hidden_dim
+        self.hidden_size_per_attention_head = self.hidden_dim // self.num_heads
+        self.tp_size = (
+            1 if self.use_data_parallel else get_tensor_model_parallel_world_size()
+        )
+        self.num_attention_heads_per_partition = divide(num_heads, self.tp_size)
+
+        self.norm0 = nn.LayerNorm(hidden_dim)
+        self.norm1 = nn.LayerNorm(hidden_dim)
+        self.mlp = MLP2(
+            [hidden_dim, mlp_dim, hidden_dim],
+            activation,
+            quant_config=quant_config,
+            prefix=f"{prefix}.mlp",
+            use_data_parallel=self.use_data_parallel,
+        )
+        self.wqkv = QKVParallelLinear(
+            hidden_size=hidden_dim,
+            head_size=self.hidden_size_per_attention_head,
+            total_num_heads=num_heads,
+            total_num_kv_heads=num_heads,
+            bias=attn_bias,
+            quant_config=quant_config,
+            prefix=f"{prefix}.wqkv",
+            disable_tp=self.use_data_parallel,
+        )
+        self.wo = RowParallelLinear(
+            hidden_dim,
+            hidden_dim,
+            bias=attn_bias,
+            quant_config=quant_config,
+            prefix=f"{prefix}.wo",
+            disable_tp=self.use_data_parallel,
+        )
+        self.attn = MultiHeadAttention(
+            self.num_attention_heads_per_partition,
+            self.hidden_size_per_attention_head,
+            self.hidden_size_per_attention_head**-0.5,
+        )
+
+    def attention_qkvpacked(
+        self,
+        x: torch.Tensor,
+        cu_seqlens: torch.Tensor,
+        rope_freqs_cis=None,
+    ):
+        seq_length = x.size(0)
+        xqkv, _ = self.wqkv(x)
+        qkv_shape = xqkv.size()[:-1] + (
+            3,
+            self.num_attention_heads_per_partition,
+            self.hidden_size_per_attention_head,
+        )
+        xqkv = xqkv.view(*qkv_shape)
+        xq, xk, xv = torch.unbind(xqkv, dim=-3)
+
+        if rope_freqs_cis is not None:
+            xq, xk = apply_rope(xq, xk, rope_freqs_cis)
+
+        # Split by sequences and process each independently
+        lengths = (cu_seqlens[1:] - cu_seqlens[:-1]).tolist()
+        q_splits = xq.split(lengths, dim=0)
+        k_splits = xk.split(lengths, dim=0)
+        v_splits = xv.split(lengths, dim=0)
+
+        attn_chunks = []
+        for q_chunk, k_chunk, v_chunk in zip(q_splits, k_splits, v_splits):
+            q_flat = q_chunk.reshape(1, q_chunk.shape[0], -1)
+            k_flat = k_chunk.reshape(1, k_chunk.shape[0], -1)
+            v_flat = v_chunk.reshape(1, v_chunk.shape[0], -1)
+            attn_chunks.append(
+                self.attn(q_flat, k_flat, v_flat).reshape(-1, q_flat.shape[-1])
+            )
+
+        attn_out = torch.cat(attn_chunks, dim=0).reshape(
+            seq_length,
+            self.num_attention_heads_per_partition
+            * self.hidden_size_per_attention_head,
+        )
+        attn_out, _ = self.wo(attn_out)
+        return attn_out
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        cu_seqlens: torch.Tensor,
+        rope_freqs_cis=None,
+    ):
+        residual = hidden_states
+        hidden_states = self.norm0(hidden_states)
+        hidden_states = self.attention_qkvpacked(
+            hidden_states, cu_seqlens, rope_freqs_cis
+        )
+        hidden_states = residual + hidden_states
+
+        residual = hidden_states
+        hidden_states = self.norm1(hidden_states)
+        hidden_states = self.mlp(hidden_states)
+        return residual + hidden_states
+
+
+class MoonViT3dEncoder(nn.Module):
+    def __init__(
+        self,
+        hidden_dim: int,
+        num_layers: int,
+        block_cfg: dict,
+        video_attn_type: str = "spatial_temporal",
+        quant_config=None,
+        prefix: str = "",
+        use_data_parallel: bool = False,
+    ) -> None:
+        super().__init__()
+        assert (
+            video_attn_type == "spatial_temporal"
+        ), f'video_attn_type must be "spatial_temporal", got {video_attn_type}'
+        self.video_attn_type = video_attn_type
+        self.rope_2d = Rope2DPosEmbRepeated(
+            block_cfg["hidden_dim"] // block_cfg["num_heads"], 512, 512
+        )
+        self.blocks = nn.ModuleList(
+            [
+                MoonViTEncoderLayer(
+                    **block_cfg,
+                    quant_config=quant_config,
+                    prefix=f"{prefix}.blocks.{layer_idx}",
+                    use_data_parallel=use_data_parallel,
+                )
+                for layer_idx in range(num_layers)
+            ]
+        )
+        self.final_layernorm = nn.LayerNorm(hidden_dim)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        grid_thws: torch.Tensor,
+    ) -> torch.Tensor:
+        rope_freqs_cis = self.rope_2d.get_freqs_cis(
+            grid_thws=grid_thws, device=hidden_states.device
+        )
+
+        lengths = torch.cat(
+            (
+                torch.zeros(1, dtype=grid_thws.dtype, device=grid_thws.device),
+                grid_thws[:, 0] * grid_thws[:, 1] * grid_thws[:, 2],
+            )
+        )
+        cu_seqlens = lengths.to(hidden_states.device).cumsum(dim=0, dtype=torch.int32)
+
+        for block in self.blocks:
+            hidden_states = block(
+                hidden_states, cu_seqlens, rope_freqs_cis=rope_freqs_cis
+            )
+
+        return self.final_layernorm(hidden_states)
+
+
+def tpool_patch_merger(
+    x: torch.Tensor,
+    grid_thws: torch.Tensor,
+    merge_kernel_size: tuple = (2, 2),
+) -> list:
+    kh, kw = merge_kernel_size
+    lengths = (grid_thws[:, 0] * grid_thws[:, 1] * grid_thws[:, 2]).tolist()
+    seqs = x.split(lengths, dim=0)
+
+    outputs = []
+    for seq, (t, h, w) in zip(seqs, grid_thws.tolist()):
+        nh, nw = h // kh, w // kw
+        value = seq.view(t, nh, kh, nw, kw, -1)
+        value = value.mean(dim=0)
+        out = value.permute(0, 2, 1, 3, 4).reshape(nh * nw, kh * kw, -1)
+        outputs.append(out)
+
+    return outputs
+
+
+class MoonViT3dPretrainedModel(nn.Module):
+    def __init__(
+        self,
+        config: KimiK25VisionConfig,
+        quant_config=None,
+        prefix: str = "",
+        use_data_parallel: bool = False,
+    ):
+        super().__init__()
+        config = deepcopy(config)
+        self.config = config
+        self.merge_kernel_size = config.merge_kernel_size
+        self.patch_size = config.patch_size
+        self.merge_type = config.merge_type
+        self.use_data_parallel = use_data_parallel
+
+        self.patch_embed = MoonVision3dPatchEmbed(
+            out_dim=config.hidden_size,
+            patch_size=config.patch_size,
+            pos_emb_height=config.init_pos_emb_height,
+            pos_emb_width=config.init_pos_emb_width,
+            pos_emb_time=config.init_pos_emb_time,
+            pos_emb_type=config.pos_emb_type,
+        )
+
+        self.encoder = MoonViT3dEncoder(
+            hidden_dim=config.hidden_size,
+            num_layers=config.num_hidden_layers,
+            block_cfg={
+                "num_heads": config.num_attention_heads,
+                "hidden_dim": config.hidden_size,
+                "mlp_dim": config.intermediate_size,
+                "activation": get_act_fn("gelu_pytorch_tanh"),
+                "attn_bias": True,
+            },
+            video_attn_type=config.video_attn_type,
+            quant_config=quant_config,
+            prefix=maybe_prefix(prefix, "encoder"),
+            use_data_parallel=use_data_parallel,
+        )
+
+    @property
+    def dtype(self) -> torch.dtype:
+        return self.patch_embed.proj.weight.dtype
+
+    @property
+    def device(self) -> torch.device:
+        return self.patch_embed.proj.weight.device
+
+    def forward(self, pixel_values: torch.Tensor, grid_thws: torch.Tensor) -> list:
+        pixel_values = pixel_values.to(device=self.device, dtype=self.dtype)
+        hidden_states = self.patch_embed(pixel_values, grid_thws)
+        hidden_states = self.encoder(hidden_states, grid_thws)
+        if self.merge_type != "sd2_tpool":
+            raise NotImplementedError(f"Not support {self.merge_type}")
+        return tpool_patch_merger(
+            hidden_states, grid_thws, merge_kernel_size=self.merge_kernel_size
+        )
+
+
+@torch.inference_mode()
+def mm_projector_forward(mm_projector: torch.nn.Module, vt_output: list):
+    num_embedding_list = [x.shape[0] for x in vt_output]
+    batched = torch.cat(vt_output, dim=0)
+    proj_out = mm_projector(batched)
+    proj_out = proj_out.reshape(-1, proj_out.shape[-1])
+    return torch.split(proj_out, num_embedding_list)
+
+
+@torch.inference_mode()
+def vision_tower_forward(
+    vision_tower: Any,
+    pixel_values: torch.Tensor,
+    grid_thw: torch.Tensor,
+    mm_projector: Any,
+    use_data_parallel: bool,
+) -> list:
+    # Note: DP sharding for vision model is not yet supported on Kunlun,
+    # always use direct forward for now.
+    vt_outputs = vision_tower(pixel_values, grid_thw)
+    tensors = mm_projector_forward(mm_projector, list(vt_outputs))
+    return list(tensors)
+
+
+class KimiK25MultiModalProjector(nn.Module):
+    def __init__(
+        self,
+        config: KimiK25VisionConfig,
+        use_data_parallel: bool = False,
+        quant_config=None,
+        prefix: str = "",
+    ):
+        super().__init__()
+        self.use_data_parallel = use_data_parallel
+        merge_h, merge_w = config.merge_kernel_size
+        self.hidden_size = config.hidden_size * merge_h * merge_w
+
+        self.pre_norm = nn.LayerNorm(config.hidden_size, eps=config.projector_ln_eps)
+        self.linear_1 = ReplicatedLinear(
+            self.hidden_size,
+            self.hidden_size,
+            bias=True,
+            quant_config=quant_config,
+            prefix=f"{prefix}.linear_1",
+        )
+        self.linear_2 = ReplicatedLinear(
+            self.hidden_size,
+            config.mm_hidden_size,
+            bias=True,
+            quant_config=quant_config,
+            prefix=f"{prefix}.linear_2",
+        )
+        self.act = GELUActivation()
+
+    def forward(self, image_features: torch.Tensor) -> torch.Tensor:
+        hidden_states = self.pre_norm(image_features).view(-1, self.hidden_size)
+        hidden_states, _ = self.linear_1(hidden_states)
+        hidden_states = self.act(hidden_states)
+        hidden_states, _ = self.linear_2(hidden_states)
+        return hidden_states

--- a/vllm_kunlun/ops/_kunlun_ops.py
+++ b/vllm_kunlun/ops/_kunlun_ops.py
@@ -609,6 +609,207 @@ class KunlunOps:
             return output
 
     @staticmethod
+    def fused_moe_ct_w4a16(
+        hidden_states: torch.Tensor,
+        w13_weight_packed_signed: torch.Tensor,
+        w2_weight_packed_signed: torch.Tensor,
+        w13_scale: torch.Tensor,
+        w2_scale: torch.Tensor,
+        router_logits: torch.Tensor,
+        moe_top_k: int,
+        renormalize: bool,
+        use_grouped_topk: bool = False,
+        num_expert_group: Optional[int] = None,
+        topk_group: Optional[int] = None,
+        scoring_func: str = "softmax",
+        e_score_correction_bias: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        """Optimized fused_moe with preprocessed packed int4 weights.
+
+        Args:
+            hidden_states: Input hidden states [M, N]
+            w13_weight_packed_signed: Preprocessed w13 weights [E, up_gate_size, hidden_dim//2], int8
+            w2_weight_packed_signed: Preprocessed w2 weights [E, hidden_dim, intermediate_size//TP//2], int8
+            w13_scale: Preprocessed w13 scale (multiplied by 7.0, float32)
+            w2_scale: Preprocessed w2 scale (multiplied by 7.0, float32)
+            router_logits: Router logits for expert selection
+            moe_top_k: Number of top experts to select
+            renormalize: Whether to renormalize expert weights
+            use_grouped_topk: Whether to use grouped topk
+            num_expert_group: Number of expert groups for grouped topk
+            topk_group: Number of top groups for grouped topk
+            scoring_func: Scoring function ("softmax" or "sigmoid")
+            e_score_correction_bias: Bias for sigmoid scoring
+
+        Returns:
+            Output tensor [M, N]
+        """
+        # Get shapes from packed weights
+        global_num_experts = w13_weight_packed_signed.shape[0]
+        up_gate_size = w13_weight_packed_signed.shape[1]
+        M, N = hidden_states.shape
+        hidden_dim = w2_weight_packed_signed.shape[1]
+
+        # Initialize tensors for topk selection
+        normed_score = torch.empty(
+            M, moe_top_k, dtype=torch.float32, device=hidden_states.device
+        )
+        topk_ids = torch.empty(
+            M, moe_top_k, dtype=torch.int32, device=hidden_states.device
+        )
+
+        num_blocks = 12
+        block_statistic = torch.zeros(
+            num_blocks,
+            global_num_experts,
+            dtype=torch.int32,
+            device=hidden_states.device,
+        )
+
+        # TopK routing
+        router_logits = router_logits.to(torch.float)
+        if scoring_func == "softmax":
+            torch.ops._C.moe_softmax_topk_norm(
+                x=router_logits,
+                normed_score=normed_score,
+                topk_index=topk_ids,
+                block_statistic=None,
+                stable=True,
+            )
+        elif scoring_func == "sigmoid":
+            torch.ops._C.moe_sigmoid_group_topk_norm(
+                x=router_logits,
+                topk_index=topk_ids,
+                norm_score=normed_score,
+                block_static=block_statistic,
+                bias=e_score_correction_bias,
+                scale=1.0,
+                n_group=num_expert_group,
+                topk_group=topk_group,
+            )
+        else:
+            raise ValueError(f"Unsupported scoring_func: {scoring_func}")
+
+        # Generate block statistic
+        torch.ops._C.gen_block_statistic(topk_ids, block_statistic)
+
+        # Pre-sort tokens by expert
+        moe_expand = torch.empty(
+            (M * moe_top_k, N), dtype=hidden_states.dtype, device=hidden_states.device
+        )
+        expert_m = torch.zeros(
+            global_num_experts, dtype=torch.int32, device=hidden_states.device
+        )
+        sorted_tokens_num_lod = torch.zeros(
+            global_num_experts + 1, dtype=torch.int32, device=hidden_states.device
+        )
+        sorted_tokens_idx = torch.zeros(
+            M * moe_top_k, dtype=torch.int32, device=hidden_states.device
+        )
+
+        torch.ops._C.moe_pre_sorted(
+            x=hidden_states,
+            topk_index=topk_ids,
+            block_statistic=block_statistic,
+            moe_expand=moe_expand,
+            moe_index=sorted_tokens_idx,
+            expert_m=expert_m,
+            sorted_tokens_num_lod=sorted_tokens_num_lod,
+        )
+        del expert_m, block_statistic  # Release after moe_pre_sorted
+
+        # First FC layer (w13) - use preprocessed weights directly
+        y = torch.empty(
+            M * moe_top_k,
+            up_gate_size,
+            dtype=hidden_states.dtype,
+            device=hidden_states.device,
+        )
+
+        # Pre-allocate perchannel_max buffer for both w13 and w2 (memory reuse)
+        # w13 needs shape [M*top_k, N], w2 needs shape [M*top_k, up_gate_size//2]
+        max_perchannel_dim = max(N, up_gate_size // 2)
+        perchannel_max_buffer = torch.ones(
+            M * moe_top_k,
+            max_perchannel_dim,
+            dtype=torch.float32,
+            device=hidden_states.device,
+        )
+        x_perchannel_max = perchannel_max_buffer[:, :N]
+
+        # Use preprocessed weights and scale directly (no XOR or type conversion needed)
+        torch.ops._C.moe_fc_v3(
+            x=moe_expand,
+            weight=w13_weight_packed_signed,
+            sorted_tokens_num_lod=sorted_tokens_num_lod,
+            sorted_tokens_idx=sorted_tokens_idx,
+            moe_topk=moe_top_k,
+            y=y,
+            x_perchannel_max=x_perchannel_max,
+            w_perchannel_max=w13_scale,
+            use_pack_int4=True,
+            sort_mode=True,
+        )
+        del moe_expand, x_perchannel_max  # Release after first FC
+
+        # Activation: silu_and_mul
+        d = y.shape[-1] // 2
+        output_shape = y.shape[:-1] + (d,)
+        out1 = torch.empty(output_shape, dtype=y.dtype, device=y.device)
+        torch.ops._C.silu_and_mul(out1, y)
+        del y  # Release y after silu_and_mul
+
+        # Second FC layer (w2) - use preprocessed weights directly
+        out = torch.empty(
+            M * moe_top_k,
+            hidden_dim,
+            dtype=hidden_states.dtype,
+            device=hidden_states.device,
+        )
+
+        out1 = out1.reshape(-1, out1.shape[-1])
+        # Reuse perchannel_max_buffer for w2 (memory optimization)
+        x2_perchannel_max = perchannel_max_buffer[:, :d]
+
+        # Use preprocessed weights and scale directly (no XOR or type conversion needed)
+        torch.ops._C.moe_fc_v3(
+            x=out1,
+            weight=w2_weight_packed_signed,
+            sorted_tokens_num_lod=sorted_tokens_num_lod,
+            sorted_tokens_idx=sorted_tokens_idx,
+            moe_topk=moe_top_k,
+            y=out,
+            x_perchannel_max=x2_perchannel_max,
+            w_perchannel_max=w2_scale,
+            use_pack_int4=True,
+            sort_mode=True,
+        )
+
+        del out1, x2_perchannel_max, perchannel_max_buffer
+
+        # Post-processing: reshape and weight by normed_score
+        dequant_scale = torch.ones(
+            [M, moe_top_k], dtype=torch.float32, device=out.device
+        )
+        output = torch.empty(
+            [M, N], dtype=hidden_states.dtype, device=hidden_states.device
+        )
+        sorted_tokens_idx = sorted_tokens_idx.view(M, moe_top_k)
+
+        # Reshape out to 3D for moe_post
+        out = out.view(M, moe_top_k, hidden_dim)
+
+        torch.ops._C.moe_post(
+            x=out,
+            moe_index=sorted_tokens_idx,
+            normed_scale=normed_score,
+            dequant_scale=dequant_scale,
+            y=output,
+        )
+
+        return output
+
+    @staticmethod
     def fused_moe_ep(
         hidden_states: torch.Tensor,
         w13_weight: torch.Tensor,

--- a/vllm_kunlun/ops/quantization/compressed_tensors/compressed_tensors_moe.py
+++ b/vllm_kunlun/ops/quantization/compressed_tensors/compressed_tensors_moe.py
@@ -32,14 +32,13 @@ from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tenso
     find_matched_target,
 )
 from vllm_kunlun.ops._kunlun_ops import KunlunOps as ops
-from vllm_kunlun.ops.quantization.kernels.quant_ops import dequant_int4_native
 
 logger = init_logger(__name__)
 
 
 class KunlunCompressedTensorsMoEMethod(FusedMoEMethodBase):
 
-    def __init_(self, moe: FusedMoEConfig):
+    def __init__(self, moe: FusedMoEConfig):
         super().__init__(moe)
 
     @staticmethod
@@ -290,6 +289,54 @@ class KunlunCompressedTensorsW8A8Int8MoEMethod(CompressedTensorsW8A8Int8MoEMetho
 
 class KunlunCompressedTensorsWNA16MoEMethod(CompressedTensorsWNA16MoEMethod):
 
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        """Optimized preprocessing for apply_moe_fc_v3.
+
+        This method:
+        1. Transpose weights and scales
+        2. Convert weights to signed int8 format (XOR 0x88)
+        3. Multiply scales by 7.0 and convert to float32
+        4. Release unused parameters to save memory
+
+        Memory optimization:
+        - Process one tensor at a time and release memory immediately
+        - Modify .data directly instead of creating new Parameter to avoid double memory
+        """
+        # Release unused parameters FIRST to free memory before processing
+        # These are created by parent class but not needed for Kunlun implementation
+        del layer.w13_weight_shape
+        del layer.w2_weight_shape
+        del layer.w13_weight_g_idx
+        del layer.w2_weight_g_idx
+        del layer.w13_g_idx_sort_indices
+        del layer.w2_g_idx_sort_indices
+
+        with torch.no_grad():
+            # Process w13 weights: transpose -> view as int8 -> in-place XOR 0x88
+            # Modify .data directly to avoid creating new Parameter (saves memory)
+            w13_data = layer.w13_weight_packed.data.transpose(1, 2).contiguous()
+            w13_data = w13_data.view(torch.int8)
+            w13_data.bitwise_xor_(0x88)  # in-place XOR
+            layer.w13_weight_packed.data = w13_data  # Direct assignment, no new Parameter
+
+            # Process w2 weights: same as w13
+            w2_data = layer.w2_weight_packed.data.transpose(1, 2).contiguous()
+            w2_data = w2_data.view(torch.int8)
+            w2_data.bitwise_xor_(0x88)  # in-place XOR
+            layer.w2_weight_packed.data = w2_data  # Direct assignment, no new Parameter
+
+            # Process w13 scale: use in-place operations to reduce memory
+            w13_scale_data = layer.w13_weight_scale.data.transpose(1, 2).contiguous()
+            w13_scale_data.mul_(7.0)  # in-place multiply
+            w13_scale_data = w13_scale_data.to(torch.float32)  # type conversion
+            layer.w13_weight_scale.data = w13_scale_data  # Direct assignment
+
+            # Process w2 scale: same as w13
+            w2_scale_data = layer.w2_weight_scale.data.transpose(1, 2).contiguous()
+            w2_scale_data.mul_(7.0)  # in-place multiply
+            w2_scale_data = w2_scale_data.to(torch.float32)  # type conversion
+            layer.w2_weight_scale.data = w2_scale_data  # Direct assignment
+
     def apply(
         self,
         layer: torch.nn.Module,
@@ -313,48 +360,28 @@ class KunlunCompressedTensorsWNA16MoEMethod(CompressedTensorsWNA16MoEMethod):
         logical_to_physical_map: Optional[torch.Tensor] = None,
         logical_replica_count: Optional[torch.Tensor] = None,
     ) -> Union[torch.Tensor, tuple[torch.Tensor, torch.Tensor]]:
-        # dequant packed weights to float16
-        w13_weight = dequant_int4_native(
-            weight_packed_uint8=layer.w13_weight_packed,
-            scale=self.moe_quant_config.w1_scale,
-        )
-        w2_weight = dequant_int4_native(
-            weight_packed_uint8=layer.w2_weight_packed,
-            scale=self.moe_quant_config.w2_scale,
-        )
-        
+        """Optimized implementation using preprocessed weights and fuse_moe_ct_w4a16."""
+        # EP mode is not supported for int4 packed weights
         if self.moe.use_ep:
-            return ops.fused_moe_ep(
-                x,
-                w13_weight,
-                w2_weight,
-                router_logits,
-                self.moe.ep_rank,
-                top_k,
-                renormalize=renormalize,
-                inplace=True,
-                use_grouped_topk=use_grouped_topk,
-                num_expert_group=num_expert_group,
-                topk_group=topk_group,
-            )
-        else:
-            return ops.fused_moe(
-                x,
-                w13_weight,
-                w2_weight,
-                router_logits,
-                self.moe.ep_rank,
-                top_k,
-                renormalize=renormalize,
-                inplace=True,
-                use_grouped_topk=use_grouped_topk,
-                num_expert_group=num_expert_group,
-                topk_group=topk_group,
-                scoring_func=scoring_func,
-                e_score_correction_bias=e_score_correction_bias,
-                w1_bias=getattr(layer, "w13_bias", None),
-                w2_bias=getattr(layer, "w2_bias", None),
-            )
+            raise NotImplementedError("EP mode is not supported for int4 packed weights yet.")
+
+        # Use preprocessed weights and scales (processed in process_weights_after_loading)
+        # Weights are already int8 (XOR 0x88) and scales are already float32 (multiplied by 7.0)
+        return ops.fused_moe_ct_w4a16(
+            hidden_states=x,
+            w13_weight_packed_signed=layer.w13_weight_packed,
+            w2_weight_packed_signed=layer.w2_weight_packed,
+            w13_scale=layer.w13_weight_scale,
+            w2_scale=layer.w2_weight_scale,
+            router_logits=router_logits,
+            moe_top_k=top_k,
+            renormalize=renormalize,
+            use_grouped_topk=use_grouped_topk,
+            num_expert_group=num_expert_group,
+            topk_group=topk_group,
+            scoring_func=scoring_func,
+            e_score_correction_bias=e_score_correction_bias,
+        )
 
 
 # monkey patch

--- a/vllm_kunlun/ops/quantization/kernels/quant_ops.py
+++ b/vllm_kunlun/ops/quantization/kernels/quant_ops.py
@@ -17,6 +17,7 @@
 # limitations under the License.
 
 import torch
+import xspeedgate_ops
 
 
 def dequant_int4(
@@ -84,3 +85,15 @@ def dequant_int4_native(weight_packed_uint8: torch.Tensor, scale: torch.Tensor):
         1, 1, weight_upacked_fp16.shape[-1] // scale.shape[-1]
     )
     return weight_upacked_fp16
+
+
+def dequant_int4_kunlun(weight_packed_uint8: torch.Tensor, scale: torch.Tensor):
+    unpacked_shape = list(weight_packed_uint8.shape)
+    unpacked_shape[-1] *= 2
+    output = torch.empty(
+        unpacked_shape, 
+        dtype=torch.float16, 
+        device=weight_packed_uint8.device
+    )
+    torch.ops.xspeedgate_ops.dequant_int4(weight_packed_uint8, output, scale, None, 32)
+    return output

--- a/vllm_kunlun/transformer_utils/config.py
+++ b/vllm_kunlun/transformer_utils/config.py
@@ -8,6 +8,7 @@ _XPU_CONFIG_REGISTRY: dict[str, type[PretrainedConfig]] = LazyConfigDict(
     deepseek_v32="DeepseekV3Config",
     glm_moe_dsa="DeepseekV3Config",
     kimi_vl="KimiVLConfig",
+    kimi_k25="KimiK25Config",
     Llama_Nemotron_Nano_VL="Nemotron_Nano_VL_Config",
     RefinedWeb="RWConfig",  # For tiiuae/falcon-40b(-instruct)
     RefinedWebModel="RWConfig",  # For tiiuae/falcon-7b(-instruct)

--- a/vllm_kunlun/transformer_utils/kimi_k25.py
+++ b/vllm_kunlun/transformer_utils/kimi_k25.py
@@ -1,0 +1,102 @@
+from transformers import DeepseekV3Config
+from transformers.configuration_utils import PretrainedConfig
+
+
+class KimiK25VisionConfig(PretrainedConfig):
+    model_type = "kimi_k25_vision"
+
+    def __init__(
+        self,
+        patch_size: int = 14,
+        init_pos_emb_height: int = 64,
+        init_pos_emb_width: int = 64,
+        init_pos_emb_time: int = 4,
+        pos_emb_type: str = "divided_fixed",
+        num_attention_heads: int = 16,
+        num_hidden_layers: int = 27,
+        hidden_size: int = 1152,
+        intermediate_size: int = 4304,
+        merge_kernel_size: tuple = (2, 2),
+        video_attn_type: str = "spatial_temporal",
+        merge_type: str = "sd2_tpool",
+        mm_projector_type: str = "patchmerger",
+        mm_hidden_size: int = None,
+        projector_hidden_act: str = "gelu",
+        projector_ln_eps: float = 1e-5,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        # Handle checkpoint field name mapping (vt_* -> standard names)
+        self.patch_size = patch_size
+        self.init_pos_emb_height = init_pos_emb_height
+        self.init_pos_emb_width = init_pos_emb_width
+        self.init_pos_emb_time = init_pos_emb_time
+        self.pos_emb_type = pos_emb_type
+        self.num_attention_heads = kwargs.get(
+            "vt_num_attention_heads", num_attention_heads
+        )
+        self.num_hidden_layers = kwargs.get("vt_num_hidden_layers", num_hidden_layers)
+        self.hidden_size = kwargs.get("vt_hidden_size", hidden_size)
+        self.intermediate_size = kwargs.get("vt_intermediate_size", intermediate_size)
+        self.merge_kernel_size = merge_kernel_size
+        self.video_attn_type = video_attn_type
+        self.merge_type = merge_type
+        self.mm_projector_type = mm_projector_type
+        if mm_hidden_size is not None:
+            self.mm_hidden_size = mm_hidden_size
+        else:
+            self.mm_hidden_size = self.hidden_size
+        self.projector_hidden_act = projector_hidden_act
+        self.projector_ln_eps = projector_ln_eps
+
+
+class KimiK25Config(PretrainedConfig):
+    model_type = "kimi_k25"
+
+    def __init__(
+        self,
+        vision_config=None,
+        text_config=None,
+        ignore_index: int = -100,
+        media_placeholder_token_id: int = 163605,
+        pad_token_id: int = 0,
+        use_unified_vision_chunk: bool = False,
+        video_placeholder: str = "<|kimi_k25_video_placeholder|>",
+        **kwargs,
+    ):
+        if vision_config is None:
+            self.vision_config = KimiK25VisionConfig()
+        elif isinstance(vision_config, dict):
+            self.vision_config = KimiK25VisionConfig(**vision_config)
+        else:
+            self.vision_config = vision_config
+
+        if text_config is None:
+            self.text_config = DeepseekV3Config()
+        elif isinstance(text_config, dict):
+            self.text_config = DeepseekV3Config(**text_config)
+        else:
+            self.text_config = text_config
+
+        # Set mm_hidden_size to text hidden size if not explicitly
+        # configured to a different value
+        if self.vision_config.mm_hidden_size == self.vision_config.hidden_size:
+            self.vision_config.mm_hidden_size = self.text_config.hidden_size
+
+        self.ignore_index = ignore_index
+        self.media_placeholder_token_id = media_placeholder_token_id
+        self.use_unified_vision_chunk = use_unified_vision_chunk
+        self.video_placeholder = video_placeholder
+
+        if getattr(self.text_config, "quantization_config", None) is not None:
+            self.quantization_config = self.text_config.quantization_config
+
+        super().__init__(pad_token_id=pad_token_id, **kwargs)
+
+    @property
+    def hidden_size(self) -> int:
+        return self.text_config.hidden_size
+
+    @property
+    def vocab_size(self) -> int:
+        return self.text_config.vocab_size

--- a/vllm_kunlun/v1/attention/backends/mla/common.py
+++ b/vllm_kunlun/v1/attention/backends/mla/common.py
@@ -1218,8 +1218,7 @@ class MLACommonImpl(MLACommonBaseImpl[M], Generic[M]):
         attn_out = torch.empty_like(q)
         ds_alpha = 1.8738542070926265
         tp_q_head_num=q.size(1)
-        softmax_lse = torch.zeros(tp_q_head_num, q.size(0), dtype=torch.float32, device=q.device)
-        softmax_lse.fill_(float('-inf'))
+        softmax_lse = torch.full((tp_q_head_num, q.size(0)), float('-inf'), dtype=torch.float32, device=q.device)
         kunlun_ops.attention(
             q=q,
             k_cache=k,
@@ -1238,7 +1237,8 @@ class MLACommonImpl(MLACommonBaseImpl[M], Generic[M]):
             v_trans=False,
             v_trans_threshold=0,
             alpha=ds_alpha,
-            softmax_lse=softmax_lse
+            softmax_lse=softmax_lse,
+            unpadded_lse=True,
         )
 
         # Unpack the output if there is multiple results
@@ -1312,7 +1312,7 @@ class MLACommonImpl(MLACommonBaseImpl[M], Generic[M]):
             k=k,
             v=v,
             context_seq_lod_xpu=prefill.query_start_loc,
-            context_seq_lod_cpu=prefill.chunked_context.cu_seq_lens_cpu[chunk_idx],
+            context_seq_lod_cpu=prefill.query_start_loc_cpu,
             softmax_scale=self.scale,
             causal=False,
             return_softmax_lse=True,
@@ -1745,7 +1745,7 @@ class MLACommonImpl(MLACommonBaseImpl[M], Generic[M]):
                     q, kv_c_and_k_pe_cache, attn_metadata, k_scale)
 
             output = torch.empty_like(suffix_output)
-            output_lse = torch.empty_like(output)
+            output_lse = torch.empty_like(suffix_lse)
             merge_attn_states(
                 output=output,
                 prefix_output=context_output,

--- a/vllm_kunlun/vllm_utils_wrapper.py
+++ b/vllm_kunlun/vllm_utils_wrapper.py
@@ -197,7 +197,7 @@ def vllm_kunlun_all_gather(self, input_: torch.Tensor, dim: int = -1) -> torch.T
         (world_size,) + input_size, dtype=input_.dtype, device=input_.device
     )
     # All-gather.
-    cast_output_tensor = output_tensor.view(-1, input_.shape[-1]) # for cudagraph
+    cast_output_tensor = output_tensor.view(-1, input_.shape[-1])  # for cudagraph
     torch.distributed.all_gather_into_tensor(
         cast_output_tensor, input_, group=self.device_group
     )
@@ -1400,6 +1400,121 @@ def fake_moe_fc(
 
 
 moe_fc.register_fake(fake_moe_fc)
+
+
+@custom_op("_C::moe_fc_v3", mutates_args=())
+def moe_fc_v3(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    sorted_tokens_num_lod: torch.Tensor,
+    sorted_tokens_idx: torch.Tensor,
+    moe_topk: int,
+    y: torch.Tensor,
+    act: Optional[str] = None,
+    x_perchannel_max: Optional[torch.Tensor] = None,
+    w_perchannel_max: Optional[torch.Tensor] = None,
+    topk_ids: Optional[torch.Tensor] = None,
+    topk_w: Optional[torch.Tensor] = None,
+    bias: Optional[torch.Tensor] = None,
+    tgemm_type: Optional[str] = None,
+    tweight_type: Optional[str] = None,
+    scale_n: int = 0,
+    scale_k: int = 0,
+    use_pack_int4: bool = False,
+    sort_mode: bool = True,
+) -> None:
+    kunlun_ops.moe_fc_v3(
+        x=x,
+        weight=weight,
+        sorted_tokens_num_lod=sorted_tokens_num_lod,
+        sorted_tokens_idx=sorted_tokens_idx,
+        moe_topk=moe_topk,
+        y=y,
+        act=act,
+        x_perchannel_max=x_perchannel_max,
+        w_perchannel_max=w_perchannel_max,
+        topk_ids=topk_ids,
+        topk_w=topk_w,
+        bias=bias,
+        tgemm_type=tgemm_type,
+        tweight_type=tweight_type,
+        scale_n=scale_n,
+        scale_k=scale_k,
+        use_pack_int4=use_pack_int4,
+        sort_mode=sort_mode,
+    )
+
+
+@impl("_C::moe_fc_v3", "CUDA")
+def moe_fc_v3_cuda(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    sorted_tokens_num_lod: torch.Tensor,
+    sorted_tokens_idx: torch.Tensor,
+    moe_topk: int,
+    y: torch.Tensor,
+    act: Optional[str] = None,
+    x_perchannel_max: Optional[torch.Tensor] = None,
+    w_perchannel_max: Optional[torch.Tensor] = None,
+    topk_ids: Optional[torch.Tensor] = None,
+    topk_w: Optional[torch.Tensor] = None,
+    bias: Optional[torch.Tensor] = None,
+    tgemm_type: Optional[str] = None,
+    tweight_type: Optional[str] = None,
+    scale_n: int = 0,
+    scale_k: int = 0,
+    use_pack_int4: bool = False,
+    sort_mode: bool = True,
+    recommended_expert_tokens: int = -1,
+) -> None:
+    kunlun_ops.moe_fc_v3(
+        x=x,
+        weight=weight,
+        sorted_tokens_num_lod=sorted_tokens_num_lod,
+        sorted_tokens_idx=sorted_tokens_idx,
+        moe_topk=moe_topk,
+        y=y,
+        act=act,
+        x_perchannel_max=x_perchannel_max,
+        w_perchannel_max=w_perchannel_max,
+        topk_ids=topk_ids,
+        topk_w=topk_w,
+        bias=bias,
+        tgemm_type=tgemm_type,
+        tweight_type=tweight_type,
+        scale_n=scale_n,
+        scale_k=scale_k,
+        use_pack_int4=use_pack_int4,
+        sort_mode=sort_mode,
+        recommended_expert_tokens=recommended_expert_tokens,
+    )
+
+
+def fake_moe_fc_v3(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    sorted_tokens_num_lod: torch.Tensor,
+    sorted_tokens_idx: torch.Tensor,
+    moe_topk: int,
+    y: torch.Tensor,
+    act: Optional[str] = None,
+    x_perchannel_max: Optional[torch.Tensor] = None,
+    w_perchannel_max: Optional[torch.Tensor] = None,
+    topk_ids: Optional[torch.Tensor] = None,
+    topk_w: Optional[torch.Tensor] = None,
+    bias: Optional[torch.Tensor] = None,
+    tgemm_type: Optional[str] = None,
+    tweight_type: Optional[str] = None,
+    scale_n: int = 0,
+    scale_k: int = 0,
+    use_pack_int4: bool = False,
+    sort_mode: bool = True,
+    recommended_expert_tokens: int = -1,
+) -> None:
+    return None
+
+
+moe_fc_v3.register_fake(fake_moe_fc_v3)
 
 
 @custom_op("_C::moe_post", mutates_args=())


### PR DESCRIPTION
## PR Description

This PR includes two main changes: **Kimi-K2.5 multimodal model support** and **optimized WNA16 MoE inference path with moe_fc_v3 kernel**, along with several MLA attention bugfixes. @KinChow @Zhihuauk @kurkol @WeiJie-520 

### 1. [Feature] Kimi-K2.5 Multimodal Model Support

Add full support for Kimi-K2.5, a multimodal variant of Kimi-K2 (DeepseekV3) with a MoonViT 3D vision tower and temporal pooling patch merger.

- Add `KimiK25Config` and `KimiK25VisionConfig` configuration classes
- Implement `KimiK25ForConditionalGeneration` model with vision tower, mm projector, and DeepseekV3 language model backbone
- Implement `MoonViT3dPretrainedModel` vision encoder with spatial-temporal attention, 2D learnable interpolated position embedding, and 3D RoPE
- Register model and config in the Kunlun model/config registries

### 2. [Feature] Optimized WNA16 MoE Inference Path

Refactor `KunlunCompressedTensorsWNA16MoEMethod` to use the `moe_fc_v3` kernel directly with preprocessed packed int8 weights, replacing the previous approach of online dequantization to float16 followed by `fused_moe`/`fused_moe_ep`.

**Before**: `packed uint4 -> dequant_int4_native (online) -> float16 weights -> fused_moe`
**After**: `packed int8 (preprocessed offline) -> moe_fc_v3 (direct)`

Key changes:
- Add `process_weights_after_loading()`: offline preprocessing including weight transpose, signed int8 conversion (XOR 0x88), scale multiplication (x7.0), and release of unused attributes to save memory
- Add `fused_moe_ct_w4a16()` in `KunlunOps`: implements topk routing, pre-sorting, two FC layers (w13/w2) via `moe_fc_v3` kernel with `use_pack_int4=True`, and `moe_post` weighted reduction, with shared `perchannel_max_buffer` between w13 and w2 to reduce peak GPU memory
- Register `_C::moe_fc_v3` custom op wrapper for torch.compile compatibility
- Remove the old `dequant_int4_native` + `fused_moe` code path

### 3. [Bugfix] MLA Attention Fixes

- **`output_lse` shape bug**: `torch.empty_like(output)` incorrectly matched `suffix_output` shape `[M, N, num_heads * v_head_dim]`; changed to `torch.empty_like(suffix_lse)` with correct shape `[M, N, num_heads]`
- **`context_seq_lod_cpu` source**: Changed from `prefill.chunked_context.cu_seq_lens_cpu[chunk_idx]` to `prefill.query_start_loc_cpu` for correct prefill chunk attention sequence lengths
- **`unpadded_lse=True`**: Added new parameter to `kunlun_ops.attention()` call for proper unpadded LSE handling
- **`softmax_lse` initialization**: Replaced two-step `torch.zeros()` + `fill_(-inf)` with single `torch.full()` for minor performance improvement

### 4. Config Registration Improvement

Changed from conditional `sys.modules` check to direct import/assignment for `_CONFIG_REGISTRY` and KimiK25 configs, ensuring registration regardless of module import order.


---

## Checklist (Required)

Before submitting this PR, please ensure that all the following items are completed:

- [ ] All code changes pass the [`pre-commit`](https://github.com/baidu/vLLM-Kunlun/blob/main/CONTRIBUTING.md) checks.
- [ ] Commits are signed off using `git commit -s`.
- [ ] The PR title is properly classified (see below).

---

## PR Type

Please prefix the PR title with one or more of the following labels to help reviewers quickly understand the nature of the change:

- `[Feature]` – New features or enhancements (e.g. Attention, Communicator, Kernel, Worker, etc.)
- `[Bugfix]` – Bug fixes
- `[CI/Build]` – CI, build system, or infrastructure improvements
- `[Doc]` – Documentation updates or fixes
- `[Misc]` – Other changes that do not fit the above categories (use sparingly)

> **Note:** If the PR spans multiple categories, include all relevant prefixes.

---

<details>
<summary><b>Detailed Checklist (Click to Expand)</b></summary>

<p>Thank you for contributing to <b>vLLM Kunlun</b>!  
To help us maintain high code quality and streamline the review process, please ensure your PR meets the following requirements.</p>

<h3>1. Code Quality</h3>

<ul>
    <li>All linting and formatting checks pass (<code>pre-commit</code>).</li>
    <li>The code is well-structured and sufficiently documented.</li>
    <li>The change is designed with maintainability and readability in mind.</li>
</ul>

<h3>2. Testing</h3>

<ul>
    <li>Relevant unit tests are added or updated.</li>
    <li>Integration tests are included when applicable.</li>
    <li>Existing tests continue to pass.</li>
</ul>

<h3>3. DCO Compliance</h3>

<p>This project follows the
<a href="https://github.com/vllm-project/vllm/blob/main/DCO">Developer Certificate of Origin (DCO)</a>.</p>

<ul>
    <li>All commits include a <code>Signed-off-by:</code> line.</li>
    <li>Use <code>git commit -s</code> to automatically add the sign-off.</li>
</ul>

<h3>4. Review Expectations</h3>

<p>During the review process, maintainers may:</p>

<ul>
    <li>Request code refactoring or additional tests.</li>
    <li>Ask for clarifications on design decisions.</li>
    <li>Suggest performance, stability, or maintainability improvements.</li>
</ul>

<p>We appreciate your patience and collaboration throughout the review process!</p>

</details>
