### PR TITLE
[Feature] Register Qwen3_5ForConditionalGeneration dense model

### DIFF
--- a/vllm_kunlun/models/__init__.py
+++ b/vllm_kunlun/models/__init__.py
@@ -98,6 +98,11 @@ def register_model():
         "vllm_kunlun.models.qwen3_5:Qwen3_5MoeForConditionalGeneration",
     )
 
+    ModelRegistry.register_model(
+        "Qwen3_5ForConditionalGeneration",
+        "vllm_kunlun.models.qwen3_5:Qwen3_5ForConditionalGeneration",
+    )
+
 
 def register_quant_method():
     """to do"""


### PR DESCRIPTION
## Summary
- Register `Qwen3_5ForConditionalGeneration` (dense version) in the model registry alongside the existing `Qwen3_5MoeForConditionalGeneration` (MoE version)
- This enables vLLM-Kunlun to serve the Qwen3.5 dense model variants on Kunlun3 XPU

## Test plan
- [ ] Verify Qwen3.5 dense model can be loaded and served via `vllm_kunlun` entry point
- [ ] Run pre-commit checks pass: `pre-commit run --all-files`

🤖 Generated with [Claude Code](https://claude.com/claude-code)