### PR TITLE
[Feature] Upgrade vLLM-Kunlun from 0.15.1 to 0.19.0

### DIFF
--- a/.github/workflows/ut.yml
+++ b/.github/workflows/ut.yml
@@ -40,7 +40,7 @@
 
 #       - name: Install vLLM
 #         run: |
-#           pip install vllm==0.11.0 --no-build-isolation --no-deps --no-deps --index-url https://pip.baidu-int.com/simple/
+#           pip install vllm==0.19.0 --no-build-isolation --no-deps --no-deps --index-url https://pip.baidu-int.com/simple/
 
 #       - name: Run Unit Test
 #         run: |

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ Please use the following recommended versions to get started quickly:
 
 | Version | Release type | Doc |
 |----------|---------------|-----|
-| v0.15.1 | Latest development version | [QuickStart](https://vllm-kunlun.readthedocs.io/en/latest/quick_start.html) and [Installation](https://vllm-kunlun.readthedocs.io/en/latest/installation.html) for more details |
+| v0.19.0 | Target development version | [QuickStart](https://vllm-kunlun.readthedocs.io/en/latest/quick_start.html) and [Installation](https://vllm-kunlun.readthedocs.io/en/latest/installation.html) for more details |
 
 ---
 

--- a/ci/scripts/docker/start_docker.sh
+++ b/ci/scripts/docker/start_docker.sh
@@ -76,7 +76,7 @@ docker run \
   --name="${DOCKER_NAME}" \
   -v /home:/home \
   -v "${WORKSPACE_MOUNT}" \
-  -v /ssd2:/ssd2 \
+  -v /ssd1:/ssd1 \
   -v /ssd1:/ssd1 \
   -v /ssd3:/ssd3 \
   -v /dev/shm:/dev/shm \

--- a/ci/scripts/docker/start_docker.sh
+++ b/ci/scripts/docker/start_docker.sh
@@ -77,7 +77,6 @@ docker run \
   -v /home:/home \
   -v "${WORKSPACE_MOUNT}" \
   -v /ssd1:/ssd1 \
-  -v /ssd1:/ssd1 \
   -v /ssd3:/ssd3 \
   -v /dev/shm:/dev/shm \
   -v /usr/lib64/libcuda.so.1:/usr/lib64/libcuda.so.1 \

--- a/ci/scripts/env/install_env.sh
+++ b/ci/scripts/env/install_env.sh
@@ -71,6 +71,7 @@ docker exec "${DOCKER_NAME}" bash -lc "
   pip install \
     \"https://baidu-kunlun-public.su.bcebos.com/v1/baidu-kunlun-share/1130/xtorch_ops-0.1.2209%2B6752ad20-cp310-cp310-linux_x86_64.whl?authorization=bce-auth-v1%2FALTAKypXxBzU7gg4Mk4K4c6OYR%2F2025-12-05T06%3A18%3A00Z%2F-1%2Fhost%2F14936c2b7e7c557c1400e4c467c79f7a9217374a7aa4a046711ac4d948f460cd\"
 
+  # TODO: replace this transitional Triton wheel once the 0.19.0 artifact is published.
   pip install \
     \"https://cce-ai-models.bj.bcebos.com/v1/vllm-kunlun-0.11.0/triton-3.0.0%2Bb2cde523-cp310-cp310-linux_x86_64.whl\"
 
@@ -87,14 +88,14 @@ docker exec "${DOCKER_NAME}" bash -lc "
   source \"${GITHUB_WORKSPACE}/vLLM-Kunlun/setup_env.sh\"
 
   ########################################
-  # 3. Install upstream vLLM 0.11.0
+  # 3. Install upstream vLLM 0.19.0
   ########################################
-  echo '===== Installing vLLM==0.11.0 ====='
+  echo '===== Installing vLLM==0.19.0 ====='
 
   pip uninstall -y vllm || true
   env | grep -i proxy || true
 
-  pip install vllm==0.11.0 \
+  pip install vllm==0.19.0 \
     --no-build-isolation \
     --no-deps \
     --index-url https://pip.baidu-int.com/simple/

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -65,17 +65,17 @@ myst_substitutions = {
     # the branch of vllm, used in vllm clone
     # - main branch: 'main'
     # - vX.Y.Z branch: 'vX.Y.Z'
-    "vllm_version": "v0.15.1",
+    "vllm_version": "v0.19.0",
     # the branch of vllm-kunlun, used in vllm-kunlun clone and image tag
     # - main branch: 'main'
     # - vX.Y.Z branch: latest vllm-kunlun release tag
-    "vllm_kunlun_version": "v0.15.1",
+    "vllm_kunlun_version": "main",
     # the newest release version of vllm-kunlun and matched vLLM, used in pip install.
     # This value should be updated when cut down release.
-    "pip_vllm_kunlun_version": "0.15.1",
-    "pip_vllm_version": "0.15.1",
+    "pip_vllm_kunlun_version": "0.19.0",
+    "pip_vllm_version": "0.19.0",
     # vllm version in ci
-    "ci_vllm_version": "v0.15.1",
+    "ci_vllm_version": "v0.19.0",
 }
 
 # For cross-file header anchors
@@ -116,7 +116,7 @@ html_logo = "logos/vllm-kunlun-logo-text-light.png"
 html_theme_options = {
     "path_to_docs": "docs/source",
     "repository_url": "https://github.com/baidu/vLLM-Kunlun",
-    "repository_branch": "v0.15.1-dev",
+    "repository_branch": "main",
     "use_repository_button": True,
     "use_edit_page_button": True,
 }

--- a/docs/source/faqs.md
+++ b/docs/source/faqs.md
@@ -2,7 +2,7 @@
 
 ## Version Specific FAQs
 
-- [[v0.15.1] FAQ & Feedback]
+- [[v0.19.0] FAQ & Feedback]
 
 ## General FAQs
 
@@ -24,7 +24,7 @@ We will support the kunlun4 M100 platform in early 2026.
 
 ### 3. How vllm-kunlun work with vLLM?
 
-vllm-kunlun is a hardware plugin for vLLM. Basically, the version of vllm-kunlun is the same as the version of vllm. For example, if you use vllm 0.15.1, you should use vllm-kunlun 0.15.1 as well. For main branch, we will make sure `vllm-kunlun` and `vllm` are compatible by each commit.
+vllm-kunlun is a hardware plugin for vLLM. Basically, the version of vllm-kunlun is the same as the version of vllm. For example, if you use vllm 0.19.0, you should use vllm-kunlun 0.19.0 as well. For main branch, we will make sure `vllm-kunlun` and `vllm` are compatible by each commit.
 
 ### 4. How to handle the out-of-memory issue?
 

--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -53,10 +53,10 @@ docker run -itd ${DOCKER_DEVICE_CONFIG} \
 ::::
 :::::
 ## Install vLLM-kunlun
-### Install vLLM 0.15.1
+### Install vLLM 0.19.0
 
 ```
-uv pip install vllm==0.15.1 --no-build-isolation --no-deps
+uv pip install vllm==0.19.0 --no-build-isolation --no-deps
 ```
 
 ### Build and Install
@@ -67,13 +67,15 @@ git clone https://github.com/baidu/vLLM-Kunlun
 
 cd vLLM-Kunlun
 
-git checkout v0.15.1-dev
+git checkout main
 
 uv pip install -r requirements.txt
 
 python setup.py build
 
 python setup.py install
+
+python vllm_kunlun/patches/patch_torch251.py
 ```
 
 ### Replace eval_frame.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "vllm-kunlun"
-version = "0.15.1.dev0"
+version = "0.19.0"
 description = "vLLM Kunlun3 backend plugin"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -12,19 +12,24 @@ license = { text = "MIT" }
 authors = [{ name = "kunlun"}]
 dependencies = []
 
-[project.scripts]
-vllm-kunlun = "vllm_kunlun.cmdline:main"
-
 [project.entry-points."vllm.platform_plugins"]
 kunlun = "vllm_kunlun:register"
 
 [project.entry-points."vllm.general_plugins"]
 kunlun_model = "vllm_kunlun:register_model"
+kunlun_quant = "vllm_kunlun.models:register_quant_method"
+
+[project.entry-points."vllm.plugins"]
+kunlun_fused_moe = "vllm_kunlun.ops.fused_moe:register_kunlun_fused_moe_ops"
 
 [tool.hatch.build]
 packages = ["vllm_kunlun"]
 include = ["vllm_kunlun/conf/*", "vllm_kunlun/data/*"]
 
+[tool.hatch.build.targets.sdist]
+artifacts = ["vllm_kunlun/*.so"]
+
 [tool.hatch.build.targets.wheel]
 packages = ["vllm_kunlun"]
+artifacts = ["vllm_kunlun/*.so"]
 output-dir = "output/dist"

--- a/setup.py
+++ b/setup.py
@@ -30,8 +30,9 @@ class CustomBuildExt(BuildExtension):
         for ext in self.extensions:
             ext_path = self.get_ext_fullpath(ext.name)
             file_name = os.path.basename(ext_path)
-            target_path = os.path.join("vllm_kunlun", file_name)
+            target_path = os.path.join(ROOT_DIR, "vllm_kunlun", file_name)
 
+            os.makedirs(os.path.dirname(target_path), exist_ok=True)
             if os.path.exists(target_path):
                 os.remove(target_path)
             shutil.copyfile(ext_path, target_path)
@@ -42,12 +43,12 @@ if __name__ == "__main__":
 
     setup(
         name="vllm_kunlun",
-        version="0.15.1",
+        version="0.19.0",
         author="vLLM-Kunlun team",
         license="Apache 2.0",
         description="vLLM Kunlun3 backend plugin",
         packages=find_packages(exclude=("docs", "examples", "tests*")),
-        package_data={"vllm_kunlun": ["_kunlun.so", "so/*.so", "include/*.h"]},
+        package_data={"vllm_kunlun": ["_kunlun*.so", "so/*.so", "include/*.h"]},
         python_requires=">=3.10",
         ext_modules=ext_modules,
         cmdclass={
@@ -63,6 +64,5 @@ if __name__ == "__main__":
             "vllm.plugins": [
                 "kunlun_fused_moe = vllm_kunlun.ops.fused_moe:register_kunlun_fused_moe_ops"
             ],
-            "console_scripts": ["vllm_kunlun = vllm_kunlun.entrypoints.main:main"],
         },
     )

--- a/tests/ut/test.py
+++ b/tests/ut/test.py
@@ -1,157 +1,943 @@
-from unittest.mock import MagicMock, Mock, patch
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+from types import SimpleNamespace
+from unittest.mock import patch
 
 import pytest
 import torch
+import torch.nn.functional as F
 
 
-def test_import():
-    """Test that the module can be imported successfully."""
-    from vllm_kunlun.compilation.wrapper import TorchCompileWrapperWithCustomDispatcher
+def _load_wrapper_module():
+    import vllm_kunlun  # noqa: F401
 
-    assert TorchCompileWrapperWithCustomDispatcher is not None
-
-
-def test_basic_instantiation():
-    """Test basic wrapper instantiation with mocked dependencies."""
-    from vllm_kunlun.compilation.wrapper import TorchCompileWrapperWithCustomDispatcher
-
-    # Create a concrete implementation
-    class TestWrapper(TorchCompileWrapperWithCustomDispatcher):
-        def forward(self, x):
-            return x * 2
-
-    # Mock all the dependencies
-    mock_config = MagicMock()
-    mock_config.compilation_config.init_backend.return_value = "eager"
-    mock_config.compilation_config.inductor_compile_config = None
-
-    with patch("vllm.config.get_current_vllm_config", return_value=mock_config):
-        with patch("vllm.config.CompilationLevel") as mock_level:
-            mock_level.DYNAMO_ONCE = 1
-            with patch("torch.compile", side_effect=lambda func, **kwargs: func):
-                with patch("torch._dynamo.convert_frame.register_bytecode_hook"):
-                    wrapper = TestWrapper(compilation_level=0)
-
-                    # Verify basic attributes exist
-                    assert hasattr(wrapper, "vllm_config")
-                    assert hasattr(wrapper, "compiled_callable")
-                    assert hasattr(wrapper, "original_code_object")
-                    assert hasattr(wrapper, "compiled_codes")
-                    assert isinstance(wrapper.compiled_codes, list)
+    return importlib.import_module("vllm_kunlun.compilation.wrapper")
 
 
-def test_forward_call():
-    """Test that the forward method can be called."""
-    from vllm_kunlun.compilation.wrapper import TorchCompileWrapperWithCustomDispatcher
-
-    class TestWrapper(TorchCompileWrapperWithCustomDispatcher):
-        def forward(self, x):
-            return x * 2
-
-    mock_config = MagicMock()
-    mock_config.compilation_config.init_backend.return_value = "eager"
-    mock_config.compilation_config.inductor_compile_config = None
-
-    with patch("vllm.config.get_current_vllm_config", return_value=mock_config):
-        with patch("vllm.config.CompilationLevel") as mock_level:
-            mock_level.DYNAMO_ONCE = 1
-            with patch("torch.compile", side_effect=lambda func, **kwargs: func):
-                with patch("torch._dynamo.convert_frame.register_bytecode_hook"):
-                    wrapper = TestWrapper(compilation_level=0)
-
-                    # Test calling the wrapper
-                    input_tensor = torch.tensor([1.0, 2.0, 3.0])
-                    result = wrapper(input_tensor)
-
-                    expected = input_tensor * 2
-                    assert torch.allclose(result, expected)
+def _make_mock_config(wrapper_module):
+    dynamic_shapes_config = SimpleNamespace(
+        evaluate_guards=False,
+        type=wrapper_module.DynamicShapesType.BACKED,
+    )
+    compilation_config = SimpleNamespace(
+        mode=wrapper_module.CompilationMode.DYNAMO_TRACE_ONCE,
+        init_backend=lambda _cfg: "eager",
+        inductor_compile_config={},
+        dynamic_shapes_config=dynamic_shapes_config,
+        cudagraph_mode=wrapper_module.CUDAGraphMode.NONE,
+    )
+    observability_config = SimpleNamespace(enable_layerwise_nvtx_tracing=False)
+    return SimpleNamespace(
+        compilation_config=compilation_config,
+        observability_config=observability_config,
+        compile_debug_dump_path=lambda: None,
+    )
 
 
-def test_custom_callable():
-    """Test wrapper with custom compiled callable."""
-    from vllm_kunlun.compilation.wrapper import TorchCompileWrapperWithCustomDispatcher
+def test_import_installs_torch251_compat_shims():
+    wrapper_module = _load_wrapper_module()
+    custom_graph_pass = importlib.import_module("torch._inductor.custom_graph_pass")
+    graph_pickler_module = importlib.import_module("torch.fx._graph_pickler")
+    dynamo_torch_module = importlib.import_module("torch._dynamo.variables.torch")
+    mistral_request_module = importlib.import_module(
+        "mistral_common.protocol.instruct.request"
+    )
+    from torch.fx import Graph
+    from vllm.model_executor.parameter import BasevLLMParameter, ModelWeightParameter
 
-    class TestWrapper(TorchCompileWrapperWithCustomDispatcher):
-        def forward(self, x):
-            return x * 2
+    assert hasattr(custom_graph_pass, "CustomGraphPass")
+    assert hasattr(graph_pickler_module, "GraphPickler")
+    assert hasattr(graph_pickler_module, "Options")
+    assert hasattr(mistral_request_module, "ReasoningEffort")
+    assert hasattr(Graph, "output_node")
+    assert hasattr(torch.compiler, "set_stance")
+    assert hasattr(torch._functorch.config, "bundled_autograd_cache")
+    assert hasattr(torch._functorch.config, "autograd_cache_normalize_inputs")
+    assert hasattr(torch._functorch.config, "enable_remote_autograd_cache")
+    assert "_cache_config_ignore_prefix" in torch._functorch.config._config
+    assert "_save_config_ignore" in torch._functorch.config._config
+    assert "_compile_ignored_keys" in torch._functorch.config._config
+    assert isinstance(torch._functorch.config.save_config_portable(), dict)
+    assert wrapper_module.TorchCompileWithNoGuardsWrapper is not None
+    assert BasevLLMParameter in torch._dynamo.config.traceable_tensor_subclasses
+    assert ModelWeightParameter in torch._dynamo.config.traceable_tensor_subclasses
+    assert getattr(
+        dynamo_torch_module.can_dispatch_torch_function,
+        "_vllm_kunlun_patched",
+        False,
+    )
 
-    custom_func = Mock(return_value=torch.tensor([5.0]))
-    mock_config = MagicMock()
-    mock_config.compilation_config.init_backend.return_value = "eager"
+    graph = Graph()
+    input_node = graph.placeholder("x")
+    graph.output(input_node)
+    assert graph.output_node().op == "output"
 
-    with patch("vllm.config.get_current_vllm_config", return_value=mock_config):
-        with patch("vllm.config.CompilationLevel") as mock_level:
-            mock_level.DYNAMO_ONCE = 1
-            with patch("torch._dynamo.convert_frame.register_bytecode_hook"):
-                wrapper = TestWrapper(
-                    compiled_callable=custom_func, compilation_level=0
+
+def test_import_allows_vllm_mistral_tokenizer_on_older_mistral_common():
+    import vllm_kunlun  # noqa: F401
+
+    mistral_tokenizer_module = importlib.import_module("vllm.tokenizers.mistral")
+
+    assert hasattr(mistral_tokenizer_module, "MistralTokenizer")
+
+
+def test_import_patches_v1_block_table_slot_mapping_kernel():
+    import vllm_kunlun
+
+    block_table_module = vllm_kunlun._custom_import("vllm.v1.worker.block_table")
+
+    assert getattr(
+        block_table_module._compute_slot_mapping_kernel,
+        "_vllm_kunlun_patched",
+        False,
+    )
+
+    query_start_loc = torch.tensor([0, 3], dtype=torch.int32)
+    positions = torch.tensor([0, 1, 5], dtype=torch.int64)
+    block_table = torch.tensor([[4, 7]], dtype=torch.int32)
+    slot_mapping = torch.empty(5, dtype=torch.int64)
+
+    block_table_module._compute_slot_mapping_kernel[(2,)](
+        3,
+        5,
+        query_start_loc,
+        positions,
+        block_table,
+        2,
+        4,
+        slot_mapping,
+        TOTAL_CP_WORLD_SIZE=1,
+        TOTAL_CP_RANK=0,
+        CP_KV_CACHE_INTERLEAVE_SIZE=1,
+        PAD_ID=-1,
+        BLOCK_SIZE=1024,
+    )
+
+    assert slot_mapping.tolist() == [16, 17, 29, -1, -1]
+
+
+def test_default_unquantized_gemm_supports_torch_compile_with_vllm_parameter():
+    from vllm.model_executor.layers import utils as layer_utils
+    from vllm.model_executor.parameter import ModelWeightParameter
+
+    import vllm_kunlun  # noqa: F401
+
+    with (
+        patch(
+            "vllm.model_executor.parameter.get_tensor_model_parallel_rank",
+            return_value=0,
+        ),
+        patch(
+            "vllm.model_executor.parameter.get_tensor_model_parallel_world_size",
+            return_value=1,
+        ),
+    ):
+        weight = ModelWeightParameter(
+            input_dim=1,
+            output_dim=0,
+            data=torch.full((4, 4), 2.0),
+            weight_loader=lambda *args, **kwargs: None,
+        )
+
+    compiled = torch.compile(
+        lambda x, param: layer_utils.default_unquantized_gemm(None, x, param, None),
+        backend="inductor",
+        fullgraph=True,
+    )
+
+    torch.testing.assert_close(
+        compiled(torch.ones((1, 4)), weight),
+        torch.full((1, 4), 8.0),
+    )
+
+
+def test_get_fx_graph_outputs_falls_back_to_last_node_without_output():
+    from torch.fx import Graph
+
+    import vllm_kunlun  # noqa: F401
+    from vllm_kunlun.compat import _get_fx_graph_outputs
+
+    graph = Graph()
+    input_node = graph.placeholder("x")
+    last_node = graph.call_function(torch.neg, (input_node,))
+
+    assert _get_fx_graph_outputs(graph) is last_node
+
+    graph.output(last_node)
+    assert _get_fx_graph_outputs(graph) is last_node
+
+
+def test_get_fx_graph_outputs_uses_mutated_args_for_inplace_custom_op():
+    from torch.fx import Graph
+
+    import vllm_kunlun  # noqa: F401
+    from vllm_kunlun.compat import _get_fx_graph_outputs
+
+    importlib.import_module("vllm.model_executor.layers.attention.attention")
+
+    graph = Graph()
+    query = graph.placeholder("query")
+    key = graph.placeholder("key")
+    value = graph.placeholder("value")
+    output = graph.placeholder("output")
+    attention_node = graph.call_function(
+        torch.ops.vllm.unified_attention_with_output.default,
+        (query, key, value, output, "layer_name", None, None, None),
+    )
+
+    assert attention_node.op == "call_function"
+    assert _get_fx_graph_outputs(graph) is output
+
+
+def test_get_fx_graph_outputs_uses_name_based_mutated_arg_fallback():
+    from torch.fx import Graph
+
+    import vllm_kunlun  # noqa: F401
+    from vllm_kunlun.compat import _get_fx_graph_outputs
+
+    def unified_attention_with_output(*args, **kwargs):
+        raise AssertionError("FX test should not execute the target")
+
+    graph = Graph()
+    query = graph.placeholder("query")
+    key = graph.placeholder("key")
+    value = graph.placeholder("value")
+    output = graph.placeholder("output")
+    output_block_scale = graph.placeholder("output_block_scale")
+    attention_node = graph.call_function(
+        unified_attention_with_output,
+        (
+            query,
+            key,
+            value,
+            output,
+            "layer_name",
+            None,
+            output_block_scale,
+            None,
+        ),
+    )
+
+    assert attention_node.op == "call_function"
+    assert _get_fx_graph_outputs(graph) == (output, output_block_scale)
+
+
+def test_import_patches_piecewise_compile_interpreter_call_module():
+    import vllm_kunlun  # noqa: F401
+
+    backends_module = importlib.import_module("vllm.compilation.backends")
+
+    assert getattr(
+        backends_module.PiecewiseCompileInterpreter.call_module,
+        "_vllm_kunlun_patched",
+        False,
+    )
+
+
+def test_register_model_imports_vllm_on_torch251():
+    from vllm import ModelRegistry
+
+    import vllm_kunlun
+
+    with patch.object(ModelRegistry, "register_model") as mock_register_model:
+        vllm_kunlun.register_model()
+
+    assert mock_register_model.call_count > 0
+    assert any(
+        call.args[0] == "Qwen3MoeForCausalLM"
+        and call.args[1] == "vllm_kunlun.models.qwen3_moe:Qwen3MoeForCausalLM"
+        for call in mock_register_model.call_args_list
+    )
+
+
+def test_import_hook_installs_kunlun_fused_moe_override():
+    from vllm.model_executor.custom_op import op_registry_oot
+
+    import vllm_kunlun
+
+    vllm_kunlun.register()
+    vllm_kunlun._custom_import("vllm.model_executor.layers.fused_moe.layer")
+
+    override_cls = op_registry_oot["UnquantizedFusedMoEMethod"]
+    assert override_cls.__module__ == "vllm_kunlun.ops.fused_moe.layer"
+
+
+def test_kunlun_unquantized_fused_moe_method_forces_kunlun_monolithic_entry():
+    from vllm_kunlun.ops.fused_moe.layer import KunlunUnquantizedFusedMoEMethod
+
+    with patch(
+        "vllm_kunlun.ops.fused_moe.layer.UnquantizedFusedMoEMethod.__init__",
+        autospec=True,
+        side_effect=lambda self, moe: setattr(self, "_is_monolithic", False),
+    ):
+        method = KunlunUnquantizedFusedMoEMethod(SimpleNamespace())
+
+    assert method.is_monolithic is True
+    assert (
+        method.apply_monolithic.__func__
+        is KunlunUnquantizedFusedMoEMethod._apply_monolithic_kunlun
+    )
+
+
+def test_kunlun_fused_moe_native_fallback_matches_reference():
+    module_name = "vllm_kunlun.ops._kunlun_ops"
+    backups = {
+        name: sys.modules.get(name)
+        for name in [module_name, "cocopod", "xspeedgate_ops"]
+    }
+
+    sys.modules.pop(module_name, None)
+
+    try:
+        with patch.dict(
+            sys.modules,
+            {
+                "cocopod": types.ModuleType("cocopod"),
+                "xspeedgate_ops": types.ModuleType("xspeedgate_ops"),
+            },
+        ):
+            from vllm_kunlun.ops._kunlun_ops import KunlunOps
+
+            hidden_states = torch.tensor([[1.0, -0.5]], dtype=torch.float32)
+            w1 = torch.tensor(
+                [
+                    [
+                        [1.0, 0.0],
+                        [0.0, 1.0],
+                        [0.5, 0.0],
+                        [0.0, 0.5],
+                    ],
+                    [
+                        [0.3, 0.2],
+                        [0.4, -0.1],
+                        [0.2, 0.1],
+                        [-0.5, 0.3],
+                    ],
+                ],
+                dtype=torch.float32,
+            )
+            w2 = torch.tensor(
+                [
+                    [
+                        [1.0, 0.0],
+                        [0.0, 1.0],
+                    ],
+                    [
+                        [0.5, -0.2],
+                        [0.1, 0.4],
+                    ],
+                ],
+                dtype=torch.float32,
+            )
+            router_logits = torch.tensor([[3.0, 1.0]], dtype=torch.float32)
+
+            result = KunlunOps.fused_moe(
+                hidden_states=hidden_states,
+                w1=w1,
+                w2=w2,
+                router_logits=router_logits,
+                ep_rank=0,
+                moe_top_k=2,
+                renormalize=True,
+            )
+    finally:
+        for name, module in backups.items():
+            if module is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = module
+
+    topk_logits, topk_ids = torch.topk(router_logits, k=2, dim=-1, sorted=False)
+    topk_weights = torch.softmax(topk_logits, dim=-1)
+    expected = torch.zeros_like(hidden_states)
+
+    for token_idx in range(hidden_states.shape[0]):
+        token_hidden_state = hidden_states[token_idx : token_idx + 1]
+        for route_idx in range(topk_ids.shape[1]):
+            expert_id = int(topk_ids[token_idx, route_idx])
+            gate_up = token_hidden_state @ w1[expert_id].transpose(0, 1)
+            half = gate_up.shape[-1] // 2
+            activated = F.silu(gate_up[..., :half]) * gate_up[..., half:]
+            expert_output = activated @ w2[expert_id].transpose(0, 1)
+            expected[token_idx] += topk_weights[
+                token_idx, route_idx
+            ] * expert_output.squeeze(0)
+
+    torch.testing.assert_close(result, expected)
+
+
+def test_kunlun_fused_moe_native_fallback_maps_global_expert_ids_to_local_weights():
+    module_name = "vllm_kunlun.ops._kunlun_ops"
+    backups = {
+        name: sys.modules.get(name)
+        for name in [module_name, "cocopod", "xspeedgate_ops"]
+    }
+
+    sys.modules.pop(module_name, None)
+
+    try:
+        with patch.dict(
+            sys.modules,
+            {
+                "cocopod": types.ModuleType("cocopod"),
+                "xspeedgate_ops": types.ModuleType("xspeedgate_ops"),
+            },
+        ):
+            from vllm_kunlun.ops._kunlun_ops import KunlunOps
+
+            hidden_states = torch.tensor(
+                [
+                    [0.5, -1.0],
+                    [1.5, 0.25],
+                ],
+                dtype=torch.float32,
+            )
+            w1 = torch.tensor(
+                [
+                    [
+                        [1.0, 0.0],
+                        [0.0, 1.0],
+                        [0.5, 0.0],
+                        [0.0, 0.5],
+                    ],
+                    [
+                        [0.6, -0.2],
+                        [0.3, 0.4],
+                        [0.2, 0.1],
+                        [-0.4, 0.3],
+                    ],
+                ],
+                dtype=torch.float32,
+            )
+            w2 = torch.tensor(
+                [
+                    [
+                        [0.7, 0.0],
+                        [0.0, 0.9],
+                    ],
+                    [
+                        [0.4, -0.1],
+                        [0.2, 0.5],
+                    ],
+                ],
+                dtype=torch.float32,
+            )
+            router_logits = torch.tensor(
+                [
+                    [0.1, -0.8, 4.0, 2.0],
+                    [-0.5, 0.2, 1.2, 3.8],
+                ],
+                dtype=torch.float32,
+            )
+
+            result = KunlunOps.fused_moe(
+                hidden_states=hidden_states,
+                w1=w1,
+                w2=w2,
+                router_logits=router_logits,
+                ep_rank=1,
+                moe_top_k=2,
+                renormalize=True,
+            )
+    finally:
+        for name, module in backups.items():
+            if module is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = module
+
+    topk_logits, topk_ids = torch.topk(router_logits, k=2, dim=-1, sorted=False)
+    topk_weights = torch.softmax(topk_logits, dim=-1)
+    expected = torch.zeros_like(hidden_states)
+    local_expert_offset = w1.shape[0]
+
+    for token_idx in range(hidden_states.shape[0]):
+        token_hidden_state = hidden_states[token_idx : token_idx + 1]
+        for route_idx in range(topk_ids.shape[1]):
+            local_expert_id = int(topk_ids[token_idx, route_idx]) - local_expert_offset
+            gate_up = token_hidden_state @ w1[local_expert_id].transpose(0, 1)
+            half = gate_up.shape[-1] // 2
+            activated = F.silu(gate_up[..., :half]) * gate_up[..., half:]
+            expert_output = activated @ w2[local_expert_id].transpose(0, 1)
+            expected[token_idx] += topk_weights[
+                token_idx, route_idx
+            ] * expert_output.squeeze(0)
+
+    torch.testing.assert_close(result, expected)
+
+
+def test_import_hook_overrides_vllm_compilation_wrapper():
+    import vllm_kunlun
+
+    vllm_kunlun.import_hook()
+
+    assert __import__ is vllm_kunlun._custom_import
+
+
+def test_import_hook_maps_merge_attn_states_aliases():
+    import vllm_kunlun
+
+    target_module_name = "vllm_kunlun.ops.attention.merge_attn_states"
+    alias_names = [
+        "vllm.attention.ops.merge_attn_states",
+        "vllm.v1.attention.ops.merge_attn_states",
+    ]
+    sentinel_module = types.ModuleType(target_module_name)
+    module_names = [target_module_name, *alias_names]
+    backups = {
+        module_name: sys.modules.get(module_name) for module_name in module_names
+    }
+
+    for module_name in module_names:
+        sys.modules.pop(module_name, None)
+
+    try:
+        with patch.object(
+            vllm_kunlun.importlib,
+            "import_module",
+            return_value=sentinel_module,
+        ) as mock_import_module:
+            with patch.object(
+                vllm_kunlun,
+                "OLD_IMPORT_HOOK",
+                side_effect=AssertionError("mapped imports must not fall back"),
+            ):
+                for alias_name in alias_names:
+                    imported_module = vllm_kunlun._custom_import(
+                        alias_name, fromlist=["merge_attn_states"]
+                    )
+                    assert imported_module is sentinel_module
+                    assert sys.modules[alias_name] is sentinel_module
+
+        assert sys.modules[target_module_name] is sentinel_module
+        assert mock_import_module.call_count == len(alias_names)
+    finally:
+        for module_name, module in backups.items():
+            if module is None:
+                sys.modules.pop(module_name, None)
+            else:
+                sys.modules[module_name] = module
+
+
+def test_import_hook_maps_attention_backend_abstract_alias():
+    import vllm_kunlun
+
+    target_module_name = "vllm.v1.attention.backend"
+    alias_name = "vllm.attention.backends.abstract"
+    sentinel_module = types.ModuleType(target_module_name)
+    backups = {
+        module_name: sys.modules.get(module_name)
+        for module_name in [target_module_name, alias_name]
+    }
+
+    for module_name in [target_module_name, alias_name]:
+        sys.modules.pop(module_name, None)
+
+    try:
+        with patch.object(
+            vllm_kunlun.importlib,
+            "import_module",
+            return_value=sentinel_module,
+        ) as mock_import_module:
+            with patch.object(
+                vllm_kunlun,
+                "OLD_IMPORT_HOOK",
+                side_effect=AssertionError("mapped imports must not fall back"),
+            ):
+                imported_module = vllm_kunlun._custom_import(
+                    alias_name,
+                    fromlist=["AttentionBackend"],
                 )
 
-                # Verify custom callable is used
-                assert wrapper.compiled_callable is custom_func
+        assert imported_module is sentinel_module
+        assert sys.modules[alias_name] is sentinel_module
+        assert sys.modules[target_module_name] is sentinel_module
+        assert mock_import_module.call_count == 1
+    finally:
+        for module_name, module in backups.items():
+            if module is None:
+                sys.modules.pop(module_name, None)
+            else:
+                sys.modules[module_name] = module
 
-                # Call should use custom callable
-                result = wrapper(torch.tensor([1.0]))  # noqa
-                assert custom_func.called
+
+def test_merge_attn_states_import_is_lazy():
+    import vllm_kunlun
+
+    module_names = [
+        "kunlun_ops",
+        "vllm_kunlun.ops",
+        "vllm_kunlun.ops._custom_ops",
+        "vllm_kunlun.ops.attention",
+        "vllm_kunlun.ops.attention.merge_attn_states",
+        "vllm.v1.attention.ops.merge_attn_states",
+    ]
+
+    for module_name in module_names:
+        sys.modules.pop(module_name, None)
+
+    imported_module = vllm_kunlun._custom_import(
+        "vllm.v1.attention.ops.merge_attn_states",
+        fromlist=["merge_attn_states"],
+    )
+
+    assert imported_module.__name__ == "vllm_kunlun.ops.attention.merge_attn_states"
+    assert "kunlun_ops" not in sys.modules
+    assert "vllm_kunlun.ops._custom_ops" not in sys.modules
 
 
-def test_bytecode_hook_basic():
-    """Test that bytecode hook can be called without errors."""
-    from types import CodeType
+def test_topk_topp_sampler_import_is_lazy():
+    import vllm_kunlun
 
-    from vllm_kunlun.compilation.wrapper import TorchCompileWrapperWithCustomDispatcher
+    module_names = [
+        "kunlun_ops",
+        "vllm_kunlun.v1.sample.ops.topk_topp_sampler",
+        "vllm.v1.sample.ops.topk_topp_sampler",
+    ]
+    backups = {
+        module_name: sys.modules.get(module_name) for module_name in module_names
+    }
 
-    class TestWrapper(TorchCompileWrapperWithCustomDispatcher):
+    for module_name in module_names:
+        sys.modules.pop(module_name, None)
+
+    try:
+        imported_module = vllm_kunlun._custom_import(
+            "vllm.v1.sample.ops.topk_topp_sampler",
+            fromlist=["TopKTopPSampler"],
+        )
+
+        assert imported_module.__name__ == "vllm_kunlun.v1.sample.ops.topk_topp_sampler"
+        assert "kunlun_ops" not in sys.modules
+    finally:
+        for module_name, module in backups.items():
+            if module is None:
+                sys.modules.pop(module_name, None)
+            else:
+                sys.modules[module_name] = module
+
+
+def test_topk_topp_sampler_falls_back_when_kunlun_ops_import_fails():
+    sampler_module = importlib.import_module(
+        "vllm_kunlun.v1.sample.ops.topk_topp_sampler"
+    )
+    sampler = sampler_module.TopKTopPSampler("raw_logprobs")
+    logits = torch.tensor([[0.1, 0.2, 0.3]], dtype=torch.float32)
+    top_k = torch.tensor([2], dtype=torch.int32)
+    expected_ids = torch.tensor([1], dtype=torch.int64)
+
+    with patch.object(
+        sampler_module.importlib,
+        "import_module",
+        side_effect=ImportError("kunlun ops unavailable"),
+    ) as mock_import_module:
+        with patch.object(
+            sampler,
+            "forward_native",
+            return_value=(expected_ids, None),
+        ) as mock_forward_native:
+            token_ids, processed = sampler.forward_kunlun(logits, {}, top_k, None)
+            sampler.forward_kunlun(logits, {}, top_k, None)
+
+    assert mock_import_module.call_count == 1
+    assert mock_forward_native.call_count == 2
+    assert torch.equal(token_ids, expected_ids)
+    assert processed is None
+    assert sampler._disable_kunlun_sampling is True
+
+
+def test_quantization_kernels_import_registers_oot_entries():
+    from vllm.model_executor.kernels.linear import (
+        _POSSIBLE_INT8_KERNELS,
+        _POSSIBLE_KERNELS,
+    )
+    from vllm.platforms import PlatformEnum
+
+    kernels_module = importlib.import_module("vllm_kunlun.quantization.kernels")
+
+    assert (
+        kernels_module.KunlunScaledMMLinearKernel
+        in _POSSIBLE_INT8_KERNELS[PlatformEnum.OOT]
+    )
+    assert (
+        kernels_module.KunlunExllamaLinearKernel in _POSSIBLE_KERNELS[PlatformEnum.OOT]
+    )
+
+
+def test_attention_compat_exports_vllm019_attention():
+    compat_module = importlib.import_module("vllm_kunlun.attention_compat")
+    from vllm.model_executor.layers.attention import Attention as UpstreamAttention
+
+    assert compat_module.Attention is UpstreamAttention
+    assert compat_module.check_upstream_fa_availability(torch.float32) is False
+    assert isinstance(
+        compat_module.check_upstream_fa_availability(torch.float16),
+        bool,
+    )
+
+
+def test_kunlun_platform_uses_parallel_config_all2all_backend():
+    from vllm.config import CUDAGraphMode
+
+    from vllm_kunlun.platforms.kunlun import KunlunPlatform
+
+    vllm_config = SimpleNamespace(
+        parallel_config=SimpleNamespace(
+            worker_cls="worker",
+            data_parallel_size=2,
+            all2all_backend="deepep_high_throughput",
+        ),
+        model_config=SimpleNamespace(use_mla=False, enforce_eager=False),
+        speculative_config=None,
+        cache_config=SimpleNamespace(block_size=16),
+        compilation_config=SimpleNamespace(
+            cudagraph_mode=CUDAGraphMode.PIECEWISE,
+            custom_ops=[],
+            pass_config=SimpleNamespace(enable_fusion=True),
+            backend="inductor",
+        ),
+    )
+
+    KunlunPlatform.check_and_update_config(vllm_config)
+
+    assert vllm_config.compilation_config.cudagraph_mode == CUDAGraphMode.NONE
+    assert vllm_config.model_config.enforce_eager is True
+    assert vllm_config.compilation_config.backend == "eager"
+
+
+def test_kunlun_platform_get_attn_backend_cls_accepts_num_heads():
+    from vllm_kunlun.platforms.kunlun import KunlunPlatform
+
+    attn_selector_config = SimpleNamespace(use_mla=False, use_sparse=False)
+
+    with patch(
+        "vllm_kunlun.platforms.kunlun.importlib.import_module",
+        return_value=object(),
+    ):
+        backend_cls = KunlunPlatform.get_attn_backend_cls(
+            None,
+            attn_selector_config=attn_selector_config,
+            num_heads=32,
+        )
+
+    assert backend_cls.endswith("KunlunAttentionBackend")
+
+
+def test_kunlun_platform_get_attn_backend_cls_falls_back_to_triton():
+    from vllm_kunlun.platforms.kunlun import KunlunPlatform
+
+    attn_selector_config = SimpleNamespace(use_mla=False, use_sparse=False)
+
+    with patch(
+        "vllm_kunlun.platforms.kunlun.importlib.import_module",
+        side_effect=OSError("kunlun attention backend unavailable"),
+    ):
+        backend_cls = KunlunPlatform.get_attn_backend_cls(
+            None,
+            attn_selector_config=attn_selector_config,
+            num_heads=32,
+        )
+
+    assert backend_cls.endswith("TritonAttentionBackend")
+
+
+def test_kunlun_platform_preregistration_skips_compressed_tensors_failures():
+    import builtins
+
+    from vllm_kunlun.platforms.kunlun import KunlunPlatform
+
+    original_import = builtins.__import__
+
+    def guarded_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "vllm_kunlun.quantization.compressed_tensors":
+            raise ImportError("compressed tensors unavailable in test")
+        return original_import(name, globals, locals, fromlist, level)
+
+    with patch.object(builtins, "__import__", side_effect=guarded_import):
+        KunlunPlatform.pre_register_and_update()
+
+
+def test_qwen35_processing_info_accepts_upstream_hf_config():
+    from vllm.multimodal.processing.context import InputProcessingContext
+    from vllm.transformers_utils.configs.qwen3_5_moe import Qwen3_5MoeConfig
+
+    from vllm_kunlun.hf_config_compat import QWEN3_5_MOE_CONFIG_TYPES
+
+    ctx = SimpleNamespace(model_config=SimpleNamespace(hf_config=Qwen3_5MoeConfig()))
+    ctx.get_hf_config = InputProcessingContext.get_hf_config.__get__(ctx, type(ctx))
+    assert isinstance(ctx.get_hf_config(QWEN3_5_MOE_CONFIG_TYPES), Qwen3_5MoeConfig)
+
+
+def test_wrapper_can_initialize_and_run_twice():
+    wrapper_module = _load_wrapper_module()
+    mock_config = _make_mock_config(wrapper_module)
+
+    class TestWrapper(wrapper_module.TorchCompileWithNoGuardsWrapper):
         def forward(self, x):
             return x * 2
 
-    mock_config = MagicMock()
-    mock_config.compilation_config.init_backend.return_value = "eager"
-    mock_config.compilation_config.inductor_compile_config = None
-    mock_config.compilation_config.local_cache_dir = None
+    with patch.object(
+        wrapper_module, "get_current_vllm_config", return_value=mock_config
+    ):
+        with patch.object(wrapper_module.envs, "VLLM_USE_BYTECODE_HOOK", False):
+            with patch.object(wrapper_module.envs, "VLLM_USE_AOT_COMPILE", False):
+                with patch.object(
+                    wrapper_module.torch,
+                    "compile",
+                    side_effect=lambda fn, **kwargs: fn,
+                ):
+                    wrapper = TestWrapper()
+                    input_tensor = torch.tensor([1.0, 2.0, 3.0])
 
-    with patch("vllm.config.get_current_vllm_config", return_value=mock_config):
-        with patch("vllm.config.CompilationLevel") as mock_level:
-            mock_level.DYNAMO_ONCE = 1
-            with patch("torch.compile", side_effect=lambda func, **kwargs: func):
-                with patch("torch._dynamo.convert_frame.register_bytecode_hook"):
-                    wrapper = TestWrapper(compilation_level=0)
-
-                    # Test with wrong code object (should be ignored)
-                    wrong_code = MagicMock(spec=CodeType)
-                    new_code = MagicMock(spec=CodeType)
-
-                    initial_count = len(wrapper.compiled_codes)
-                    wrapper.bytecode_hook(wrong_code, new_code)
-
-                    # Should not add anything
-                    assert len(wrapper.compiled_codes) == initial_count
+                    assert torch.allclose(wrapper(input_tensor), input_tensor * 2)
+                    assert torch.allclose(wrapper(input_tensor), input_tensor * 2)
+                    assert wrapper.first_compile is False
 
 
-def test_use_custom_dispatcher_flag():
-    """Test that use_custom_dispatcher flag is set based on compilation_level."""
-    from vllm_kunlun.compilation.wrapper import TorchCompileWrapperWithCustomDispatcher
+def test_bytecode_hook_ignores_unrelated_code_objects():
+    wrapper_module = _load_wrapper_module()
+    mock_config = _make_mock_config(wrapper_module)
 
-    class TestWrapper(TorchCompileWrapperWithCustomDispatcher):
+    class TestWrapper(wrapper_module.TorchCompileWithNoGuardsWrapper):
         def forward(self, x):
-            return x * 2
+            return x
 
-    mock_config = MagicMock()
-    mock_config.compilation_config.init_backend.return_value = "eager"
-    mock_config.compilation_config.inductor_compile_config = None
+    with patch.object(
+        wrapper_module, "get_current_vllm_config", return_value=mock_config
+    ):
+        with patch.object(wrapper_module.envs, "VLLM_USE_BYTECODE_HOOK", True):
+            with patch.object(wrapper_module.envs, "VLLM_USE_AOT_COMPILE", False):
+                with patch.object(
+                    wrapper_module.torch,
+                    "compile",
+                    side_effect=lambda fn, **kwargs: fn,
+                ):
+                    with patch.object(
+                        wrapper_module.torch._dynamo.convert_frame,
+                        "register_bytecode_hook",
+                    ):
+                        wrapper = TestWrapper()
+                        wrong_code = (lambda: None).__code__
+                        new_code = (lambda: None).__code__
 
-    with patch("vllm.config.get_current_vllm_config", return_value=mock_config):
-        with patch("vllm.config.CompilationLevel") as mock_level:
-            mock_level.DYNAMO_ONCE = 1
-            with patch("torch.compile", side_effect=lambda func, **kwargs: func):
-                with patch("torch._dynamo.convert_frame.register_bytecode_hook"):
-                    # Test with low level
-                    wrapper_low = TestWrapper(compilation_level=0)
-                    assert wrapper_low.use_custom_dispatcher is False
+                        wrapper.bytecode_hook(wrong_code, new_code)
 
-                    # Test with high level
-                    wrapper_high = TestWrapper(compilation_level=2)
-                    assert wrapper_high.use_custom_dispatcher is True
+                        assert wrapper._compiled_bytecode is None
+
+
+def test_qwen3_moe_loader_compat_patch_skips_unmatched_expert_weights(
+    monkeypatch,
+):
+    from vllm_kunlun.compat import apply_qwen3_moe_loader_compat_patch
+
+    seen_weight_names = []
+
+    class FakeQwen3MoeModel:
+        def named_parameters(self):
+            return [
+                ("layers.47.mlp.experts.w2_weight", object()),
+            ]
+
+        def get_expert_mapping(self):
+            return [
+                (
+                    "layers.47.mlp.experts.w2_weight",
+                    "layers.47.mlp.experts.0.down_proj.weight",
+                    0,
+                    "w2",
+                ),
+                (
+                    "layers.48.mlp.experts.w2_weight",
+                    "layers.48.mlp.experts.0.down_proj.weight",
+                    0,
+                    "w2",
+                ),
+            ]
+
+        def load_weights(self, weights):
+            seen_weight_names.extend(name for name, _ in weights)
+            return set(seen_weight_names)
+
+    fake_module = type("FakeModule", (), {"Qwen3MoeModel": FakeQwen3MoeModel})
+    monkeypatch.setattr("vllm_kunlun.compat.import_module", lambda _: fake_module)
+
+    apply_qwen3_moe_loader_compat_patch()
+
+    model = FakeQwen3MoeModel()
+    loaded = model.load_weights(
+        [
+            ("layers.47.mlp.experts.0.down_proj.weight", torch.zeros(1)),
+            ("layers.48.mlp.experts.0.down_proj.weight", torch.zeros(1)),
+            ("layers.48.self_attn.q_proj.weight", torch.zeros(1)),
+        ]
+    )
+
+    assert "layers.47.mlp.experts.0.down_proj.weight" in seen_weight_names
+    assert "layers.48.mlp.experts.0.down_proj.weight" not in seen_weight_names
+    assert "layers.48.self_attn.q_proj.weight" in seen_weight_names
+    assert "layers.47.mlp.experts.0.down_proj.weight" in loaded
+
+
+def test_custom_qwen3_moe_model_skips_unmatched_expert_weights(monkeypatch):
+    from vllm_kunlun.models.qwen3_moe import Qwen3MoeModel
+
+    model = object.__new__(Qwen3MoeModel)
+    model.quant_config = None
+
+    loaded_names = []
+
+    class FakeParam:
+        def weight_loader(
+            self,
+            _param,
+            _loaded_weight,
+            name_mapped,
+            shard_id=None,
+            expert_id=None,
+            return_success=False,
+        ):
+            loaded_names.append((name_mapped, shard_id, expert_id))
+            if return_success:
+                return True
+            return None
+
+    monkeypatch.setattr(
+        "vllm_kunlun.models.qwen3_moe.upstream.is_pp_missing_parameter",
+        lambda *_args, **_kwargs: False,
+    )
+
+    model.named_parameters = lambda: [
+        ("model.layers.47.mlp.experts.w2_weight", FakeParam()),
+    ]
+    model.get_expert_mapping = lambda: [
+        (
+            "layers.47.mlp.experts.w2_weight",
+            "layers.47.mlp.experts.0.down_proj.weight",
+            0,
+            "w2",
+        ),
+        (
+            "layers.48.mlp.experts.w2_weight",
+            "layers.48.mlp.experts.0.down_proj.weight",
+            0,
+            "w2",
+        ),
+    ]
+
+    loaded = Qwen3MoeModel.load_weights(
+        model,
+        [
+            ("model.layers.47.mlp.experts.0.down_proj.weight", torch.zeros(1)),
+            ("model.layers.48.mlp.experts.0.down_proj.weight", torch.zeros(1)),
+        ],
+    )
+
+    assert loaded_names == [("model.layers.47.mlp.experts.w2_weight", "w2", 0)]
+    assert "model.layers.47.mlp.experts.w2_weight" in loaded
+    assert all("layers.48" not in name for name in loaded)
 
 
 if __name__ == "__main__":

--- a/tests/ut/test_v1_worker_utils.py
+++ b/tests/ut/test_v1_worker_utils.py
@@ -1,0 +1,128 @@
+"""
+Copyright (c) 2026 Baidu, Inc. All Rights Reserved.
+
+This file is a part of the vllm-kunlun project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from types import SimpleNamespace
+
+import torch
+
+
+class _FakeBackend:
+    @staticmethod
+    def get_supported_kernel_block_sizes():
+        return [8]
+
+    @staticmethod
+    def get_kv_cache_block_dim(
+        kernel_block_size,
+        num_kv_heads,
+        head_size,
+        cache_dtype_str=None,
+    ):
+        return 0
+
+
+def _ensure_torch251_compat_shims():
+    import vllm_kunlun  # noqa: F401
+    import vllm_kunlun.schema  # noqa: F401
+    from vllm_kunlun.compat import apply_torch251_compat_shims
+
+    apply_torch251_compat_shims()
+
+
+def test_prepare_kernel_block_sizes_preserves_kv_cache_group_ids():
+    _ensure_torch251_compat_shims()
+
+    from vllm.v1.kv_cache_interface import (
+        EncoderOnlyAttentionSpec,
+        FullAttentionSpec,
+        KVCacheConfig,
+        KVCacheGroupSpec,
+    )
+
+    from vllm_kunlun.v1.worker.utils import AttentionGroup, prepare_kernel_block_sizes
+
+    encoder_spec = EncoderOnlyAttentionSpec(
+        block_size=16,
+        num_kv_heads=1,
+        head_size=1,
+        dtype=torch.float32,
+    )
+    attn_spec = FullAttentionSpec(
+        block_size=16,
+        num_kv_heads=1,
+        head_size=1,
+        dtype=torch.float32,
+    )
+    kv_cache_config = KVCacheConfig(
+        num_blocks=0,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(layer_names=["encoder"], kv_cache_spec=encoder_spec),
+            KVCacheGroupSpec(layer_names=["decoder"], kv_cache_spec=attn_spec),
+        ],
+    )
+    attn_groups = [
+        [],
+        [
+            AttentionGroup(
+                backend=_FakeBackend,
+                layer_names=["decoder"],
+                kv_cache_spec=attn_spec,
+                kv_cache_group_id=1,
+            )
+        ],
+    ]
+
+    kernel_block_sizes = prepare_kernel_block_sizes(kv_cache_config, attn_groups)
+
+    assert kernel_block_sizes == [None, 8]
+
+
+def test_kv_block_zeroer_init_meta_uses_aligned_kernel_block_sizes():
+    _ensure_torch251_compat_shims()
+
+    from vllm.v1.kv_cache_interface import FullAttentionSpec
+
+    from vllm_kunlun.v1.worker.utils import AttentionGroup, KVBlockZeroer
+
+    attn_spec = FullAttentionSpec(
+        block_size=16,
+        num_kv_heads=1,
+        head_size=1,
+        dtype=torch.float32,
+    )
+    attn_group = AttentionGroup(
+        backend=_FakeBackend,
+        layer_names=["decoder"],
+        kv_cache_spec=attn_spec,
+        kv_cache_group_id=1,
+    )
+    zeroer = KVBlockZeroer(device=torch.device("cpu"), pin_memory=False)
+    static_forward_context = {
+        "decoder": SimpleNamespace(kv_cache=torch.zeros((4, 4), dtype=torch.float32))
+    }
+
+    zeroer.init_meta(
+        [attn_group],
+        [None, 8],
+        cache_dtype="auto",
+        runner_only_attn_layers=set(),
+        static_forward_context=static_forward_context,
+    )
+
+    assert zeroer._meta is not None

--- a/vllm_kunlun/__init__.py
+++ b/vllm_kunlun/__init__.py
@@ -6,13 +6,24 @@ import logging
 import os
 import sys
 
-from vllm.logger import init_logger as init_vllm_logger
+from .compat import (
+    _patch_piecewise_compile_interpreter_call_module,
+    _patch_traceable_vllm_parameter_subclasses,
+    _patch_v1_block_table_triton_kernel,
+    apply_qwen3_moe_loader_compat_patch,
+    apply_torch251_compat_shims,
+)
+from .ops.fused_moe import register_kunlun_fused_moe_ops
+
+apply_torch251_compat_shims()
 
 OLD_IMPORT_HOOK = builtins.__import__
 
 
 def _configure_kunlun_logger() -> logging.Logger:
     """Reuse vLLM's handler for the vllm_kunlun logger tree."""
+    from vllm.logger import init_logger as init_vllm_logger
+
     vllm_logger = init_vllm_logger("vllm")
     kunlun_logger = logging.getLogger("vllm_kunlun")
 
@@ -26,30 +37,73 @@ def _configure_kunlun_logger() -> logging.Logger:
 
 
 def _custom_import(module_name, globals=None, locals=None, fromlist=(), level=0):
-    try:
-        module_mappings = {
-            "vllm.compilation.wrapper": "vllm_kunlun.compilation.wrapper",
-            "vllm.v1.worker.utils": "vllm_kunlun.v1.worker.utils",
-            "vllm.model_executor.model_loader.bitsandbytes_loader": "vllm_kunlun.models.model_loader.bitsandbytes_loader",
-            "vllm.v1.sample.ops.topk_topp_sampler": "vllm_kunlun.v1.sample.ops.topk_topp_sampler",
-            "vllm.v1.sample.rejection_sampler": "vllm_kunlun.v1.sample.rejection_sampler",
-            "vllm.attention.ops.merge_attn_states": "vllm_kunlun.ops.attention.merge_attn_states",
-            "vllm.model_executor.models.config": "vllm_kunlun.models.config",
-        }
+    module_mappings = {
+        "vllm.compilation.wrapper": "vllm_kunlun.compilation.wrapper",
+        "vllm.v1.worker.utils": "vllm_kunlun.v1.worker.utils",
+        "vllm.attention.backends.abstract": "vllm.v1.attention.backend",
+        "vllm.model_executor.model_loader.bitsandbytes_loader": "vllm_kunlun.models.model_loader.bitsandbytes_loader",
+        "vllm.v1.sample.ops.topk_topp_sampler": "vllm_kunlun.v1.sample.ops.topk_topp_sampler",
+        "vllm.v1.sample.rejection_sampler": "vllm_kunlun.v1.sample.rejection_sampler",
+        "vllm.attention.ops.merge_attn_states": "vllm_kunlun.ops.attention.merge_attn_states",
+        "vllm.v1.attention.ops.merge_attn_states": "vllm_kunlun.ops.attention.merge_attn_states",
+        "vllm.model_executor.models.config": "vllm_kunlun.models.config",
+    }
 
-        if module_name in module_mappings:
-            if module_name in sys.modules:
-                return sys.modules[module_name]
-            target_module = module_mappings[module_name]
-            module = importlib.import_module(target_module)
-            sys.modules[module_name] = module
-            sys.modules[target_module] = module
-    except Exception:
-        pass
+    if module_name in module_mappings:
+        if module_name in sys.modules:
+            return sys.modules[module_name]
+        target_module = module_mappings[module_name]
+        module = importlib.import_module(target_module)
+        sys.modules[module_name] = module
+        sys.modules[target_module] = module
+        return module
 
-    return OLD_IMPORT_HOOK(
+    module = OLD_IMPORT_HOOK(
         module_name, globals=globals, locals=locals, fromlist=fromlist, level=level
     )
+
+    if module_name == "vllm.model_executor.models.qwen3_moe":
+        try:
+            apply_qwen3_moe_loader_compat_patch(module)
+        except Exception:
+            logging.getLogger("vllm_kunlun").exception(
+                "[KunlunPlugin] deferred Qwen3-MoE loader compat patch failed"
+            )
+            raise
+    elif module_name == "vllm.model_executor.parameter":
+        try:
+            _patch_traceable_vllm_parameter_subclasses(module)
+        except Exception:
+            logging.getLogger("vllm_kunlun").exception(
+                "[KunlunPlugin] deferred vLLM parameter Dynamo compat patch failed"
+            )
+            raise
+    elif module_name == "vllm.compilation.backends":
+        try:
+            _patch_piecewise_compile_interpreter_call_module(module)
+        except Exception:
+            logging.getLogger("vllm_kunlun").exception(
+                "[KunlunPlugin] deferred PiecewiseCompileInterpreter compat patch failed"
+            )
+            raise
+    elif module_name == "vllm.v1.worker.block_table":
+        try:
+            _patch_v1_block_table_triton_kernel(module)
+        except Exception:
+            logging.getLogger("vllm_kunlun").exception(
+                "[KunlunPlugin] deferred v1 block_table Triton compat patch failed"
+            )
+            raise
+    elif module_name == "vllm.model_executor.layers.fused_moe.layer":
+        try:
+            register_kunlun_fused_moe_ops()
+        except Exception:
+            logging.getLogger("vllm_kunlun").exception(
+                "[KunlunPlugin] deferred Kunlun FusedMoE override registration failed"
+            )
+            raise
+
+    return module
 
 
 def import_hook():

--- a/vllm_kunlun/attention_compat.py
+++ b/vllm_kunlun/attention_compat.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import importlib.util
+
+import torch
+from vllm.model_executor.layers.attention import Attention
+
+_FLASH_ATTENTION_MODULES = (
+    "vllm.vllm_flash_attn",
+    "flash_attn",
+)
+_FLASH_ATTENTION_DTYPES = {
+    torch.float16,
+    torch.bfloat16,
+}
+
+__all__ = ["Attention", "check_upstream_fa_availability"]
+
+
+def check_upstream_fa_availability(dtype: torch.dtype) -> bool:
+    if dtype not in _FLASH_ATTENTION_DTYPES:
+        return False
+
+    return any(
+        importlib.util.find_spec(module_name) is not None
+        for module_name in _FLASH_ATTENTION_MODULES
+    )

--- a/vllm_kunlun/compat.py
+++ b/vllm_kunlun/compat.py
@@ -1,0 +1,633 @@
+"""Compatibility helpers for running vLLM 0.19.x on PyTorch 2.5.1."""
+
+from __future__ import annotations
+
+import logging
+import pickle
+import sys
+import types
+from contextlib import contextmanager, nullcontext
+from dataclasses import dataclass
+from enum import Enum
+from importlib import import_module
+from typing import Any, Iterable
+
+import torch
+
+_MISSING_OUTPUT_NODE_WARNING_EMITTED = False
+_MUTATED_OUTPUT_DEBUG_EMITTED = False
+_MISSING_EXAMPLE_VALUE_DEBUG_EMITTED = False
+
+
+def _ensure_custom_graph_pass_module() -> None:
+    """Provide torch._inductor.custom_graph_pass on older PyTorch builds."""
+    module_name = "torch._inductor.custom_graph_pass"
+    if module_name in sys.modules:
+        return
+
+    module = types.ModuleType(module_name)
+
+    class CustomGraphPass:
+        """Minimal fallback base class used by vLLM Inductor passes."""
+
+        def __call__(self, graph: Any) -> None:
+            return None
+
+        def uuid(self) -> str:
+            return self.__class__.__name__
+
+    module.CustomGraphPass = CustomGraphPass
+    sys.modules[module_name] = module
+
+
+def _ensure_graph_pickler_module() -> None:
+    """Backfill torch.fx._graph_pickler for PyTorch 2.5."""
+    module_name = "torch.fx._graph_pickler"
+    if module_name in sys.modules:
+        return
+
+    module = types.ModuleType(module_name)
+
+    @dataclass
+    class Options:
+        ops_filter: Any = None
+
+    class GraphPickler:
+        def reducer_override(self, obj: Any) -> Any:
+            return NotImplemented
+
+        @staticmethod
+        def dumps(obj: Any, options: Any | None = None) -> bytes:
+            del options
+            return pickle.dumps(obj, protocol=pickle.HIGHEST_PROTOCOL)
+
+        @staticmethod
+        def loads(data: bytes, fake_mode: Any | None = None) -> Any:
+            del fake_mode
+            return pickle.loads(data)
+
+    module.GraphPickler = GraphPickler
+    module.Options = Options
+    sys.modules[module_name] = module
+
+
+def _ensure_mistral_reasoning_effort_enum() -> None:
+    """Backfill mistral_common's ReasoningEffort for older releases."""
+    try:
+        request_module = import_module("mistral_common.protocol.instruct.request")
+    except ImportError:
+        return
+
+    if hasattr(request_module, "ReasoningEffort"):
+        return
+
+    class ReasoningEffort(str, Enum):
+        LOW = "low"
+        MEDIUM = "medium"
+        HIGH = "high"
+
+    request_module.ReasoningEffort = ReasoningEffort
+
+
+def _patch_v1_block_table_triton_kernel(module: types.ModuleType | None = None) -> None:
+    """Replace Triton's slot-mapping kernel with a torch fallback."""
+    if module is None:
+        module = import_module("vllm.v1.worker.block_table")
+
+    existing_kernel = getattr(module, "_compute_slot_mapping_kernel", None)
+    if getattr(existing_kernel, "_vllm_kunlun_patched", False):
+        return
+
+    def _compute_slot_mapping_kernel_impl(
+        num_tokens: int,
+        max_num_tokens: int,
+        query_start_loc: torch.Tensor,
+        positions: torch.Tensor,
+        block_table: torch.Tensor,
+        block_table_stride: int,
+        block_size: int,
+        slot_mapping: torch.Tensor,
+        TOTAL_CP_WORLD_SIZE: int,
+        TOTAL_CP_RANK: int,
+        CP_KV_CACHE_INTERLEAVE_SIZE: int,
+        PAD_ID: int,
+        BLOCK_SIZE: int,
+    ) -> None:
+        del block_table_stride, BLOCK_SIZE
+
+        slot_mapping[:max_num_tokens].fill_(PAD_ID)
+        if num_tokens == 0:
+            return
+
+        virtual_block_size = block_size * TOTAL_CP_WORLD_SIZE
+        interleave_span = TOTAL_CP_WORLD_SIZE * CP_KV_CACHE_INTERLEAVE_SIZE
+        num_reqs = query_start_loc.numel() - 1
+
+        for req_idx in range(num_reqs):
+            start_idx = int(query_start_loc[req_idx].item())
+            end_idx = int(query_start_loc[req_idx + 1].item())
+            if end_idx <= start_idx:
+                continue
+
+            pos = positions[start_idx:end_idx]
+            block_indices = torch.div(pos, virtual_block_size, rounding_mode="floor")
+            block_numbers = (
+                block_table[req_idx]
+                .index_select(
+                    0,
+                    block_indices.to(dtype=torch.long),
+                )
+                .to(torch.int64)
+            )
+
+            virtual_block_offsets = pos - block_indices * virtual_block_size
+            is_local = (
+                torch.div(
+                    virtual_block_offsets,
+                    CP_KV_CACHE_INTERLEAVE_SIZE,
+                    rounding_mode="floor",
+                )
+                % TOTAL_CP_WORLD_SIZE
+                == TOTAL_CP_RANK
+            )
+            local_block_offsets = (
+                torch.div(
+                    virtual_block_offsets,
+                    interleave_span,
+                    rounding_mode="floor",
+                )
+                * CP_KV_CACHE_INTERLEAVE_SIZE
+                + virtual_block_offsets % CP_KV_CACHE_INTERLEAVE_SIZE
+            )
+            slot_ids = block_numbers * block_size + local_block_offsets
+            slot_mapping[start_idx:end_idx] = torch.where(
+                is_local,
+                slot_ids,
+                torch.full_like(slot_ids, PAD_ID),
+            )
+
+    class _ComputeSlotMappingKernelWrapper:
+        _vllm_kunlun_patched = True
+
+        def __getitem__(self, grid):
+            del grid
+            return _compute_slot_mapping_kernel_impl
+
+    module._compute_slot_mapping_kernel = _ComputeSlotMappingKernelWrapper()
+
+
+def _ensure_fx_graph_output_node() -> None:
+    """Backfill torch.fx.Graph.output_node for PyTorch 2.5."""
+    graph_cls = torch.fx.Graph
+    if hasattr(graph_cls, "output_node"):
+        return
+
+    def output_node(self: torch.fx.Graph) -> torch.fx.Node:
+        for node in reversed(tuple(self.nodes)):
+            if node.op == "output":
+                return node
+        raise RuntimeError("Graph has no output node")
+
+    output_node._vllm_kunlun_patched = True  # type: ignore[attr-defined]
+    graph_cls.output_node = output_node  # type: ignore[attr-defined]
+
+
+def _get_fx_graph_outputs(graph: torch.fx.Graph) -> Any:
+    """Extract the output value(s) from an FX graph across PyTorch variants."""
+    global _MISSING_OUTPUT_NODE_WARNING_EMITTED
+
+    nodes = tuple(graph.nodes)
+    if not nodes:
+        raise RuntimeError("Graph has no nodes")
+
+    last_node = nodes[-1]
+    if last_node.op == "output":
+        return last_node.args[0]
+
+    mutated_outputs = _get_mutated_node_outputs(last_node)
+    if mutated_outputs is not None:
+        if not _MISSING_OUTPUT_NODE_WARNING_EMITTED:
+            logging.getLogger("vllm_kunlun.compat").warning(
+                "FX graph is missing an explicit output node; "
+                "falling back to mutated output args of %s (%s)",
+                last_node.name,
+                last_node.op,
+            )
+            _MISSING_OUTPUT_NODE_WARNING_EMITTED = True
+        return mutated_outputs
+
+    if not _MISSING_OUTPUT_NODE_WARNING_EMITTED:
+        logging.getLogger("vllm_kunlun.compat").warning(
+            "FX graph is missing an explicit output node; "
+            "falling back to the last node %s (%s)",
+            last_node.name,
+            last_node.op,
+        )
+        _MISSING_OUTPUT_NODE_WARNING_EMITTED = True
+
+    return last_node
+
+
+def _normalize_mutated_outputs(mutated_args: list[Any]) -> Any | None:
+    if not mutated_args:
+        return None
+    if len(mutated_args) == 1:
+        return mutated_args[0]
+    return tuple(mutated_args)
+
+
+def _collect_mutated_arg_candidates(
+    node: torch.fx.Node,
+    indices: Iterable[int],
+    names: Iterable[str] = (),
+) -> Any | None:
+    mutated_args: list[Any] = []
+    seen: set[int] = set()
+
+    for index in indices:
+        if index >= len(node.args):
+            continue
+        value = node.args[index]
+        if value is None or id(value) in seen:
+            continue
+        mutated_args.append(value)
+        seen.add(id(value))
+
+    for name in names:
+        value = node.kwargs.get(name)
+        if value is None or id(value) in seen:
+            continue
+        mutated_args.append(value)
+        seen.add(id(value))
+
+    return _normalize_mutated_outputs(mutated_args)
+
+
+def _describe_fx_arg(arg: Any) -> str:
+    if isinstance(arg, torch.fx.Node):
+        return f"{arg.name}:{arg.op}"
+    return type(arg).__name__
+
+
+def _maybe_log_mutated_output_debug(
+    node: torch.fx.Node,
+    target: Any,
+    schema: Any,
+) -> None:
+    global _MUTATED_OUTPUT_DEBUG_EMITTED
+
+    target_repr = str(target).lower()
+    if (
+        _MUTATED_OUTPUT_DEBUG_EMITTED
+        or "unified_attention_with_output" not in target_repr
+    ):
+        return
+
+    logging.getLogger("vllm_kunlun.compat").warning(
+        "Failed to infer mutated outputs for %s (%s): target_type=%s target=%r "
+        "schema=%s args=%s kwargs=%s",
+        node.name,
+        node.op,
+        type(target).__name__,
+        target,
+        schema,
+        [_describe_fx_arg(arg) for arg in node.args],
+        sorted(node.kwargs),
+    )
+    _MUTATED_OUTPUT_DEBUG_EMITTED = True
+
+
+def _maybe_log_missing_example_value_debug(
+    target: str,
+    outputs: Any,
+) -> None:
+    global _MISSING_EXAMPLE_VALUE_DEBUG_EMITTED
+
+    if _MISSING_EXAMPLE_VALUE_DEBUG_EMITTED:
+        return
+
+    def describe_output(value: Any) -> str:
+        if isinstance(value, torch.fx.Node):
+            meta_keys = sorted(value.meta)
+            return f"{value.name}:{value.op}:meta={meta_keys}"
+        return repr(value)
+
+    logging.getLogger("vllm_kunlun.compat").warning(
+        "Missing example_value while materializing outputs for submodule %s: %s",
+        target,
+        torch.fx.map_arg(outputs, describe_output),
+    )
+    _MISSING_EXAMPLE_VALUE_DEBUG_EMITTED = True
+
+
+def _get_mutated_node_outputs(node: torch.fx.Node) -> Any | None:
+    """Infer outputs from in-place mutated args when a graph returns None."""
+    target = getattr(node, "target", None)
+    schema = getattr(target, "_schema", None)
+    if schema is not None:
+        mutated_args: list[Any] = []
+        for index, arg_schema in enumerate(schema.arguments):
+            alias_info = getattr(arg_schema, "alias_info", None)
+            if alias_info is None or not getattr(alias_info, "is_write", False):
+                continue
+
+            if index < len(node.args):
+                value = node.args[index]
+            else:
+                value = node.kwargs.get(arg_schema.name)
+
+            if value is not None:
+                mutated_args.append(value)
+
+        normalized_outputs = _normalize_mutated_outputs(mutated_args)
+        if normalized_outputs is not None:
+            return normalized_outputs
+
+    target_repr = str(target).lower()
+    for op_name in (
+        "unified_attention_with_output",
+        "unified_mla_attention_with_output",
+    ):
+        if op_name not in target_repr:
+            continue
+        fallback_outputs = _collect_mutated_arg_candidates(
+            node,
+            indices=(3, 6),
+            names=("output", "output_block_scale"),
+        )
+        if fallback_outputs is not None:
+            return fallback_outputs
+
+    _maybe_log_mutated_output_debug(node, target, schema)
+    return None
+
+
+def _ensure_compiler_set_stance() -> None:
+    """Backfill torch.compiler.set_stance for PyTorch 2.5."""
+    if hasattr(torch.compiler, "set_stance"):
+        return
+
+    def set_stance(_stance: str):
+        return nullcontext()
+
+    torch.compiler.set_stance = set_stance  # type: ignore[attr-defined]
+
+
+def _ensure_functorch_config_keys() -> None:
+    """Expose vLLM 0.19.x functorch config keys on PyTorch 2.5."""
+    config_module = import_module("torch._functorch.config")
+    missing_defaults = {
+        "bundled_autograd_cache": False,
+        "autograd_cache_normalize_inputs": False,
+        "enable_remote_autograd_cache": False,
+        "_cache_config_ignore_prefix": [],
+        "_save_config_ignore": [],
+        "_compile_ignored_keys": set(),
+    }
+
+    for key, default in missing_defaults.items():
+        if key in config_module._config:
+            continue
+        config_module._allowed_keys.add(key)
+        value = default.copy() if isinstance(default, (list, dict, set)) else default
+        config_module._config[key] = value
+        config_module._default[key] = (
+            value.copy() if isinstance(value, (list, dict, set)) else value
+        )
+
+
+def _ensure_torch_accelerator_namespace() -> None:
+    """Backfill torch.accelerator with a CUDA-backed proxy on PyTorch 2.5."""
+    if hasattr(torch, "accelerator"):
+        return
+
+    class _CudaAcceleratorProxy:
+        def is_available(self) -> bool:
+            return torch.cuda.is_available()
+
+        def device_count(self) -> int:
+            return torch.cuda.device_count()
+
+        def set_device_index(self, device: Any) -> None:
+            torch.cuda.set_device(device)
+
+        def current_device_index(self) -> int:
+            return torch.cuda.current_device()
+
+        def empty_cache(self) -> None:
+            torch.cuda.empty_cache()
+
+        def synchronize(self, device: Any | None = None) -> None:
+            torch.cuda.synchronize(device)
+
+        def memory_stats(self, device: Any | None = None) -> dict[str, Any]:
+            return torch.cuda.memory_stats(device)
+
+        def memory_reserved(self, device: Any | None = None) -> int:
+            return torch.cuda.memory_reserved(device)
+
+        def max_memory_allocated(self, device: Any | None = None) -> int:
+            return torch.cuda.max_memory_allocated(device)
+
+        def reset_peak_memory_stats(self, device: Any | None = None) -> None:
+            torch.cuda.reset_peak_memory_stats(device)
+
+        @contextmanager
+        def device_index(self, device: Any) -> Any:
+            with torch.cuda.device(device):
+                yield
+
+        def __getattr__(self, name: str) -> Any:
+            return getattr(torch.cuda, name)
+
+    torch.accelerator = _CudaAcceleratorProxy()  # type: ignore[attr-defined]
+
+
+def _patch_traceable_vllm_parameter_subclasses(module: Any | None = None) -> None:
+    """Teach torch 2.5 Dynamo to trace vLLM parameter tensor subclasses."""
+    if module is None:
+        module = sys.modules.get("vllm.model_executor.parameter")
+        if module is None:
+            try:
+                module = import_module("vllm.model_executor.parameter")
+            except Exception:
+                return
+
+    traceable_subclasses = getattr(
+        torch._dynamo.config, "traceable_tensor_subclasses", None
+    )
+    if traceable_subclasses is None:
+        return
+
+    for class_name in (
+        "BasevLLMParameter",
+        "ModelWeightParameter",
+        "_ColumnvLLMParameter",
+        "RowvLLMParameter",
+    ):
+        parameter_cls = getattr(module, class_name, None)
+        if parameter_cls is not None:
+            traceable_subclasses.add(parameter_cls)
+
+
+def _disable_dynamo_torch_function_dispatch() -> None:
+    """Use traceable tensor subclasses instead of torch_function dispatch."""
+    dynamo_torch_module = import_module("torch._dynamo.variables.torch")
+    current = getattr(dynamo_torch_module, "can_dispatch_torch_function", None)
+    if current is None or getattr(current, "_vllm_kunlun_patched", False):
+        return
+
+    def return_false(*args: Any, **kwargs: Any) -> bool:
+        return False
+
+    return_false._vllm_kunlun_patched = True  # type: ignore[attr-defined]
+    dynamo_torch_module.can_dispatch_torch_function = return_false
+
+
+def _patch_piecewise_compile_interpreter_call_module(
+    module: Any | None = None,
+) -> None:
+    """Handle FX graphs without an explicit output node on PyTorch 2.5."""
+    if module is None:
+        module = sys.modules.get("vllm.compilation.backends")
+        if module is None:
+            try:
+                module = import_module("vllm.compilation.backends")
+            except Exception:
+                return
+
+    interpreter_cls = getattr(module, "PiecewiseCompileInterpreter", None)
+    if interpreter_cls is None:
+        return
+
+    current = getattr(interpreter_cls, "call_module", None)
+    if current is None or getattr(current, "_vllm_kunlun_patched", False):
+        return
+
+    def patched_call_module(
+        self,
+        target: torch.fx.node.Target,
+        args: tuple[torch.fx.node.Argument, ...],
+        kwargs: dict[str, Any],
+    ) -> Any:
+        assert isinstance(target, str)
+
+        gm = getattr(self.module, target)
+        outputs = _get_fx_graph_outputs(gm.graph)
+        try:
+            output = module.fx.map_arg(outputs, lambda node: node.meta["example_value"])
+        except KeyError:
+            if isinstance(outputs, torch.fx.Node):
+                fallback_outputs = _get_mutated_node_outputs(outputs)
+                if fallback_outputs is not None and fallback_outputs is not outputs:
+                    outputs = fallback_outputs
+                    output = module.fx.map_arg(
+                        outputs, lambda node: node.meta["example_value"]
+                    )
+                else:
+                    _maybe_log_missing_example_value_debug(target, outputs)
+                    raise
+            else:
+                _maybe_log_missing_example_value_debug(target, outputs)
+                raise
+
+        if target in self.compile_submod_names:
+            index = self.compile_submod_names.index(target)
+            submod = self.fetch_attr(target)
+
+            sym_shape_indices = [
+                i for i, x in enumerate(args) if isinstance(x, torch.SymInt)
+            ]
+
+            from torch._inductor.compile_fx import graph_returns_tuple
+
+            piecewise_backend_module = import_module(
+                "vllm.compilation.piecewise_backend"
+            )
+            piecewise_backend = piecewise_backend_module.PiecewiseBackend(
+                submod,
+                self.vllm_config,
+                index,
+                len(self.compile_submod_names),
+                sym_shape_indices,
+                self.vllm_backend,
+                graph_returns_tuple(submod),
+                submod_name=target,
+            )
+
+            self.module.__dict__[target] = module.wrap_with_cudagraph_if_needed(
+                piecewise_backend,
+                self.vllm_config,
+                self.compilation_config,
+                piecewise_backend.is_first_graph,
+                piecewise_backend.is_last_graph,
+            )
+
+            module.compilation_counter.num_piecewise_capturable_graphs_seen += 1
+
+        return output
+
+    patched_call_module._vllm_kunlun_patched = True  # type: ignore[attr-defined]
+    interpreter_cls.call_module = patched_call_module
+
+
+def apply_qwen3_moe_loader_compat_patch(module: Any | None = None) -> None:
+    """Skip extra Qwen3-MoE expert weights that do not map to local params."""
+    if module is None:
+        module = import_module("vllm.model_executor.models.qwen3_moe")
+    model_cls = module.Qwen3MoeModel
+
+    if getattr(model_cls.load_weights, "_vllm_kunlun_patched", False):
+        return
+
+    logger = logging.getLogger("vllm_kunlun.compat")
+    original_load_weights = model_cls.load_weights
+
+    def patched_load_weights(
+        self, weights: Iterable[tuple[str, torch.Tensor]]
+    ) -> set[str]:
+        params_dict = dict(self.named_parameters())
+        missing_weight_names = {
+            weight_name
+            for param_name, weight_name, *_ in self.get_expert_mapping()
+            if param_name not in params_dict
+        }
+        if not missing_weight_names:
+            return original_load_weights(self, weights)
+
+        filtered_weights: list[tuple[str, torch.Tensor]] = []
+        skipped_count = 0
+        skipped_example: str | None = None
+        for name, loaded_weight in weights:
+            if any(weight_name in name for weight_name in missing_weight_names):
+                skipped_count += 1
+                if skipped_example is None:
+                    skipped_example = name
+                continue
+            filtered_weights.append((name, loaded_weight))
+
+        if skipped_count:
+            logger.warning(
+                "Skipping %d unmatched Qwen3-MoE expert weights. Example: %s",
+                skipped_count,
+                skipped_example,
+            )
+
+        return original_load_weights(self, filtered_weights)
+
+    patched_load_weights._vllm_kunlun_patched = True  # type: ignore[attr-defined]
+    model_cls.load_weights = patched_load_weights
+
+
+def apply_torch251_compat_shims() -> None:
+    """Apply the compatibility shims needed by vLLM 0.19.x on torch 2.5.1."""
+    _ensure_custom_graph_pass_module()
+    _ensure_graph_pickler_module()
+    _ensure_mistral_reasoning_effort_enum()
+    _ensure_fx_graph_output_node()
+    _ensure_compiler_set_stance()
+    _ensure_functorch_config_keys()
+    _ensure_torch_accelerator_namespace()
+    _disable_dynamo_torch_function_dispatch()
+    _patch_traceable_vllm_parameter_subclasses()
+    _patch_piecewise_compile_interpreter_call_module()

--- a/vllm_kunlun/compilation/wrapper.py
+++ b/vllm_kunlun/compilation/wrapper.py
@@ -105,8 +105,14 @@ class TorchCompileWithNoGuardsWrapper:
             return ctx.result
         return callable_fn(*args, **kwargs)
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        compile_prefix: str = "",
+        is_encoder: bool = False,
+    ) -> None:
         self.compiled = False
+        self._compile_prefix = compile_prefix
+        self._is_encoder = is_encoder
 
         vllm_config = get_current_vllm_config()
         self.vllm_config = vllm_config
@@ -117,7 +123,14 @@ class TorchCompileWithNoGuardsWrapper:
         if mode is None:
             raise RuntimeError("Compilation mode cannot be NO_COMPILATION")
 
-        backend = vllm_config.compilation_config.init_backend(vllm_config)
+        try:
+            backend = vllm_config.compilation_config.init_backend(
+                vllm_config,
+                prefix=compile_prefix,
+                is_encoder=is_encoder,
+            )
+        except TypeError:
+            backend = vllm_config.compilation_config.init_backend(vllm_config)
 
         # options is only safe to populate when backend is a plain string
         # (e.g. "inductor"). On PyTorch 2.5, passing a non-empty options dict
@@ -224,11 +237,12 @@ class TorchCompileWithNoGuardsWrapper:
                         self.forward, *args, **kwargs
                     )
         else:
-            ctx = (
-                nullcontext()
-                if self.first_compile or not self.evaluate_guards
-                else torch.compiler.set_stance("fail_on_recompile")
-            )
+            if self.first_compile or not self.evaluate_guards:
+                ctx = nullcontext()
+            elif hasattr(torch.compiler, "set_stance"):
+                ctx = torch.compiler.set_stance("fail_on_recompile")
+            else:
+                ctx = nullcontext()
             self.first_compile = False
             with _compilation_context(), ctx:
                 return self._call_with_optional_nvtx_range(
@@ -305,3 +319,52 @@ class TorchCompileWithNoGuardsWrapper:
             yield
         finally:
             self.__class__.forward.__code__ = original
+
+
+def reset_compile_wrapper(model: torch.nn.Module) -> None:
+    """
+    Reset compiled wrapper state so elastic EP can rebuild with new settings.
+    """
+    if not isinstance(model, TorchCompileWithNoGuardsWrapper) and hasattr(
+        model, "model"
+    ):
+        model = model.model
+    if not isinstance(model, TorchCompileWithNoGuardsWrapper):
+        return
+    if hasattr(model, "do_not_compile") and model.do_not_compile:
+        return
+
+    from vllm.compilation.counter import compilation_counter
+
+    compilation_counter.num_models_seen = 0
+    compilation_counter.num_graphs_seen = 0
+    compilation_counter.num_piecewise_graphs_seen = 0
+    compilation_counter.num_piecewise_capturable_graphs_seen = 0
+    compilation_counter.num_backend_compilations = 0
+    compilation_counter.num_gpu_runner_capture_triggers = 0
+    compilation_counter.num_cudagraph_captured = 0
+    compilation_counter.num_inductor_compiles = 0
+    compilation_counter.num_eager_compiles = 0
+    compilation_counter.num_cache_entries_updated = 0
+    compilation_counter.num_compiled_artifacts_saved = 0
+    compilation_counter.stock_torch_compile_count = 0
+    compilation_counter.num_aot_compiles = 0
+    compilation_counter.num_aot_artifacts_saved = 0
+    compilation_counter.num_aot_artifacts_loaded = 0
+
+    if hasattr(model, "aot_compiled_fn"):
+        model.aot_compiled_fn = None
+    if hasattr(model, "was_aot_compile_fn_loaded_from_disk"):
+        model.was_aot_compile_fn_loaded_from_disk = False
+
+    compilation_config = model.vllm_config.compilation_config
+    compilation_config.cache_dir = ""
+    if hasattr(compilation_config, "local_cache_dir"):
+        compilation_config.local_cache_dir = ""
+
+    model.__class__.forward.__code__ = model.original_code_object()
+    TorchCompileWithNoGuardsWrapper.__init__(
+        model,
+        compile_prefix=getattr(model, "_compile_prefix", ""),
+        is_encoder=getattr(model, "_is_encoder", False),
+    )

--- a/vllm_kunlun/hf_config_compat.py
+++ b/vllm_kunlun/hf_config_compat.py
@@ -1,0 +1,12 @@
+from vllm.transformers_utils.configs.qwen3_5 import (
+    Qwen3_5Config as UpstreamQwen3_5Config,
+)
+from vllm.transformers_utils.configs.qwen3_5_moe import (
+    Qwen3_5MoeConfig as UpstreamQwen3_5MoeConfig,
+)
+
+from vllm_kunlun.transformers_utils.configs.qwen3_5 import Qwen3_5Config
+from vllm_kunlun.transformers_utils.configs.qwen3_5_moe import Qwen3_5MoeConfig
+
+QWEN3_5_CONFIG_TYPES = (Qwen3_5Config, UpstreamQwen3_5Config)
+QWEN3_5_MOE_CONFIG_TYPES = (Qwen3_5MoeConfig, UpstreamQwen3_5MoeConfig)

--- a/vllm_kunlun/models/__init__.py
+++ b/vllm_kunlun/models/__init__.py
@@ -26,9 +26,10 @@ def register_model():
     #     "Qwen3ForCausalLM",
     #     "vllm_kunlun.models.qwen3:Qwen3ForCausalLM")
 
-    # ModelRegistry.register_model(
-    #     "Qwen3MoeForCausalLM",
-    #     "vllm_kunlun.models.qwen3_moe:Qwen3MoeForCausalLM")
+    ModelRegistry.register_model(
+        "Qwen3MoeForCausalLM",
+        "vllm_kunlun.models.qwen3_moe:Qwen3MoeForCausalLM",
+    )
 
     ModelRegistry.register_model(
         "Qwen3NextForCausalLM", "vllm_kunlun.models.qwen3_next:Qwen3NextForCausalLM"

--- a/vllm_kunlun/models/qwen3_5.py
+++ b/vllm_kunlun/models/qwen3_5.py
@@ -76,6 +76,10 @@ from vllm.model_executor.models.utils import (
 from vllm.multimodal import MULTIMODAL_REGISTRY
 from vllm.sequence import IntermediateTensors
 
+from vllm_kunlun.hf_config_compat import (
+    QWEN3_5_CONFIG_TYPES,
+    QWEN3_5_MOE_CONFIG_TYPES,
+)
 from vllm_kunlun.ops.mamba.mamba_utils import (
     MambaStateCopyFunc,
     MambaStateCopyFuncCalculator,
@@ -105,12 +109,12 @@ logger = init_logger(__name__)
 
 class Qwen3_5ProcessingInfo(Qwen3VLProcessingInfo):
     def get_hf_config(self):
-        return self.ctx.get_hf_config(Qwen3_5Config)
+        return self.ctx.get_hf_config(QWEN3_5_CONFIG_TYPES)
 
 
 class Qwen3_5MoeProcessingInfo(Qwen3VLProcessingInfo):
     def get_hf_config(self):
-        return self.ctx.get_hf_config(Qwen3_5MoeConfig)
+        return self.ctx.get_hf_config(QWEN3_5_MOE_CONFIG_TYPES)
 
 
 class Qwen3_5GatedDeltaNet(Qwen3NextGatedDeltaNet):

--- a/vllm_kunlun/models/qwen3_moe.py
+++ b/vllm_kunlun/models/qwen3_moe.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import logging
+import typing
+from collections.abc import Iterable
+
+import torch
+from vllm.config import VllmConfig
+from vllm.model_executor.models import qwen3_moe as upstream
+
+logger = logging.getLogger(__name__)
+
+
+class Qwen3MoeModel(upstream.Qwen3MoeModel):
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        stacked_params_mapping = [
+            ("qkv_proj", "q_proj", "q"),
+            ("qkv_proj", "k_proj", "k"),
+            ("qkv_proj", "v_proj", "v"),
+            ("gate_up_proj", "gate_proj", 0),
+            ("gate_up_proj", "up_proj", 1),
+        ]
+        ignore_suffixes = (
+            ".bias",
+            "_bias",
+            ".weight_scale",
+            "_weight_scale",
+            ".input_scale",
+            "_input_scale",
+        )
+
+        params_dict = dict(self.named_parameters())
+        loaded_params: set[str] = set()
+        expert_params_mapping = self.get_expert_mapping()
+        skipped_count = 0
+        skipped_example: str | None = None
+        for name, loaded_weight in weights:
+            if self.quant_config is not None and (
+                scale_name := self.quant_config.get_cache_scale(name)
+            ):
+                param = params_dict[scale_name]
+                weight_loader = getattr(
+                    param, "weight_loader", upstream.default_weight_loader
+                )
+                assert (
+                    loaded_weight.numel() == 1
+                ), f"KV scale numel {loaded_weight.numel()} != 1"
+                loaded_weight = loaded_weight.squeeze()
+                weight_loader(param, loaded_weight)
+                loaded_params.add(scale_name)
+                continue
+            if "scale" in name or "zero_point" in name:
+                name = upstream.maybe_remap_kv_scale_name(name, params_dict)
+                if name is None:
+                    continue
+            for param_name, weight_name, shard_id in stacked_params_mapping:
+                if weight_name not in name:
+                    continue
+                if "mlp.experts" in name:
+                    continue
+                name = name.replace(weight_name, param_name)
+
+                if name.endswith(ignore_suffixes) and name not in params_dict:
+                    continue
+                if upstream.is_pp_missing_parameter(name, self):
+                    continue
+                if name.endswith("scale"):
+                    name = upstream.maybe_remap_kv_scale_name(name, params_dict)
+                    if name is None:
+                        continue
+                if name not in params_dict:
+                    continue
+
+                param = params_dict[name]
+                weight_loader = getattr(
+                    param, "weight_loader", upstream.default_weight_loader
+                )
+                if weight_loader == upstream.default_weight_loader:
+                    weight_loader(param, loaded_weight)
+                else:
+                    weight_loader(param, loaded_weight, shard_id)
+                break
+            else:
+                is_expert_weight = False
+                for mapping in expert_params_mapping:
+                    param_name, weight_name, expert_id, shard_id = mapping
+                    if weight_name not in name:
+                        continue
+
+                    is_expert_weight = True
+                    name_mapped = name.replace(weight_name, param_name)
+
+                    if upstream.is_pp_missing_parameter(name_mapped, self):
+                        continue
+                    if (
+                        name_mapped.endswith(ignore_suffixes)
+                        and name_mapped not in params_dict
+                    ):
+                        continue
+                    if name_mapped not in params_dict:
+                        skipped_count += 1
+                        if skipped_example is None:
+                            skipped_example = name
+                        continue
+
+                    param = params_dict[name_mapped]
+                    weight_loader = typing.cast(
+                        typing.Callable[..., bool], param.weight_loader
+                    )
+                    success = weight_loader(
+                        param,
+                        loaded_weight,
+                        name_mapped,
+                        shard_id=shard_id,
+                        expert_id=expert_id,
+                        return_success=True,
+                    )
+                    if success:
+                        name = name_mapped
+                        break
+                else:
+                    if is_expert_weight:
+                        continue
+                    if name.endswith(ignore_suffixes) and name not in params_dict:
+                        continue
+                    if upstream.is_pp_missing_parameter(name, self):
+                        continue
+                    if name not in params_dict:
+                        continue
+                    param = params_dict[name]
+                    weight_loader = getattr(
+                        param, "weight_loader", upstream.default_weight_loader
+                    )
+                    weight_loader(param, loaded_weight)
+            loaded_params.add(name)
+
+        if skipped_count:
+            logger.warning(
+                "Skipping %d unmatched Qwen3-MoE expert weights. Example: %s",
+                skipped_count,
+                skipped_example,
+            )
+
+        return loaded_params
+
+
+class Qwen3MoeForCausalLM(upstream.Qwen3MoeForCausalLM):
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
+        original_model_cls = upstream.Qwen3MoeModel
+        upstream.Qwen3MoeModel = Qwen3MoeModel
+        try:
+            super().__init__(vllm_config=vllm_config, prefix=prefix)
+        finally:
+            upstream.Qwen3MoeModel = original_model_cls

--- a/vllm_kunlun/models/qwen3_next.py
+++ b/vllm_kunlun/models/qwen3_next.py
@@ -10,7 +10,6 @@ import torch
 from einops import rearrange
 from torch import nn
 from transformers.activations import ACT2FN
-from vllm.attention.layer import Attention
 from vllm.compilation.decorators import support_torch_compile
 from vllm.config import (
     CacheConfig,
@@ -88,6 +87,7 @@ from vllm.transformers_utils.configs import Qwen3NextConfig
 from vllm.utils.torch_utils import direct_register_custom_op
 from vllm.v1.attention.backend import AttentionMetadata
 
+from vllm_kunlun.attention_compat import Attention
 from vllm_kunlun.ops._kunlun_ops import KunlunOps as ops
 
 # from vllm_kunlun.ops.attention.layer import Attention

--- a/vllm_kunlun/models/qwen3_omni_moe_thinker.py
+++ b/vllm_kunlun/models/qwen3_omni_moe_thinker.py
@@ -43,7 +43,6 @@ from transformers.models.qwen3_omni_moe.processing_qwen3_omni_moe import (
     Qwen3OmniMoeProcessor,
 )
 from transformers.models.whisper import WhisperFeatureExtractor
-from vllm.attention.layer import check_upstream_fa_availability
 from vllm.compilation.decorators import support_torch_compile
 from vllm.config import VllmConfig
 from vllm.distributed import get_pp_group
@@ -92,6 +91,8 @@ from vllm.multimodal.processing import (
 )
 from vllm.platforms.interface import _Backend
 from vllm.sequence import IntermediateTensors
+
+from ..attention_compat import check_upstream_fa_availability
 
 # yapf: enable
 from .qwen2_5_vl import (

--- a/vllm_kunlun/models/qwen3_vl.py
+++ b/vllm_kunlun/models/qwen3_vl.py
@@ -47,7 +47,6 @@ from transformers.models.qwen3_vl.video_processing_qwen3_vl import (
     smart_resize as video_smart_resize,
 )
 from transformers.video_utils import VideoMetadata
-from vllm.attention.layer import check_upstream_fa_availability
 from vllm.compilation.decorators import support_torch_compile
 from vllm.config import VllmConfig
 from vllm.distributed import get_pp_group
@@ -99,6 +98,8 @@ from vllm.sequence import IntermediateTensors
 from vllm.transformers_utils.config import uses_mrope
 from vllm.utils import is_list_of
 
+from vllm_kunlun.attention_compat import check_upstream_fa_availability
+
 from .qwen2_5_vl import (
     Qwen2_5_VisionAttention,
     Qwen2_5_VisionRotaryEmbedding,
@@ -117,7 +118,6 @@ _MAX_FRAMES_PER_VIDEO = 24576
 
 
 class Qwen3_VisionPatchEmbed(nn.Module):
-
     def __init__(
         self,
         patch_size: int = 14,
@@ -147,7 +147,6 @@ class Qwen3_VisionPatchEmbed(nn.Module):
 
 
 class Qwen3_VisionMLP(nn.Module):
-
     def __init__(
         self,
         in_features: int,
@@ -185,7 +184,6 @@ class Qwen3_VisionMLP(nn.Module):
 
 
 class Qwen3_VisionBlock(nn.Module):
-
     def __init__(
         self,
         dim: int,
@@ -245,7 +243,6 @@ class Qwen3_VisionBlock(nn.Module):
 
 
 class Qwen3_VisionPatchMerger(nn.Module):
-
     def __init__(
         self,
         d_model: int,
@@ -298,7 +295,6 @@ class Qwen3_VisionPatchMerger(nn.Module):
 
 
 class Qwen3_VisionTransformer(nn.Module):
-
     def __init__(
         self,
         vision_config: Qwen3VLVisionConfig,
@@ -448,7 +444,6 @@ class Qwen3_VisionTransformer(nn.Module):
         return rotary_pos_emb
 
     def fast_pos_embed_interpolate(self, grid_thw: list[list[int]]) -> torch.Tensor:
-
         num_grid_per_side = self.num_grid_per_side
         m_size = self.spatial_merge_size
         hidden_dim = self.pos_embed.embedding_dim
@@ -615,7 +610,6 @@ class Qwen3_VisionTransformer(nn.Module):
 
 
 class Qwen3VLProcessingInfo(Qwen2VLProcessingInfo):
-
     def get_hf_config(self):
         return self.ctx.get_hf_config(Qwen3VLConfig)
 
@@ -782,7 +776,6 @@ class Qwen3VLProcessingInfo(Qwen2VLProcessingInfo):
 
 
 class Qwen3VLDummyInputsBuilder(BaseDummyInputsBuilder[Qwen3VLProcessingInfo]):
-
     def get_dummy_text(self, mm_counts: Mapping[str, int]) -> str:
         num_images = mm_counts.get("image", 0)
         num_videos = mm_counts.get("video", 0)
@@ -866,7 +859,6 @@ class Qwen3VLDummyInputsBuilder(BaseDummyInputsBuilder[Qwen3VLProcessingInfo]):
 
 
 class Qwen3VLMultiModalProcessor(BaseMultiModalProcessor[Qwen3VLProcessingInfo]):
-
     def _get_data_parser(self) -> MultiModalDataParser:
         return MultiModalDataParser(video_needs_metadata=True)
 
@@ -1067,7 +1059,6 @@ class Qwen3VLMultiModalProcessor(BaseMultiModalProcessor[Qwen3VLProcessingInfo])
     }
 )
 class Qwen3LLMModel(Qwen3Model):
-
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
         super().__init__(vllm_config=vllm_config, prefix=prefix)
         if not get_pp_group().is_first_rank:
@@ -1125,7 +1116,6 @@ class Qwen3LLMModel(Qwen3Model):
 
 
 class Qwen3LLMForCausalLM(Qwen3ForCausalLM):
-
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
         super(Qwen3ForCausalLM, self).__init__()
         config = vllm_config.model_config.hf_config.text_config
@@ -1400,7 +1390,6 @@ class Qwen3VLForConditionalGeneration(
     def _process_image_input(
         self, image_input: Qwen2_5_VLImageInputs
     ) -> tuple[torch.Tensor, ...]:
-
         grid_thw = image_input["image_grid_thw"]
         assert grid_thw.ndim == 2
         grid_thw_list = grid_thw.tolist()
@@ -1428,7 +1417,6 @@ class Qwen3VLForConditionalGeneration(
     def _process_video_input(
         self, video_input: Qwen2_5_VLVideoInputs
     ) -> tuple[torch.Tensor, ...]:
-
         grid_thw = video_input["video_grid_thw"]
         assert grid_thw.ndim == 2
         grid_thw_list = grid_thw.tolist()
@@ -1480,7 +1468,6 @@ class Qwen3VLForConditionalGeneration(
     def get_multimodal_embeddings(
         self, **kwargs: object
     ) -> Optional[MultiModalEmbeddings]:
-
         mm_input_by_modality = self._parse_and_validate_multimodal_inputs(**kwargs)
         if not mm_input_by_modality:
             return None
@@ -1513,12 +1500,13 @@ class Qwen3VLForConditionalGeneration(
         ]
         multimodal_embeddings_cat = torch.cat(multimodal_embeddings, dim=0)
 
-        multimodal_embeddings_main, multimodal_embeddings_multiscale = (
-            torch.split(  # noqa:E501
-                multimodal_embeddings_cat,
-                [self.visual_dim, self.multiscale_dim],
-                dim=-1,
-            )
+        (
+            multimodal_embeddings_main,
+            multimodal_embeddings_multiscale,
+        ) = torch.split(  # noqa:E501
+            multimodal_embeddings_cat,
+            [self.visual_dim, self.multiscale_dim],
+            dim=-1,
         )
 
         multimodal_embeddings = torch.split(
@@ -1556,10 +1544,11 @@ class Qwen3VLForConditionalGeneration(
         inputs_embeds = self.language_model.get_input_embeddings(input_ids)
         if multimodal_embeddings is not None:
             if self.use_deepstack:
-                deepstack_input_embeds, multimodal_embeddings = (
-                    self._compute_deepstack_embeds(  # noqa:E501
-                        input_ids, inputs_embeds, multimodal_embeddings
-                    )
+                (
+                    deepstack_input_embeds,
+                    multimodal_embeddings,
+                ) = self._compute_deepstack_embeds(  # noqa:E501
+                    input_ids, inputs_embeds, multimodal_embeddings
                 )
             inputs_embeds = merge_multimodal_embeddings(
                 input_ids,
@@ -1743,7 +1732,6 @@ class Qwen3VLForConditionalGeneration(
         return self.language_model.compute_logits(hidden_states)
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
-
         skip_prefixes = []
         if self.visual is None:
             skip_prefixes.extend(["visual."])

--- a/vllm_kunlun/ops/__init__.py
+++ b/vllm_kunlun/ops/__init__.py
@@ -15,17 +15,14 @@
 # This file is a part of the vllm-ascend project.
 #
 
-import vllm_kunlun.ops._custom_ops
-import vllm_kunlun.ops.fused_moe.layer
+"""Kunlun ops package.
 
-# base layers
-import vllm_kunlun.ops.layernorm
-import vllm_kunlun.ops.linear
+Avoid eager side-effect imports here. vLLM 0.19 imports
+``vllm.v1.attention.ops.merge_attn_states`` during CLI argument parsing, and our
+import hook redirects that path into ``vllm_kunlun.ops.attention``. Pulling in
+``vllm_kunlun.ops`` package-wide side effects at that stage forces ``kunlun_ops``
+and ``torch_xmlir`` to load before the service is even configured.
 
-# embedding
-import vllm_kunlun.ops.rotary_embedding
-import vllm_kunlun.ops.vocab_parallel_embedding
-import vllm_kunlun.v1.sample.spec_decode.eagle  # noqa: F401
-
-# TODO @xyDong0223 remove v0.16.0
-# import vllm_kunlun.ops.mla
+The individual submodules still import and register their runtime pieces when
+they are imported explicitly by model/attention code.
+"""

--- a/vllm_kunlun/ops/_kunlun_ops.py
+++ b/vllm_kunlun/ops/_kunlun_ops.py
@@ -21,26 +21,296 @@ from typing import Optional
 
 import cocopod  # noqa
 import torch
+import torch.nn.functional as F
 import xspeedgate_ops  # noqa
 from vllm.logger import init_logger
 from vllm.v1.worker.workspace import current_workspace_manager
 
 logger = init_logger(__name__)
 
+kunlun_ops = None
 try:
-    import kunlun_ops
+    import kunlun_ops as _kunlun_ops
 
+    kunlun_ops = _kunlun_ops
     logger.info("Load custom ops library success!")
-except ImportError as e:
-    logger.warning("Import error msg: %s", e.msg)
+except (ImportError, OSError) as e:
+    logger.warning("Import error msg: %s", e)
 
 
 _per_token_smooth_quant = True
+_logged_native_moe_fallback = False
 
 
 def is_per_token_smooth_quant():
     """is per token smooth quant"""
     return _per_token_smooth_quant
+
+
+def _torch_op_exists(namespace: str, op_name: str) -> bool:
+    try:
+        getattr(getattr(torch.ops, namespace), op_name)
+        return True
+    except AttributeError:
+        return False
+
+
+def _grouped_topk_native(
+    gating_output: torch.Tensor,
+    topk: int,
+    renormalize: bool,
+    num_expert_group: int,
+    topk_group: int,
+    scoring_func: str,
+    e_score_correction_bias: torch.Tensor | None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if scoring_func == "softmax":
+        scores = torch.softmax(gating_output.float(), dim=-1)
+    elif scoring_func == "sigmoid":
+        scores = gating_output.float().sigmoid()
+    else:
+        raise ValueError(f"Unsupported scoring function: {scoring_func}")
+
+    num_tokens = scores.shape[0]
+    if e_score_correction_bias is not None:
+        original_scores = scores
+        scores = scores + e_score_correction_bias.unsqueeze(0)
+        group_scores = (
+            scores.view(num_tokens, num_expert_group, -1).topk(2, dim=-1)[0].sum(dim=-1)
+        )
+    else:
+        group_scores = scores.view(num_tokens, num_expert_group, -1).max(dim=-1).values
+
+    group_idx = torch.topk(group_scores, k=topk_group, dim=-1, sorted=False)[1]
+    group_mask = torch.zeros_like(group_scores)
+    group_mask.scatter_(1, group_idx, 1)
+    score_mask = (
+        group_mask.unsqueeze(-1)
+        .expand(num_tokens, num_expert_group, scores.shape[-1] // num_expert_group)
+        .reshape(num_tokens, -1)
+    )
+    masked_scores = scores.masked_fill(~score_mask.bool(), float("-inf"))
+
+    if e_score_correction_bias is not None:
+        topk_ids = torch.topk(masked_scores, k=topk, dim=-1, sorted=False)[1]
+        topk_weights = original_scores.gather(1, topk_ids)
+    else:
+        topk_weights, topk_ids = torch.topk(masked_scores, k=topk, dim=-1, sorted=False)
+
+    if renormalize:
+        topk_weights = topk_weights / topk_weights.sum(dim=-1, keepdim=True).clamp_min(
+            torch.finfo(topk_weights.dtype).eps
+        )
+
+    return topk_weights.to(torch.float32), topk_ids.to(torch.int32)
+
+
+def _select_experts_native(
+    router_logits: torch.Tensor,
+    moe_top_k: int,
+    renormalize: bool,
+    use_grouped_topk: bool,
+    num_expert_group: int | None,
+    topk_group: int | None,
+    scoring_func: str,
+    e_score_correction_bias: torch.Tensor | None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    router_logits = router_logits.float()
+
+    if use_grouped_topk:
+        if num_expert_group is None or topk_group is None:
+            raise ValueError("Grouped top-k requires expert-group metadata.")
+        return _grouped_topk_native(
+            gating_output=router_logits,
+            topk=moe_top_k,
+            renormalize=renormalize,
+            num_expert_group=num_expert_group,
+            topk_group=topk_group,
+            scoring_func=scoring_func,
+            e_score_correction_bias=e_score_correction_bias,
+        )
+
+    if scoring_func == "softmax":
+        topk_logits, topk_ids = torch.topk(
+            router_logits, k=moe_top_k, dim=-1, sorted=False
+        )
+        if renormalize:
+            topk_weights = torch.softmax(topk_logits, dim=-1)
+        else:
+            log_z = torch.logsumexp(router_logits, dim=-1, keepdim=True)
+            topk_weights = (topk_logits - log_z).exp()
+    elif scoring_func == "sigmoid":
+        scores = router_logits.sigmoid()
+        topk_weights, topk_ids = torch.topk(scores, k=moe_top_k, dim=-1, sorted=False)
+        if renormalize:
+            topk_weights = topk_weights / topk_weights.sum(
+                dim=-1, keepdim=True
+            ).clamp_min(torch.finfo(topk_weights.dtype).eps)
+    else:
+        raise ValueError(f"Unsupported scoring function: {scoring_func}")
+
+    return topk_weights.to(torch.float32), topk_ids.to(torch.int32)
+
+
+def _swiglu_native(x: torch.Tensor) -> torch.Tensor:
+    half = x.shape[-1] // 2
+    return F.silu(x[..., :half]) * x[..., half:]
+
+
+def _iter_local_moe_routes_cpu(
+    topk_ids: torch.Tensor,
+    topk_weights: torch.Tensor,
+    moe_top_k: int,
+    num_local_experts: int,
+    ep_rank: int,
+):
+    flat_topk_ids_cpu = topk_ids.reshape(-1).to(device="cpu", dtype=torch.int64)
+    flat_topk_weights_cpu = topk_weights.reshape(-1).to(
+        device="cpu", dtype=torch.float32
+    )
+
+    expert_id_offset = ep_rank * num_local_experts
+    if (
+        ep_rank != 0
+        and flat_topk_ids_cpu.numel() > 0
+        and int(flat_topk_ids_cpu.max().item()) < num_local_experts
+    ):
+        expert_id_offset = 0
+
+    local_expert_ids_cpu = flat_topk_ids_cpu - expert_id_offset
+    valid_mask = (local_expert_ids_cpu >= 0) & (
+        local_expert_ids_cpu < num_local_experts
+    )
+    if not bool(valid_mask.any()):
+        return
+
+    valid_route_indices_cpu = torch.nonzero(valid_mask, as_tuple=False).flatten()
+    local_expert_ids_cpu = local_expert_ids_cpu.index_select(0, valid_route_indices_cpu)
+    route_weights_cpu = flat_topk_weights_cpu.index_select(0, valid_route_indices_cpu)
+
+    sort_order = torch.argsort(local_expert_ids_cpu, stable=True)
+    sorted_route_indices_cpu = valid_route_indices_cpu.index_select(0, sort_order)
+    sorted_expert_ids_cpu = local_expert_ids_cpu.index_select(0, sort_order)
+    sorted_route_weights_cpu = route_weights_cpu.index_select(0, sort_order)
+    sorted_token_indices_cpu = torch.div(
+        sorted_route_indices_cpu,
+        moe_top_k,
+        rounding_mode="floor",
+    )
+
+    counts = torch.bincount(sorted_expert_ids_cpu, minlength=num_local_experts)
+    start = 0
+    for local_expert_id, count in enumerate(counts.tolist()):
+        if count == 0:
+            continue
+        end = start + count
+        yield (
+            local_expert_id,
+            sorted_token_indices_cpu[start:end],
+            sorted_route_weights_cpu[start:end],
+        )
+        start = end
+
+
+def _run_moe_native(
+    hidden_states: torch.Tensor,
+    w1: torch.Tensor,
+    w2: torch.Tensor,
+    router_logits: torch.Tensor,
+    ep_rank: int,
+    moe_top_k: int,
+    renormalize: bool,
+    use_grouped_topk: bool,
+    num_expert_group: int | None,
+    topk_group: int | None,
+    w1_bias: torch.Tensor | None,
+    w2_bias: torch.Tensor | None,
+    scoring_func: str,
+    e_score_correction_bias: torch.Tensor | None,
+) -> torch.Tensor:
+    topk_weights, topk_ids = _select_experts_native(
+        router_logits=router_logits,
+        moe_top_k=moe_top_k,
+        renormalize=renormalize,
+        use_grouped_topk=use_grouped_topk,
+        num_expert_group=num_expert_group,
+        topk_group=topk_group,
+        scoring_func=scoring_func,
+        e_score_correction_bias=e_score_correction_bias,
+    )
+
+    token_count, hidden_size = hidden_states.shape
+    num_local_experts = w1.shape[0]
+    output = torch.zeros(
+        (token_count, hidden_size),
+        dtype=hidden_states.dtype,
+        device=hidden_states.device,
+    )
+
+    for (
+        local_expert_id,
+        token_indices_cpu,
+        route_weights_cpu,
+    ) in _iter_local_moe_routes_cpu(
+        topk_ids=topk_ids,
+        topk_weights=topk_weights,
+        moe_top_k=moe_top_k,
+        num_local_experts=num_local_experts,
+        ep_rank=ep_rank,
+    ):
+        token_indices = token_indices_cpu.to(
+            device=hidden_states.device, dtype=torch.long
+        )
+        route_weights = route_weights_cpu.to(
+            device=hidden_states.device,
+            dtype=hidden_states.dtype,
+        )
+        expert_hidden_states = hidden_states.index_select(0, token_indices)
+        gate_up = expert_hidden_states @ w1[local_expert_id].transpose(0, 1)
+        if w1_bias is not None:
+            gate_up = gate_up + w1_bias[local_expert_id]
+        activated = _swiglu_native(gate_up)
+        expert_output = activated @ w2[local_expert_id].transpose(0, 1)
+        if w2_bias is not None:
+            expert_output = expert_output + w2_bias[local_expert_id]
+        expert_output = expert_output * route_weights.unsqueeze(-1)
+        output.index_add_(0, token_indices, expert_output)
+
+    return output
+
+
+def _should_use_native_moe_fallback(
+    hidden_states: torch.Tensor,
+    scoring_func: str,
+    use_grouped_topk: bool,
+) -> bool:
+    if hidden_states.device.type == "cpu":
+        return True
+
+    if scoring_func == "softmax" and not use_grouped_topk:
+        required_ops = (
+            _torch_op_exists("_C", "moe_softmax_topk_norm"),
+            _torch_op_exists("xspeedgate_ops", "moe_pre_small"),
+            _torch_op_exists("xspeedgate_ops", "moe_active_expert_balance"),
+            _torch_op_exists("xspeedgate_ops", "fused_moe"),
+        )
+    elif scoring_func == "sigmoid" and use_grouped_topk:
+        required_ops = (_torch_op_exists("_C", "moe_sigmoid_group_topk_norm"),)
+    else:
+        required_ops = ()
+
+    return not all(required_ops)
+
+
+def _log_native_moe_fallback_once() -> None:
+    global _logged_native_moe_fallback
+    if _logged_native_moe_fallback:
+        return
+    _logged_native_moe_fallback = True
+    logger.warning(
+        "Falling back to native PyTorch MoE path because Kunlun MoE custom ops "
+        "are unavailable in the current runtime."
+    )
 
 
 class KunlunOps:
@@ -393,6 +663,29 @@ class KunlunOps:
         e_score_correction_bias: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         """fused_moe"""
+        if _should_use_native_moe_fallback(
+            hidden_states=hidden_states,
+            scoring_func=scoring_func,
+            use_grouped_topk=use_grouped_topk,
+        ):
+            _log_native_moe_fallback_once()
+            return _run_moe_native(
+                hidden_states=hidden_states,
+                w1=w1,
+                w2=w2,
+                router_logits=router_logits,
+                ep_rank=ep_rank,
+                moe_top_k=moe_top_k,
+                renormalize=renormalize,
+                use_grouped_topk=use_grouped_topk,
+                num_expert_group=num_expert_group,
+                topk_group=topk_group,
+                w1_bias=w1_bias,
+                w2_bias=w2_bias,
+                scoring_func=scoring_func,
+                e_score_correction_bias=e_score_correction_bias,
+            )
+
         global_num_experts, up_gate_size, _ = w1.shape
         M, N = hidden_states.shape
         hidden_dim = w2.shape[1]

--- a/vllm_kunlun/ops/attention/merge_attn_states.py
+++ b/vllm_kunlun/ops/attention/merge_attn_states.py
@@ -1,9 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import importlib
 from typing import Optional
 
-import kunlun_ops
 import torch
+
+
+def _get_kunlun_ops():
+    return importlib.import_module("kunlun_ops")
 
 
 def merge_attn_states(
@@ -14,7 +18,6 @@ def merge_attn_states(
     suffix_lse: torch.Tensor,
     output_lse: Optional[torch.Tensor] = None,
 ) -> None:
-
-    return kunlun_ops.attention_merge_stage(
+    return _get_kunlun_ops().attention_merge_stage(
         prefix_output, prefix_lse, suffix_output, suffix_lse, output, output_lse
     )

--- a/vllm_kunlun/ops/fused_moe/layer.py
+++ b/vllm_kunlun/ops/fused_moe/layer.py
@@ -25,6 +25,11 @@ class KunlunUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod):
       routing internally with device-optimized kernels.
     """
 
+    def __init__(self, moe):
+        super().__init__(moe)
+        self._is_monolithic = True
+        self.apply_monolithic = self._apply_monolithic_kunlun
+
     @property
     def is_monolithic(self) -> bool:
         return True
@@ -33,7 +38,7 @@ class KunlunUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod):
         """Skip _setup_kernel() since Kunlun does not need Triton kernels."""
         FusedMoEMethodBase.process_weights_after_loading(self, layer)
 
-    def apply_monolithic(
+    def _apply_monolithic_kunlun(
         self,
         layer,
         x: torch.Tensor,

--- a/vllm_kunlun/patches/patch_torch251.py
+++ b/vllm_kunlun/patches/patch_torch251.py
@@ -1,98 +1,47 @@
-"""
-vLLM Compatibility Patch Script for PyTorch 2.5.1
-==================================================
+"""Patch vLLM 0.19.x so it can run on PyTorch 2.5.1."""
 
-Why are these patches necessary?
---------------------------------
-vLLM (v0.15.x) was developed and tested against newer versions of PyTorch
-(2.7+), which introduced several API changes that are NOT available in
-PyTorch 2.5.1. Running vLLM on PyTorch 2.5.1 without these patches will
-result in AttributeError or TypeError exceptions at runtime.
-
-Specifically, the following incompatibilities exist:
-
-1. `torch._functorch.config.bundled_autograd_cache` — This configuration
-   option was introduced in PyTorch 2.7+. It does not exist in PyTorch
-   2.5.1, so any code referencing it (either as a direct attribute or via
-   `torch._functorch.config.patch(...)`) will raise an AttributeError.
-
-2. `patched_inline_call(self_: Any)` signature — The inline call hook
-   signature changed between PyTorch versions. In PyTorch 2.5.1, it
-   expects `(parent, func, args, kwargs)` rather than `(self_: Any)`.
-
-3. `torch.Size(...)` constructor — In certain compilation contexts under
-   PyTorch 2.5.1, `torch.Size()` does not work correctly during tracing.
-   Using `torch.empty().size` is a compatible workaround.
-
-4. `list[int]` type hint — Python 3.10 supports `list[int]` in type
-   annotations, but certain runtime introspection paths (especially
-   within torch.compile / FX tracing) may fail to resolve built-in
-   generic aliases. Using `typing.List[int]` avoids this.
-
-When should these patches be removed?
---------------------------------------
-These patches are TEMPORARY workarounds for PyTorch 2.5.1 compatibility.
-They should be REMOVED once the environment is upgraded to PyTorch 2.9+,
-where all referenced APIs are stable and available. Keeping these patches
-on PyTorch 2.9+ may cause unexpected behavior.
-
-Usage:
-------
-    python patch_torch251.py           # Apply all patches
-    python patch_torch251.py --dry-run # Preview changes without modifying files
-    python patch_torch251.py --revert  # Restore all files from .bak backups
-"""
+from __future__ import annotations
 
 import os
 import shutil
 import site
 import sys
 
-# ============================================================
-# Base path for the target Python environment
-# ============================================================
-# Determine the site-packages directory dynamically to keep this
-# script portable across different Python installations.
-_site_packages_list = []
+_site_packages = []
 try:
-    _site_packages_list = site.getsitepackages()
+    _site_packages = site.getsitepackages()
 except Exception:
-    _site_packages_list = []
-if _site_packages_list:
-    # Prefer the first returned site-packages directory.
-    SITE_PACKAGES = _site_packages_list[0]
+    _site_packages = []
+
+if _site_packages:
+    SITE_PACKAGES = _site_packages[0]
 else:
-    # Fallback: use the current environment prefix.
     SITE_PACKAGES = sys.prefix
 
-# ============================================================
-# Patch definitions
-# Each patch contains:
-#   - file:      target file path (relative to SITE_PACKAGES)
-#   - desc:      human-readable description
-#   - lines:     original line numbers (for reference only)
-#   - old:       the exact code to find and replace
-#   - new:       the replacement code
-#   - count:     (optional) number of occurrences to replace.
-#                Defaults to 1. Use 0 to replace ALL occurrences.
-#
-# IMPORTANT: When multiple patches target the same file, the
-# import/header patches should come BEFORE the body patches to
-# ensure correct dependency order.
-# ============================================================
 PATCHES = [
-    # ----------------------------------------------------------
-    # Patch 1: decorators.py — Fix inline call signature
-    # ----------------------------------------------------------
+    {
+        "file": "vllm/compilation/passes/inductor_pass.py",
+        "lines": "22",
+        "desc": (
+            "Backfill torch._inductor.custom_graph_pass with a fallback base "
+            "class when PyTorch 2.5.1 does not ship this module."
+        ),
+        "old": "from torch._inductor.custom_graph_pass import CustomGraphPass",
+        "new": """\
+try:
+    from torch._inductor.custom_graph_pass import CustomGraphPass
+except ModuleNotFoundError:
+    class CustomGraphPass:
+        def __call__(self, graph):
+            return None
+
+        def uuid(self):
+            return self.__class__.__name__""",
+    },
     {
         "file": "vllm/compilation/decorators.py",
-        "desc": (
-            "Fix patched_inline_call signature. "
-            "PyTorch 2.5.1 uses (parent, func, args, kwargs) instead of "
-            "(self_: Any). The self_.f_code attribute does not exist in "
-            "2.5.1; use func.get_code() instead."
-        ),
-        "lines": "505-508",
+        "lines": "547-550",
+        "desc": "Adapt patched_inline_call to the PyTorch 2.5.1 callback signature.",
         "old": """\
         def patched_inline_call(self_: Any) -> Any:
             code = self_.f_code
@@ -100,29 +49,14 @@ PATCHES = [
             return inline_call(self_)""",
         "new": """\
         def patched_inline_call(parent, func, args, kwargs):
-            # [PyTorch 2.5.1 compat] Use func.get_code() instead of
-            # self_.f_code, which is not available in this version.
             code = func.get_code()
-
-            # Note: vLLM 0.15.x uses self.compilation_config directly
-            # (not self.vllm_config.compilation_config)
             self.compilation_config.traced_files.add(code.co_filename)
-
-            # Pass all four arguments as expected by PyTorch 2.5.1
             return inline_call(parent, func, args, kwargs)""",
     },
-    # ----------------------------------------------------------
-    # Patch 2: layer.py — Fix torch.Size during tracing
-    # ----------------------------------------------------------
     {
-        "file": "vllm/attention/layer.py",
-        "desc": (
-            "Replace torch.Size() with torch.empty().size. "
-            "In PyTorch 2.5.1, torch.Size() does not work correctly "
-            "during torch.compile tracing. torch.empty().size produces "
-            "a compatible result."
-        ),
-        "lines": "378-380",
+        "file": "vllm/model_executor/layers/attention/attention.py",
+        "lines": "437-440",
+        "desc": "Avoid torch.Size tracing issues on PyTorch 2.5.1.",
         "old": """\
                 output_shape = torch.Size(
                     (num_tokens, self.num_heads * self.head_size_v)
@@ -132,79 +66,50 @@ PATCHES = [
                     (num_tokens, self.num_heads * self.head_size_v)
                 ).size()""",
     },
-    # ----------------------------------------------------------
-    # Patch 3: piecewise_backend.py — Remove bundled_autograd_cache
-    #          context manager (serialize path)
-    # ----------------------------------------------------------
+    {
+        "file": "vllm/model_executor/models/openpangu.py",
+        "lines": "779-783",
+        "desc": "Avoid torch.Size tracing issues in OpenPangu attention output.",
+        "old": """\
+            output_shape=torch.Size(
+                [q.shape[0], q.shape[1] // self.head_dim * self.v_channels]
+            ),""",
+        "new": """\
+            output_shape=torch.empty(
+                [q.shape[0], q.shape[1] // self.head_dim * self.v_channels]
+            ).size(),""",
+        "required": False,
+    },
     {
         "file": "vllm/compilation/piecewise_backend.py",
+        "lines": "221-227",
         "desc": (
-            "Remove bundled_autograd_cache context manager around "
-            "serialization. torch._functorch.config.bundled_autograd_cache "
-            "does not exist in PyTorch 2.5.1."
+            "Remove bundled_autograd_cache patching during serialize because "
+            "that config flag does not exist on PyTorch 2.5.1."
         ),
-        "lines": "180-185",
         "old": """\
             with torch._functorch.config.patch("bundled_autograd_cache", True):
                 entry = fn.serialize()
 
                 f = io.BytesIO()
                 StandaloneCompiledArtifactsPickler(f).dump(entry)
-                result = f.getvalue()""",
+                result = f.getvalue()
+            return result""",
         "new": """\
             entry = fn.serialize()
 
             f = io.BytesIO()
             StandaloneCompiledArtifactsPickler(f).dump(entry)
-            result = f.getvalue()""",
+            result = f.getvalue()
+            return result""",
     },
-    # ----------------------------------------------------------
-    # Patch 4: piecewise_backend.py — Remove bundled_autograd_cache
-    #          context manager (compile path)
-    # ----------------------------------------------------------
-    {
-        "file": "vllm/compilation/piecewise_backend.py",
-        "desc": (
-            "Remove bundled_autograd_cache context manager around "
-            "compilation. Same reason as above — the config option is "
-            "unavailable in PyTorch 2.5.1."
-        ),
-        "lines": "243-254",
-        "old": """\
-                with (
-                    torch._functorch.config.patch("bundled_autograd_cache", True),
-                ):
-                    range_entry.runnable = self.vllm_backend.compiler_manager.compile(
-                        self.graph,
-                        args_list,
-                        self.vllm_backend.inductor_config,
-                        self.compilation_config,
-                        compile_range=range_entry.compile_range,
-                        graph_index=self.piecewise_compile_index,
-                        num_graphs=self.total_piecewise_compiles,
-                    )""",
-        "new": """\
-                range_entry.runnable = self.vllm_backend.compiler_manager.compile(
-                    self.graph,
-                    args_list,
-                    self.vllm_backend.inductor_config,
-                    self.compilation_config,
-                    compile_range=range_entry.compile_range,
-                    graph_index=self.piecewise_compile_index,
-                    num_graphs=self.total_piecewise_compiles,
-                )""",
-    },
-    # ----------------------------------------------------------
-    # Patch 5: compiler_interface.py — Comment out unavailable config
-    # ----------------------------------------------------------
     {
         "file": "vllm/compilation/compiler_interface.py",
+        "lines": "778-780",
         "desc": (
-            "Comment out bundled_autograd_cache assignment. "
-            "This attribute does not exist in torch._functorch.config "
-            "on PyTorch 2.5.1 and will raise AttributeError."
+            "Skip bundled_autograd_cache assignment because the attribute is "
+            "absent on PyTorch 2.5.1."
         ),
-        "lines": "654-656",
         "old": """\
 def set_functorch_config() -> None:
     if not envs.VLLM_USE_MEGA_AOT_ARTIFACT:
@@ -212,387 +117,106 @@ def set_functorch_config() -> None:
         "new": """\
 def set_functorch_config() -> None:
     if not envs.VLLM_USE_MEGA_AOT_ARTIFACT:
-        # [PyTorch 2.5.1 compat] bundled_autograd_cache is not available.
-        # TODO: Restore this line after upgrading to PyTorch 2.9+
-        # torch._functorch.config.bundled_autograd_cache = False
         pass""",
     },
-    # ----------------------------------------------------------
-    # Patch 6: parallel_state.py — Add List to typing imports
-    #          (must be applied BEFORE Patch 7)
-    # ----------------------------------------------------------
     {
         "file": "vllm/distributed/parallel_state.py",
-        "desc": (
-            "Add List to the typing import. Required by Patch 7 which "
-            "changes list[int] to List[int]. Without this import, "
-            "List would be undefined."
-        ),
-        "lines": "36",
-        "old": "from typing import Any, Optional",
-        "new": "from typing import Any, List, Optional",
+        "lines": "32",
+        "desc": "Import List so PyTorch 2.5 tracing does not trip on list[int].",
+        "old": "from typing import TYPE_CHECKING, Any, Protocol",
+        "new": "from typing import TYPE_CHECKING, Any, List, Protocol",
     },
-    # ----------------------------------------------------------
-    # Patch 7: parallel_state.py — Use List[int] instead of list[int]
-    # ----------------------------------------------------------
     {
         "file": "vllm/distributed/parallel_state.py",
-        "desc": (
-            "Replace built-in generic `list[int]` with `List[int]` from "
-            "typing. While Python 3.10 supports `list[int]` in annotations, "
-            "certain runtime introspection paths used by torch.compile / "
-            "FX tracing may fail to resolve it. Using `typing.List[int]` "
-            "is the safe, backward-compatible form."
-        ),
-        "lines": "173, 225",
-        # Replace ALL occurrences in the file
-        "count": 0,
+        "lines": "187,239",
+        "desc": "Replace list[int] annotations with typing.List[int].",
         "old": "    output_shape: list[int],",
         "new": "    output_shape: List[int],",
+        "count": 0,
     },
-    # ----------------------------------------------------------
-    # Patch 8: vllm/transformers_utils/config.py - add qwen3_5
-    # ----------------------------------------------------------
-    {
-        "file": "vllm/transformers_utils/config.py",
-        "desc": ("support qwen3_5 in vllm0.15.1"),
-        "lines": "101",
-        "old": """\
-_CONFIG_REGISTRY: dict[str, type[PretrainedConfig]] = LazyConfigDict(
-    afmoe="AfmoeConfig",
-    bagel="BagelConfig",
-    chatglm="ChatGLMConfig",
-    deepseek_vl_v2="DeepseekVLV2Config",
-    deepseek_v32="DeepseekV3Config",
-    flex_olmo="FlexOlmoConfig",
-    hunyuan_vl="HunYuanVLConfig",
-    isaac="IsaacConfig",
-    kimi_linear="KimiLinearConfig",
-    kimi_vl="KimiVLConfig",
-    kimi_k25="KimiK25Config",
-    RefinedWeb="RWConfig",  # For tiiuae/falcon-40b(-instruct)
-    RefinedWebModel="RWConfig",  # For tiiuae/falcon-7b(-instruct)
-    jais="JAISConfig",
-    mlp_speculator="MLPSpeculatorConfig",
-    medusa="MedusaConfig",
-    midashenglm="MiDashengLMConfig",
-    eagle="EAGLEConfig",
-    speculators="SpeculatorsConfig",
-    nemotron="NemotronConfig",
-    olmo3="Olmo3Config",
-    ovis="OvisConfig",
-    ultravox="UltravoxConfig",
-    step3_vl="Step3VLConfig",
-    step3_text="Step3TextConfig",
-    step3p5="Step3p5Config",
-    qwen3_asr="Qwen3ASRConfig",
-    qwen3_next="Qwen3NextConfig",
-    lfm2_moe="Lfm2MoeConfig",
-    tarsier2="Tarsier2Config",
-)""",
-        "new": """\
-_CONFIG_REGISTRY: dict[str, type[PretrainedConfig]] = LazyConfigDict(
-    afmoe="AfmoeConfig",
-    bagel="BagelConfig",
-    chatglm="ChatGLMConfig",
-    deepseek_vl_v2="DeepseekVLV2Config",
-    deepseek_v32="DeepseekV3Config",
-    flex_olmo="FlexOlmoConfig",
-    hunyuan_vl="HunYuanVLConfig",
-    isaac="IsaacConfig",
-    kimi_linear="KimiLinearConfig",
-    kimi_vl="KimiVLConfig",
-    kimi_k25="KimiK25Config",
-    RefinedWeb="RWConfig",  # For tiiuae/falcon-40b(-instruct)
-    RefinedWebModel="RWConfig",  # For tiiuae/falcon-7b(-instruct)
-    jais="JAISConfig",
-    mlp_speculator="MLPSpeculatorConfig",
-    medusa="MedusaConfig",
-    midashenglm="MiDashengLMConfig",
-    eagle="EAGLEConfig",
-    speculators="SpeculatorsConfig",
-    nemotron="NemotronConfig",
-    olmo3="Olmo3Config",
-    ovis="OvisConfig",
-    ultravox="UltravoxConfig",
-    step3_vl="Step3VLConfig",
-    step3_text="Step3TextConfig",
-    step3p5="Step3p5Config",
-    qwen3_asr="Qwen3ASRConfig",
-    qwen3_next="Qwen3NextConfig",
-    qwen3_5="Qwen3_5Config",
-    qwen3_5_moe="Qwen3_5MoeConfig",
-    lfm2_moe="Lfm2MoeConfig",
-    tarsier2="Tarsier2Config",
-)""",
-    },
-    # ----------------------------------------------------------
-    # Patch 9: vllm/transformers_utils/configs/__init__.py
-    #                       add qwen3_5
-    # ----------------------------------------------------------
-    {
-        "file": "vllm/transformers_utils/configs/__init__.py",
-        "desc": ("support qwen3_5 in vllm0.15.1"),
-        "lines": "55",
-        "old": """\
-_CLASS_TO_MODULE: dict[str, str] = {
-    "AfmoeConfig": "vllm.transformers_utils.configs.afmoe",
-    "BagelConfig": "vllm.transformers_utils.configs.bagel",
-    "ChatGLMConfig": "vllm.transformers_utils.configs.chatglm",
-    "DeepseekVLV2Config": "vllm.transformers_utils.configs.deepseek_vl2",
-    "DotsOCRConfig": "vllm.transformers_utils.configs.dotsocr",
-    "EAGLEConfig": "vllm.transformers_utils.configs.eagle",
-    "FlexOlmoConfig": "vllm.transformers_utils.configs.flex_olmo",
-    "HunYuanVLConfig": "vllm.transformers_utils.configs.hunyuan_vl",
-    "HunYuanVLTextConfig": "vllm.transformers_utils.configs.hunyuan_vl",
-    "HunYuanVLVisionConfig": "vllm.transformers_utils.configs.hunyuan_vl",
-    "IsaacConfig": "vllm.transformers_utils.configs.isaac",
-    # RWConfig is for the original tiiuae/falcon-40b(-instruct) and
-    # tiiuae/falcon-7b(-instruct) models. Newer Falcon models will use the
-    # `FalconConfig` class from the official HuggingFace transformers library.
-    "RWConfig": "vllm.transformers_utils.configs.falcon",
-    "JAISConfig": "vllm.transformers_utils.configs.jais",
-    "Lfm2MoeConfig": "vllm.transformers_utils.configs.lfm2_moe",
-    "MedusaConfig": "vllm.transformers_utils.configs.medusa",
-    "MiDashengLMConfig": "vllm.transformers_utils.configs.midashenglm",
-    "MLPSpeculatorConfig": "vllm.transformers_utils.configs.mlp_speculator",
-    "MoonViTConfig": "vllm.transformers_utils.configs.moonvit",
-    "KimiLinearConfig": "vllm.transformers_utils.configs.kimi_linear",
-    "KimiVLConfig": "vllm.transformers_utils.configs.kimi_vl",
-    "KimiK25Config": "vllm.transformers_utils.configs.kimi_k25",
-    "NemotronConfig": "vllm.transformers_utils.configs.nemotron",
-    "NemotronHConfig": "vllm.transformers_utils.configs.nemotron_h",
-    "Olmo3Config": "vllm.transformers_utils.configs.olmo3",
-    "OvisConfig": "vllm.transformers_utils.configs.ovis",
-    "PixelShuffleSiglip2VisionConfig": "vllm.transformers_utils.configs.isaac",
-    "RadioConfig": "vllm.transformers_utils.configs.radio",
-    "SpeculatorsConfig": "vllm.transformers_utils.configs.speculators.base",
-    "UltravoxConfig": "vllm.transformers_utils.configs.ultravox",
-    "Step3VLConfig": "vllm.transformers_utils.configs.step3_vl",
-    "Step3VisionEncoderConfig": "vllm.transformers_utils.configs.step3_vl",
-    "Step3TextConfig": "vllm.transformers_utils.configs.step3_vl",
-    "Step3p5Config": "vllm.transformers_utils.configs.step3p5",
-    "Qwen3ASRConfig": "vllm.transformers_utils.configs.qwen3_asr",
-    "Qwen3NextConfig": "vllm.transformers_utils.configs.qwen3_next",
-    "Tarsier2Config": "vllm.transformers_utils.configs.tarsier2",
-    # Special case: DeepseekV3Config is from HuggingFace Transformers
-    "DeepseekV3Config": "transformers",
-}""",
-        "new": """\
-_CLASS_TO_MODULE: dict[str, str] = {
-    "AfmoeConfig": "vllm.transformers_utils.configs.afmoe",
-    "BagelConfig": "vllm.transformers_utils.configs.bagel",
-    "ChatGLMConfig": "vllm.transformers_utils.configs.chatglm",
-    "DeepseekVLV2Config": "vllm.transformers_utils.configs.deepseek_vl2",
-    "DotsOCRConfig": "vllm.transformers_utils.configs.dotsocr",
-    "EAGLEConfig": "vllm.transformers_utils.configs.eagle",
-    "FlexOlmoConfig": "vllm.transformers_utils.configs.flex_olmo",
-    "HunYuanVLConfig": "vllm.transformers_utils.configs.hunyuan_vl",
-    "HunYuanVLTextConfig": "vllm.transformers_utils.configs.hunyuan_vl",
-    "HunYuanVLVisionConfig": "vllm.transformers_utils.configs.hunyuan_vl",
-    "IsaacConfig": "vllm.transformers_utils.configs.isaac",
-    # RWConfig is for the original tiiuae/falcon-40b(-instruct) and
-    # tiiuae/falcon-7b(-instruct) models. Newer Falcon models will use the
-    # `FalconConfig` class from the official HuggingFace transformers library.
-    "RWConfig": "vllm.transformers_utils.configs.falcon",
-    "JAISConfig": "vllm.transformers_utils.configs.jais",
-    "Lfm2MoeConfig": "vllm.transformers_utils.configs.lfm2_moe",
-    "MedusaConfig": "vllm.transformers_utils.configs.medusa",
-    "MiDashengLMConfig": "vllm.transformers_utils.configs.midashenglm",
-    "MLPSpeculatorConfig": "vllm.transformers_utils.configs.mlp_speculator",
-    "MoonViTConfig": "vllm.transformers_utils.configs.moonvit",
-    "KimiLinearConfig": "vllm.transformers_utils.configs.kimi_linear",
-    "KimiVLConfig": "vllm.transformers_utils.configs.kimi_vl",
-    "KimiK25Config": "vllm.transformers_utils.configs.kimi_k25",
-    "NemotronConfig": "vllm.transformers_utils.configs.nemotron",
-    "NemotronHConfig": "vllm.transformers_utils.configs.nemotron_h",
-    "Olmo3Config": "vllm.transformers_utils.configs.olmo3",
-    "OvisConfig": "vllm.transformers_utils.configs.ovis",
-    "PixelShuffleSiglip2VisionConfig": "vllm.transformers_utils.configs.isaac",
-    "RadioConfig": "vllm.transformers_utils.configs.radio",
-    "SpeculatorsConfig": "vllm.transformers_utils.configs.speculators.base",
-    "UltravoxConfig": "vllm.transformers_utils.configs.ultravox",
-    "Step3VLConfig": "vllm.transformers_utils.configs.step3_vl",
-    "Step3VisionEncoderConfig": "vllm.transformers_utils.configs.step3_vl",
-    "Step3TextConfig": "vllm.transformers_utils.configs.step3_vl",
-    "Step3p5Config": "vllm.transformers_utils.configs.step3p5",
-    "Qwen3ASRConfig": "vllm.transformers_utils.configs.qwen3_asr",
-    "Qwen3NextConfig": "vllm.transformers_utils.configs.qwen3_next",
-    "Qwen3_5Config": "vllm_kunlun.transformers_utils.configs.qwen3_5",
-    "Qwen3_5TextConfig": "vllm_kunlun.transformers_utils.configs.qwen3_5",
-    "Qwen3_5MoeConfig": "vllm_kunlun.transformers_utils.configs.qwen3_5_moe",
-    "Qwen3_5MoeTextConfig": "vllm_kunlun.transformers_utils.configs.qwen3_5_moe",
-    "Tarsier2Config": "vllm.transformers_utils.configs.tarsier2",
-    # Special case: DeepseekV3Config is from HuggingFace Transformers
-    "DeepseekV3Config": "transformers",
-}""",
-    },
-    {
-        "file": "vllm/transformers_utils/configs/__init__.py",
-        "desc": ("support qwen3_5 in vllm0.15.1"),
-        "lines": "97",
-        "old": """\
-__all__ = [
-    "AfmoeConfig",
-    "BagelConfig",
-    "ChatGLMConfig",
-    "DeepseekVLV2Config",
-    "DeepseekV3Config",
-    "DotsOCRConfig",
-    "EAGLEConfig",
-    "FlexOlmoConfig",
-    "HunYuanVLConfig",
-    "HunYuanVLTextConfig",
-    "HunYuanVLVisionConfig",
-    "IsaacConfig",
-    "RWConfig",
-    "JAISConfig",
-    "Lfm2MoeConfig",
-    "MedusaConfig",
-    "MiDashengLMConfig",
-    "MLPSpeculatorConfig",
-    "MoonViTConfig",
-    "KimiLinearConfig",
-    "KimiVLConfig",
-    "KimiK25Config",
-    "NemotronConfig",
-    "NemotronHConfig",
-    "Olmo3Config",
-    "OvisConfig",
-    "PixelShuffleSiglip2VisionConfig",
-    "RadioConfig",
-    "SpeculatorsConfig",
-    "UltravoxConfig",
-    "Step3VLConfig",
-    "Step3VisionEncoderConfig",
-    "Step3TextConfig",
-    "Step3p5Config",
-    "Qwen3ASRConfig",
-    "Qwen3NextConfig",
-    "Tarsier2Config",
-]""",
-        "new": """\
-__all__ = [
-    "AfmoeConfig",
-    "BagelConfig",
-    "ChatGLMConfig",
-    "DeepseekVLV2Config",
-    "DeepseekV3Config",
-    "DotsOCRConfig",
-    "EAGLEConfig",
-    "FlexOlmoConfig",
-    "HunYuanVLConfig",
-    "HunYuanVLTextConfig",
-    "HunYuanVLVisionConfig",
-    "IsaacConfig",
-    "RWConfig",
-    "JAISConfig",
-    "Lfm2MoeConfig",
-    "MedusaConfig",
-    "MiDashengLMConfig",
-    "MLPSpeculatorConfig",
-    "MoonViTConfig",
-    "KimiLinearConfig",
-    "KimiVLConfig",
-    "KimiK25Config",
-    "NemotronConfig",
-    "NemotronHConfig",
-    "Olmo3Config",
-    "OvisConfig",
-    "PixelShuffleSiglip2VisionConfig",
-    "RadioConfig",
-    "SpeculatorsConfig",
-    "UltravoxConfig",
-    "Step3VLConfig",
-    "Step3VisionEncoderConfig",
-    "Step3TextConfig",
-    "Step3p5Config",
-    "Qwen3ASRConfig",
-    "Qwen3NextConfig",
-    "Qwen3_5Config",
-    "Qwen3_5TextConfig",
-    "Qwen3_5MoeConfig",
-    "Qwen3_5MoeTextConfig",
-    "Tarsier2Config",
-]""",
-    },
-    # ----------------------------------------------------------
-    # Patch 10: utils.py — Add backend="torch_native" to
-    #           apply_token_bitmask_inplace call
-    # ----------------------------------------------------------
     {
         "file": "vllm/v1/structured_output/utils.py",
+        "lines": "121",
         "desc": (
-            "Add backend='torch_native' parameter to "
-            "xgr.apply_token_bitmask_inplace call. Without this parameter, "
-            "the default backend may not be compatible with the Kunlun "
-            "platform on PyTorch 2.5.1."
+            "Force xgrammar torch-native backend to avoid backend selection "
+            "mismatches on Kunlun."
         ),
-        "lines": "119",
-        "old": (
-            "xgr.apply_token_bitmask_inplace(logits, grammar_bitmask, "
-            "indices=index_tensor)"
-        ),
+        "old": "        xgr.apply_token_bitmask_inplace(logits, grammar_bitmask, indices=index_tensor)",
         "new": (
-            "xgr.apply_token_bitmask_inplace(logits, grammar_bitmask, "
-            'indices=index_tensor, backend="torch_native")'
+            "        xgr.apply_token_bitmask_inplace("
+            'logits, grammar_bitmask, indices=index_tensor, backend="torch_native")'
         ),
+        "required": False,
+    },
+    {
+        "file": "vllm/compilation/wrapper.py",
+        "lines": "199-203",
+        "desc": "Fall back to nullcontext() when torch.compiler.set_stance is unavailable.",
+        "old": """\
+            ctx = (
+                nullcontext()
+                if self.first_compile or not self.evaluate_guards
+                else torch.compiler.set_stance("fail_on_recompile")
+            )""",
+        "new": """\
+            if self.first_compile or not self.evaluate_guards:
+                ctx = nullcontext()
+            elif hasattr(torch.compiler, "set_stance"):
+                ctx = torch.compiler.set_stance("fail_on_recompile")
+            else:
+                ctx = nullcontext()""",
+        "required": False,
     },
 ]
 
 
-# ============================================================
-# Core logic
-# ============================================================
-
-
 def get_full_path(relative_path: str) -> str:
-    """Construct the full file path from SITE_PACKAGES."""
     return os.path.join(SITE_PACKAGES, relative_path)
 
 
-def apply_patch(patch: dict, dry_run: bool = False) -> str:
-    """
-    Apply a single patch.
-    Returns: 'success', 'skipped', or 'failed'
-    """
-    file_path = get_full_path(patch["file"])
-    desc = patch["desc"]
-    # How many occurrences to replace: default 1, use 0 for all
-    count = patch.get("count", 1)
+def _backup_path(file_path: str) -> str:
+    return f"{file_path}.bak"
+
+
+def apply_patch(patch: dict[str, object], dry_run: bool = False) -> str:
+    file_path = get_full_path(str(patch["file"]))
+    required = bool(patch.get("required", True))
+    count = int(patch.get("count", 1))
 
     print(
         f"\n{'[DRY RUN] ' if dry_run else ''}"
         f"Patch: {patch['file']} (lines {patch['lines']})"
     )
-    print(f"  Description: {desc}")
+    print(f"  Description: {patch['desc']}")
 
-    # 1. Read the file
     try:
-        with open(file_path, "r", encoding="utf-8") as f:
-            content = f.read()
+        with open(file_path, "r", encoding="utf-8") as handle:
+            content = handle.read()
     except FileNotFoundError:
-        print(f"  FAIL: File not found: {file_path}")
-        return "failed"
+        if required:
+            print(f"  FAIL: File not found: {file_path}")
+            return "failed"
+        print(f"  SKIP: Optional file not found: {file_path}")
+        return "skipped"
 
-    # 2. Check if already patched (idempotent)
-    if patch["new"] in content and patch["old"] not in content:
+    old = str(patch["old"])
+    new = str(patch["new"])
+
+    if new in content and old not in content:
         print("  SKIP: Already patched.")
         return "skipped"
 
-    # 3. Verify the original code exists
-    if patch["old"] not in content:
-        print(
-            "  FAIL: Original code not found. The file may have been "
-            "modified or the vLLM version may differ."
-        )
-        return "failed"
+    if old not in content:
+        if required:
+            print("  FAIL: Original code not found.")
+            return "failed"
+        print("  SKIP: Optional patch target not found.")
+        return "skipped"
 
-    # Count how many occurrences will be replaced
-    num_occurrences = content.count(patch["old"])
-    replacements = num_occurrences if count == 0 else min(count, num_occurrences)
+    occurrences = content.count(old)
+    replacements = occurrences if count == 0 else min(count, occurrences)
     print(
-        f"  Found {num_occurrences} occurrence(s), "
+        f"  Found {occurrences} occurrence(s), "
         f"will replace {'all' if count == 0 else replacements}."
     )
 
@@ -600,52 +224,46 @@ def apply_patch(patch: dict, dry_run: bool = False) -> str:
         print("  OK: Would apply patch.")
         return "success"
 
-    # 4. Backup (only once per file, never overwrite existing .bak)
-    backup_path = file_path + ".bak"
+    backup_path = _backup_path(file_path)
     if not os.path.exists(backup_path):
         shutil.copy2(file_path, backup_path)
         print(f"  Backup created: {backup_path}")
     else:
-        print(f"  Backup already exists, not overwriting: {backup_path}")
+        print(f"  Backup already exists: {backup_path}")
 
-    # 5. Replace and write back
     if count == 0:
-        # Replace ALL occurrences
-        new_content = content.replace(patch["old"], patch["new"])
+        new_content = content.replace(old, new)
     else:
-        new_content = content.replace(patch["old"], patch["new"], count)
+        new_content = content.replace(old, new, count)
 
-    with open(file_path, "w", encoding="utf-8") as f:
-        f.write(new_content)
+    with open(file_path, "w", encoding="utf-8") as handle:
+        handle.write(new_content)
 
     print(f"  SUCCESS: Patch applied ({replacements} replacement(s)).")
     return "success"
 
 
-def revert_all():
-    """Restore all patched files from their .bak backups."""
+def revert_all() -> None:
     print("=" * 64)
     print("  Reverting all patches from .bak backups")
     print("=" * 64)
 
-    seen = set()
+    seen: set[str] = set()
     for patch in PATCHES:
-        file_path = get_full_path(patch["file"])
+        file_path = get_full_path(str(patch["file"]))
         if file_path in seen:
             continue
         seen.add(file_path)
 
-        backup_path = file_path + ".bak"
+        backup_path = _backup_path(file_path)
         if os.path.exists(backup_path):
             shutil.copy2(backup_path, file_path)
             print(f"  Restored: {file_path}")
         else:
             print(f"  No backup found for: {file_path}")
 
-    print("\nRevert complete.")
 
-
-def main():
+def main() -> None:
     dry_run = "--dry-run" in sys.argv
     revert = "--revert" in sys.argv
 
@@ -654,35 +272,28 @@ def main():
         return
 
     print("=" * 64)
-    print("  vLLM Compatibility Patch for PyTorch 2.5.1")
+    print("  vLLM 0.19.x Compatibility Patch for PyTorch 2.5.1")
+    print(f"  Site-packages: {SITE_PACKAGES}")
     print(f"  Total patches: {len(PATCHES)}")
     if dry_run:
-        print("  Mode: DRY RUN (no files will be modified)")
-    print("")
-    print("  NOTE: These patches are TEMPORARY. Remove them after")
-    print("        upgrading to PyTorch 2.9+.")
+        print("  Mode: DRY RUN")
     print("=" * 64)
 
     results = {"success": 0, "skipped": 0, "failed": 0}
-
     for patch in PATCHES:
         result = apply_patch(patch, dry_run=dry_run)
         results[result] += 1
 
     print("\n" + "=" * 64)
     print(
-        f"  Results: "
-        f"{results['success']} applied  |  "
-        f"{results['skipped']} skipped  |  "
-        f"{results['failed']} failed  |  "
-        f"{len(PATCHES)} total"
+        f"  Results: {results['success']} applied | "
+        f"{results['skipped']} skipped | {results['failed']} failed"
     )
     if not dry_run and results["success"] > 0:
-        print("  Original files backed up as .bak")
-        print("  To revert: python patch_torch251.py --revert")
+        print("  Original files are backed up as .bak")
+        print("  Revert with: python patch_torch251.py --revert")
     print("=" * 64)
 
-    # Exit with non-zero code if any patch failed
     if results["failed"] > 0:
         sys.exit(1)
 

--- a/vllm_kunlun/platforms/kunlun.py
+++ b/vllm_kunlun/platforms/kunlun.py
@@ -1,5 +1,6 @@
 """kunlun"""
 
+import importlib
 from typing import TYPE_CHECKING, Optional
 
 import psutil
@@ -17,6 +18,21 @@ else:
     VllmConfig = None
 
 logger = init_logger(__name__)
+
+
+def _resolve_backend_or_fallback(primary_backend: str, fallback_backend: str) -> str:
+    try:
+        importlib.import_module(primary_backend.rsplit(".", 1)[0])
+        return primary_backend
+    except Exception as exc:
+        logger.warning(
+            "Failed to import Kunlun attention backend %s; falling back to %s. "
+            "Original error: %s",
+            primary_backend,
+            fallback_backend,
+            exc,
+        )
+        return fallback_backend
 
 
 class KunlunPlatform(Platform):
@@ -145,6 +161,11 @@ class KunlunPlatform(Platform):
         return DeviceCapability(major=major, minor=minor)
 
     @classmethod
+    def num_compute_units(cls, device_id: int = 0) -> int:
+        """Return the hardware compute-unit count exposed through torch.cuda."""
+        return torch.cuda.get_device_properties(device_id).multi_processor_count
+
+    @classmethod
     def check_and_update_config(cls, vllm_config: "VllmConfig") -> None:
         """
         TODO Update here for v0.15.1
@@ -221,7 +242,8 @@ class KunlunPlatform(Platform):
         from vllm.config import CUDAGraphMode
 
         if (
-            envs.VLLM_ALL2ALL_BACKEND == "deepep_high_throughput"
+            getattr(parallel_config, "all2all_backend", None)
+            == "deepep_high_throughput"
             and parallel_config.data_parallel_size > 1
             and vllm_config.compilation_config.cudagraph_mode != CUDAGraphMode.NONE
         ):
@@ -249,6 +271,7 @@ class KunlunPlatform(Platform):
         cls,
         selected_backend: "AttentionBackendEnum",
         attn_selector_config: "AttentionSelectorConfig",
+        num_heads: int | None = None,
     ) -> str:
         """
             Returns the class of attention backend based on the selected backend and other parameters.
@@ -265,6 +288,7 @@ class KunlunPlatform(Platform):
         Returns:
             str: Class name of the attention backend.
         """
+        del selected_backend, num_heads
         if attn_selector_config.use_mla:
             if attn_selector_config.use_sparse:
                 logger.info_once("Using Sparse MLA backend on V1 engine.")
@@ -274,8 +298,10 @@ class KunlunPlatform(Platform):
                 )
             return "vllm_kunlun.v1.attention.backends.mla.flashmla.FlashMLABackend"
         elif not attn_selector_config.use_mla:
-            return (
-                "vllm_kunlun.v1.attention.backends.kunlun_attn.KunlunAttentionBackend"
+            return _resolve_backend_or_fallback(
+                "vllm_kunlun.v1.attention.backends.kunlun_attn."
+                "KunlunAttentionBackend",
+                "vllm.v1.attention.backends.triton_attn.TritonAttentionBackend",
             )
         else:
             return (
@@ -382,9 +408,17 @@ class KunlunPlatform(Platform):
         cls, parser: FlexibleArgumentParser | None = None
     ) -> None:
         from vllm_kunlun.quantization.awq import KunlunAWQConfig  # noqa
-        from vllm_kunlun.quantization.compressed_tensors import (  # noqa
-            KunlunCompressedTensorsConfig,
-        )
         from vllm_kunlun.quantization.gptq import KunlunGPTQConfig  # noqa
         from vllm_kunlun.quantization.kernels import _POSSIBLE_INT8_KERNELS  # noqa
         from vllm_kunlun.quantization.kernels import _POSSIBLE_KERNELS  # noqa
+
+        try:
+            from vllm_kunlun.quantization.compressed_tensors import (  # noqa: F401
+                KunlunCompressedTensorsConfig,
+            )
+        except Exception as exc:
+            logger.warning(
+                "Skipping compressed-tensors quantization registration during "
+                "platform pre-registration: %s",
+                exc,
+            )

--- a/vllm_kunlun/platforms/version.py
+++ b/vllm_kunlun/platforms/version.py
@@ -1,8 +1,8 @@
 """vllm_kunlun version.py"""
 
-vllm_version = "0.15.1"
+vllm_version = "0.19.0"
 
-xvllm_version_tuple = (0, 15, 1)
+xvllm_version_tuple = (0, 19, 0)
 
 
 def get_xvllm_version():

--- a/vllm_kunlun/quantization/kernels/__init__.py
+++ b/vllm_kunlun/quantization/kernels/__init__.py
@@ -1,4 +1,4 @@
-from vllm.model_executor.layers.quantization.kernels.scaled_mm import (
+from vllm.model_executor.kernels.linear import (
     _POSSIBLE_INT8_KERNELS,
 )
 from vllm.platforms import PlatformEnum

--- a/vllm_kunlun/quantization/kernels/exllama.py
+++ b/vllm_kunlun/quantization/kernels/exllama.py
@@ -19,13 +19,59 @@
 from typing import Optional
 
 import torch
-from vllm.model_executor.layers.quantization.kernels.mixed_precision import (
-    _POSSIBLE_KERNELS,
+from vllm.model_executor.kernels.linear import _POSSIBLE_KERNELS
+from vllm.model_executor.kernels.linear.mixed_precision import MPLinearLayerConfig
+from vllm.model_executor.kernels.linear.mixed_precision.exllama import (
     ExllamaLinearKernel,
 )
+from vllm.platforms import PlatformEnum, current_platform
 
 
 class KunlunExllamaLinearKernel(ExllamaLinearKernel):
+    @classmethod
+    def can_implement(cls, c: MPLinearLayerConfig) -> tuple[bool, str | None]:
+        if not current_platform.is_out_of_tree():
+            return super().can_implement(c)
+
+        if c.has_g_idx and c.partition_weight_shape[0] != c.full_weight_shape[0]:
+            return (
+                False,
+                "Act reordering currently not supported by Exllama, "
+                "when the input features are partitioned across devices",
+            )
+
+        if c.partition_weight_shape[1] % (32 // c.weight_type.size_bits) != 0:
+            return (
+                False,
+                "Output features must be a multiple of the pack factor "
+                "(32 / num_bits) so that we can correctly pack the zero points",
+            )
+
+        if c.act_type != torch.float16:
+            return False, "Exllama only supports float16 activations"
+
+        if c.weight_type not in cls.SUPPORTED_QUANT_TYPES:
+            return (
+                False,
+                f"Quant type ({c.weight_type}) not supported by Exllama, "
+                f"supported types are: {cls.SUPPORTED_QUANT_TYPES}",
+            )
+
+        if c.group_size <= 0:
+            return (
+                False,
+                f"Group size ({c.group_size}) must be positive, "
+                "Exllama does not support channelwise quantization",
+            )
+
+        if c.full_weight_shape[0] % c.group_size != 0:
+            return (
+                False,
+                f"Group size ({c.group_size}) does not evenly divide the number "
+                f"of input features ({c.full_weight_shape[0]})",
+            )
+
+        return True, None
 
     def apply_weights(
         self,
@@ -51,6 +97,11 @@ class KunlunExllamaLinearKernel(ExllamaLinearKernel):
         return output.reshape(out_shape)
 
 
-# remove ExllamaLinearKernel and add KunlunExllamaLinearKernel
-_POSSIBLE_KERNELS.remove(ExllamaLinearKernel)
-_POSSIBLE_KERNELS.append(KunlunExllamaLinearKernel)
+_POSSIBLE_KERNELS.setdefault(PlatformEnum.OOT, [])
+_POSSIBLE_KERNELS[PlatformEnum.OOT] = [
+    kernel
+    for kernel in _POSSIBLE_KERNELS[PlatformEnum.OOT]
+    if kernel is not ExllamaLinearKernel
+]
+if KunlunExllamaLinearKernel not in _POSSIBLE_KERNELS[PlatformEnum.OOT]:
+    _POSSIBLE_KERNELS[PlatformEnum.OOT].append(KunlunExllamaLinearKernel)

--- a/vllm_kunlun/quantization/kernels/scale_mm.py
+++ b/vllm_kunlun/quantization/kernels/scale_mm.py
@@ -19,7 +19,7 @@
 from typing import Optional
 
 import torch
-from vllm.model_executor.layers.quantization.kernels.scaled_mm import (
+from vllm.model_executor.kernels.linear.scaled_mm import (
     CutlassInt8ScaledMMLinearKernel,
     Int8ScaledMMLinearLayerConfig,
 )
@@ -27,7 +27,6 @@ from vllm.platforms import current_platform
 
 
 class KunlunScaledMMLinearKernel(CutlassInt8ScaledMMLinearKernel):
-
     @classmethod
     def is_supported(
         cls, compute_capability: int | None = None

--- a/vllm_kunlun/v1/sample/ops/topk_topp_sampler.py
+++ b/vllm_kunlun/v1/sample/ops/topk_topp_sampler.py
@@ -1,15 +1,19 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import importlib
 import os
 from typing import Optional
 
-import kunlun_ops
 import torch
 import torch.nn as nn
 from vllm.logger import init_logger
 
 logger = init_logger(__name__)
+
+
+def _get_kunlun_ops():
+    return importlib.import_module("kunlun_ops")
 
 
 class TopKTopPSampler(nn.Module):
@@ -23,8 +27,15 @@ class TopKTopPSampler(nn.Module):
     def __init__(self, logprobs_mode):
         super().__init__()
         self.logprobs_mode = logprobs_mode
-        logger.info_once("Using FlashInfer for top-p & top-k sampling.")
-        self.forward = self.forward_kunlun
+        self._disable_kunlun_sampling = logprobs_mode in (
+            "processed_logits",
+            "processed_logprobs",
+        )
+        if self._disable_kunlun_sampling:
+            self.forward = self.forward_native
+        else:
+            logger.info_once("Using Kunlun top-p & top-k sampling when available.")
+            self.forward = self.forward_kunlun
         self.apply_top_k_top_p = apply_top_k_top_p
 
     def forward_native(
@@ -56,6 +67,8 @@ class TopKTopPSampler(nn.Module):
         p: Optional[torch.Tensor],
     ) -> tuple[torch.Tensor, torch.Tensor | None]:
         """More optimized implementation for top-k and top-p sampling."""
+        if self._disable_kunlun_sampling:
+            return self.forward_native(logits, generators, k, p)
         if (k is None and p is None) or generators:
             if generators:
                 logger.debug_once(
@@ -64,10 +77,19 @@ class TopKTopPSampler(nn.Module):
                     "PyTorch-native implementation."
                 )
             return self.forward_native(logits, generators, k, p)
-        # flashinfer sampling functions expect contiguous logits.
-        # In flex_attn/triton_attn fp32 inference, logits can be non-contiguous
-        # because of slicing operation in logits_processor.
-        return flashinfer_sample(logits.contiguous(), k, p, generators), None
+        try:
+            # Kunlun sampling functions expect contiguous logits. In
+            # flex_attn/triton_attn fp32 inference, logits can be
+            # non-contiguous because of slicing operation in logits_processor.
+            return flashinfer_sample(logits.contiguous(), k, p, generators), None
+        except Exception as exc:
+            self._disable_kunlun_sampling = True
+            logger.warning_once(
+                "Kunlun sampling ops unavailable; falling back to "
+                "PyTorch-native top-k/top-p sampling. Original error: %s",
+                exc,
+            )
+            return self.forward_native(logits, generators, k, p)
 
 
 def apply_top_k_top_p(
@@ -196,6 +218,7 @@ def flashinfer_sample(
     """
     assert not (k is None and p is None)
     probs = logits.softmax(dim=-1, dtype=torch.float32)
+    kunlun_ops = _get_kunlun_ops()
     if k is None:
         # Top-p only.
         next_token_ids = kunlun_ops.top_p_sampling_from_probs(

--- a/vllm_kunlun/v1/worker/utils.py
+++ b/vllm_kunlun/v1/worker/utils.py
@@ -1,23 +1,191 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import math
 from collections import defaultdict
-from dataclasses import dataclass
-from typing import TYPE_CHECKING, Optional
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from itertools import product as iprod
+from typing import TYPE_CHECKING, Any, Optional
 
 import torch
-from vllm.attention.backends.abstract import AttentionBackend
-from vllm.config import ModelConfig, SchedulerConfig, VllmConfig
+from vllm.config import CacheConfig, ModelConfig, SchedulerConfig, VllmConfig
+from vllm.logger import init_logger
 from vllm.model_executor.models.interfaces import MultiModalEmbeddings
 from vllm.model_executor.models.utils import extract_layer_index
-from vllm.multimodal.cache import processor_only_cache_from_config
 from vllm.multimodal.registry import MultiModalRegistry
 from vllm.platforms import current_platform
-from vllm.v1.attention.backends.utils import AttentionMetadataBuilder
+from vllm.triton_utils import tl, triton
+from vllm.utils.math_utils import largest_power_of_2_divisor
+from vllm.utils.mem_utils import MemorySnapshot, format_gib
+from vllm.v1.attention.backend import (
+    AttentionBackend,
+    AttentionMetadataBuilder,
+    MultipleOf,
+)
 from vllm.v1.core.encoder_cache_manager import compute_mm_encoder_budget
-from vllm.v1.kv_cache_interface import KVCacheGroupSpec, KVCacheSpec
+from vllm.v1.kv_cache_interface import (
+    AttentionSpec,
+    EncoderOnlyAttentionSpec,
+    FullAttentionSpec,
+    KVCacheConfig,
+    KVCacheGroupSpec,
+    KVCacheSpec,
+    MambaSpec,
+    UniformTypeKVCacheSpecs,
+)
 
 if TYPE_CHECKING:
-    from vllm.attention.layer import Attention
+    from vllm.model_executor.layers.attention import Attention
+
+logger = init_logger(__name__)
+
+
+@triton.jit
+def _zero_kv_blocks_kernel(
+    seg_addrs_ptr,
+    block_ids_ptr,
+    n_blocks,
+    N_SEGS: tl.constexpr,
+    PAGE_SIZE_EL: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    """Zero KV cache blocks across all segments in a single launch."""
+    pid = tl.program_id(0)
+    chunks = PAGE_SIZE_EL // BLOCK_SIZE
+    work_per_block = N_SEGS * chunks
+    block_index = pid // work_per_block
+    if block_index >= n_blocks:
+        return
+    remainder = pid % work_per_block
+    seg_index = remainder // chunks
+    chunk_index = remainder % chunks
+    block_id = tl.load(block_ids_ptr + block_index)
+    seg_addr = tl.load(seg_addrs_ptr + seg_index)
+    ptr = tl.cast(seg_addr, tl.pointer_type(tl.int32))
+    offset = (
+        block_id.to(tl.int64) * PAGE_SIZE_EL + chunk_index.to(tl.int64) * BLOCK_SIZE
+    )
+    cols = tl.arange(0, BLOCK_SIZE).to(tl.int64)
+    tl.store(ptr + offset + cols, tl.zeros([BLOCK_SIZE], dtype=tl.int32))
+
+
+class KVBlockZeroer:
+    """Manage efficient zeroing of KV cache blocks via a Triton kernel."""
+
+    def __init__(self, device: torch.device, pin_memory: bool):
+        self.device = device
+        self.pin_memory = pin_memory
+        self._meta: tuple[torch.Tensor, int, int, int] | None = None
+        self._id_cap: int = 0
+        self._ids_pinned: torch.Tensor | None = None
+        self._ids_gpu: torch.Tensor | None = None
+
+    def init_meta(
+        self,
+        attn_groups_iter: Iterable["AttentionGroup"],
+        kernel_block_sizes: list[int],
+        cache_dtype: str,
+        runner_only_attn_layers: set[str],
+        static_forward_context: dict[str, Any],
+    ) -> None:
+        seen_ptrs: set[int] = set()
+        seg_addrs: list[int] = []
+        page_size_el: int | None = None
+
+        for group in attn_groups_iter:
+            spec = group.kv_cache_spec
+            if type(spec) is not FullAttentionSpec:
+                continue
+            if group.kv_cache_group_id >= len(kernel_block_sizes):
+                continue
+            kernel_bs = kernel_block_sizes[group.kv_cache_group_id]
+            ratio = spec.block_size // kernel_bs
+            block_dim = group.backend.get_kv_cache_block_dim(
+                kernel_bs,
+                spec.num_kv_heads,
+                spec.head_size,
+                cache_dtype_str=cache_dtype,
+            )
+
+            for layer_name in group.layer_names:
+                if layer_name in runner_only_attn_layers:
+                    continue
+                kv = static_forward_context[layer_name].kv_cache
+                if not isinstance(kv, torch.Tensor):
+                    continue
+                data_ptr = kv.data_ptr()
+                if data_ptr in seen_ptrs:
+                    continue
+                seen_ptrs.add(data_ptr)
+
+                element_size = kv.element_size()
+                cur_bytes = kv.stride(block_dim) * element_size
+                assert cur_bytes % 4 == 0
+                kernel_block_el = cur_bytes // 4
+                cur_page_el = kernel_block_el * ratio
+                if page_size_el is None:
+                    page_size_el = cur_page_el
+                else:
+                    assert (
+                        page_size_el == cur_page_el
+                    ), f"Non-uniform page sizes: {page_size_el} vs {cur_page_el}"
+
+                block_stride_bytes = cur_bytes
+                outer_dims = [
+                    dim
+                    for dim in range(block_dim)
+                    if kv.stride(dim) * element_size > block_stride_bytes
+                ]
+                outer_strides = [kv.stride(dim) * element_size for dim in outer_dims]
+                for outer in iprod(*(range(kv.shape[dim]) for dim in outer_dims)):
+                    off_bytes = sum(
+                        index * stride for index, stride in zip(outer, outer_strides)
+                    )
+                    seg_addrs.append(data_ptr + off_bytes)
+
+        if not seg_addrs or page_size_el is None:
+            self._meta = None
+            return
+
+        blk_size = min(largest_power_of_2_divisor(page_size_el), 1024)
+        self._id_cap = 8192
+        self._ids_pinned = torch.empty(
+            self._id_cap, dtype=torch.int64, pin_memory=self.pin_memory
+        )
+        self._ids_gpu = torch.empty(self._id_cap, dtype=torch.int64, device=self.device)
+        self._meta = (
+            torch.tensor(seg_addrs, dtype=torch.uint64, device=self.device),
+            page_size_el,
+            blk_size,
+            len(seg_addrs),
+        )
+
+    def zero_block_ids(self, block_ids: list[int]) -> None:
+        if not block_ids or self._meta is None:
+            return
+        seg_addrs, page_size_el, blk_size, n_segs = self._meta
+        n_blocks = len(block_ids)
+        if n_blocks > self._id_cap:
+            self._id_cap = n_blocks * 2
+            self._ids_pinned = torch.empty(
+                self._id_cap, dtype=torch.int64, pin_memory=self.pin_memory
+            )
+            self._ids_gpu = torch.empty(
+                self._id_cap, dtype=torch.int64, device=self.device
+            )
+        assert self._ids_pinned is not None and self._ids_gpu is not None
+        self._ids_pinned[:n_blocks].numpy()[:] = block_ids
+        idx = self._ids_gpu[:n_blocks]
+        idx.copy_(self._ids_pinned[:n_blocks], non_blocking=True)
+        grid = (n_blocks * n_segs * (page_size_el // blk_size),)
+        _zero_kv_blocks_kernel[grid](
+            seg_addrs,
+            idx,
+            n_blocks,
+            N_SEGS=n_segs,
+            PAGE_SIZE_EL=page_size_el,
+            BLOCK_SIZE=blk_size,
+        )
 
 
 class MultiModalBudget:
@@ -34,13 +202,15 @@ class MultiModalBudget:
         self.model_config = model_config
         self.scheduler_config = scheduler_config
         self.mm_registry = mm_registry
-        self.cache = cache = processor_only_cache_from_config(model_config, mm_registry)
+        # vLLM 0.19 moved MM processor cache creation onto the registry and
+        # requires a full VllmConfig. This utility only receives ModelConfig /
+        # SchedulerConfig, so keep the legacy helper import-safe here.
+        self.cache = cache = None
 
         self.max_model_len = model_config.max_model_len
         self.max_num_reqs = scheduler_config.max_num_seqs
 
         self.mm_limits = mm_registry.get_mm_limits_per_prompt(model_config, cache=cache)
-
         max_tokens_by_modality = (
             mm_registry.get_max_tokens_per_item_by_nonzero_modality(
                 model_config, cache=cache
@@ -55,15 +225,13 @@ class MultiModalBudget:
         self.encoder_compute_budget = encoder_compute_budget
         self.encoder_cache_size = encoder_cache_size
 
-        max_items_per_prompt_by_modality = dict[str, int]()
-        max_items_per_batch_by_modality = dict[str, int]()
+        max_items_per_prompt_by_modality = {}
+        max_items_per_batch_by_modality = {}
 
         for modality, max_tokens in max_tokens_by_modality.items():
-            (
-                max_items_per_prompt,
-                max_items_per_batch,
-            ) = self.get_max_items(modality, max_tokens)
-
+            max_items_per_prompt, max_items_per_batch = self.get_max_items(
+                modality, max_tokens
+            )
             max_items_per_prompt_by_modality[modality] = max_items_per_prompt
             max_items_per_batch_by_modality[modality] = max_items_per_batch
 
@@ -72,9 +240,7 @@ class MultiModalBudget:
         self.max_items_per_batch_by_modality = max_items_per_batch_by_modality
 
     def get_modality_with_max_tokens(self) -> str:
-        max_tokens_by_modality = self.max_tokens_by_modality
-        modality, _ = max(max_tokens_by_modality.items(), key=lambda x: x[1])
-
+        modality, _ = max(self.max_tokens_by_modality.items(), key=lambda item: item[1])
         return modality
 
     def get_encoder_budget(self) -> int:
@@ -88,20 +254,12 @@ class MultiModalBudget:
         if max_tokens_per_item == 0:
             return 0, 0
 
-        # Check how many items of this modality can be supported by
-        # the encoder budget.
         encoder_budget = self.get_encoder_budget()
-
-        # TODO: handle encoder-decoder models once we support them.
         if encoder_budget == 0:
             return 0, 0
 
         max_encoder_items_per_batch = encoder_budget // max_tokens_per_item
-
-        # Check how many items of this modality can be supported by
-        # the decoder budget.
         mm_limit = self.mm_limits[modality]
-
         max_items_per_prompt = max(
             1,
             min(mm_limit, self.max_model_len // max_tokens_per_item),
@@ -109,7 +267,6 @@ class MultiModalBudget:
 
         scheduler_config = self.scheduler_config
         max_num_reqs = self.max_num_reqs
-
         if not scheduler_config.enable_chunked_prefill:
             max_num_reqs = min(
                 max_num_reqs,
@@ -117,43 +274,117 @@ class MultiModalBudget:
             )
 
         max_decoder_items_per_batch = max_num_reqs * max_items_per_prompt
-
         max_items_per_batch = max(
             1,
             min(max_encoder_items_per_batch, max_decoder_items_per_batch),
         )
-
         return max_items_per_prompt, max_items_per_batch
 
 
 @dataclass
 class AttentionGroup:
     backend: type[AttentionBackend]
-    # When ubatching is enabled we will have a metadata builder for each ubatch
-    # so that if they use internal persistant buffers for cudagraphs, and they
-    # won't have to worry about conflicting with the other ubatches.
-    metadata_builders: list[AttentionMetadataBuilder]
     layer_names: list[str]
     kv_cache_spec: KVCacheSpec
+    kv_cache_group_id: int
+    metadata_builders: list[AttentionMetadataBuilder] = field(
+        default_factory=lambda: []
+    )
 
-    @staticmethod
-    def create_with_metadata_builders(
-        backend: type[AttentionBackend],
-        layer_names: list[str],
-        kv_cache_spec: KVCacheSpec,
+    def create_metadata_builders(
+        self,
         vllm_config: VllmConfig,
         device: torch.device,
+        kernel_block_size: int | None = None,
         num_metadata_builders: int = 1,
-    ) -> "AttentionGroup":
-        metadata_builders = [
-            backend.get_builder_cls()(kv_cache_spec, layer_names, vllm_config, device)
+    ) -> None:
+        kv_cache_spec_builder = (
+            self.kv_cache_spec.copy_with_new_block_size(kernel_block_size)
+            if kernel_block_size is not None
+            else self.kv_cache_spec
+        )
+        self.metadata_builders = [
+            self.backend.get_builder_cls()(
+                kv_cache_spec_builder,
+                self.layer_names,
+                vllm_config,
+                device,
+            )
             for _ in range(num_metadata_builders)
         ]
-        return AttentionGroup(backend, metadata_builders, layer_names, kv_cache_spec)
 
     def get_metadata_builder(self, ubatch_id: int = 0) -> AttentionMetadataBuilder:
         assert len(self.metadata_builders) > ubatch_id
         return self.metadata_builders[ubatch_id]
+
+
+def select_common_block_size(
+    kv_manager_block_size: int,
+    backends: list[type[AttentionBackend]],
+) -> int:
+    """Select a block size supported by all attention backends."""
+
+    def block_size_is_supported(
+        backends: list[type[AttentionBackend]], block_size: int
+    ) -> bool:
+        for backend in backends:
+            is_supported = False
+            for supported_size in backend.get_supported_kernel_block_sizes():
+                if isinstance(supported_size, int):
+                    if block_size == supported_size:
+                        is_supported = True
+                elif isinstance(supported_size, MultipleOf):
+                    if block_size % supported_size.base == 0:
+                        is_supported = True
+                else:
+                    raise ValueError(f"Unknown supported size: {supported_size}")
+            if not is_supported:
+                return False
+        return True
+
+    if block_size_is_supported(backends, kv_manager_block_size):
+        return kv_manager_block_size
+
+    all_int_supported_sizes = set(
+        supported_size
+        for backend in backends
+        for supported_size in backend.get_supported_kernel_block_sizes()
+        if isinstance(supported_size, int)
+    )
+
+    for supported_size in sorted(all_int_supported_sizes, reverse=True):
+        if kv_manager_block_size % supported_size != 0:
+            continue
+        if block_size_is_supported(backends, supported_size):
+            return supported_size
+    raise ValueError(f"No common block size for {kv_manager_block_size}.")
+
+
+def prepare_kernel_block_sizes(
+    kv_cache_config: KVCacheConfig, attn_groups: list[list[AttentionGroup]]
+) -> list[int]:
+    """Generate kernel block sizes matching each KV cache group."""
+    kernel_block_sizes = []
+    for kv_cache_gid, kv_cache_group in enumerate(kv_cache_config.kv_cache_groups):
+        kv_cache_spec = kv_cache_group.kv_cache_spec
+        if isinstance(kv_cache_spec, UniformTypeKVCacheSpecs):
+            kv_cache_spec = next(iter(kv_cache_spec.kv_cache_specs.values()))
+        if isinstance(kv_cache_spec, EncoderOnlyAttentionSpec):
+            continue
+        if isinstance(kv_cache_spec, AttentionSpec):
+            kv_manager_block_size = kv_cache_group.kv_cache_spec.block_size
+            group_backends = [group.backend for group in attn_groups[kv_cache_gid]]
+            selected_kernel_size = select_common_block_size(
+                kv_manager_block_size, group_backends
+            )
+            kernel_block_sizes.append(selected_kernel_size)
+        elif isinstance(kv_cache_spec, MambaSpec):
+            kernel_block_sizes.append(kv_cache_spec.block_size)
+        else:
+            raise NotImplementedError(
+                f"unknown kv cache spec {kv_cache_group.kv_cache_spec}"
+            )
+    return kernel_block_sizes
 
 
 def sanity_check_mm_encoder_outputs(
@@ -161,29 +392,57 @@ def sanity_check_mm_encoder_outputs(
     expected_num_items: int,
 ) -> None:
     """
-    Perform sanity checks for the result of
-    [`vllm.model_executor.models.SupportsMultiModal.get_multimodal_embeddings`][].
+    Perform sanity checks for the result of multimodal embedding generation.
     """
     assert isinstance(mm_embeddings, (list, tuple, torch.Tensor)), (
         "Expected multimodal embeddings to be a list/tuple of 2D tensors, "
-        f"or a single 3D tensor, but got {type(mm_embeddings)} "
-        "instead. This is most likely due to incorrect implementation "
-        "of the model's `get_multimodal_embeddings` method."
+        f"or a single 3D tensor, but got {type(mm_embeddings)} instead. "
+        "This is most likely due to incorrect implementation of the model's "
+        "`embed_multimodal` method."
     )
 
     assert len(mm_embeddings) == expected_num_items, (
-        "Expected number of multimodal embeddings to match number of "
-        f"input items: {expected_num_items}, but got {len(mm_embeddings)=} "
-        "instead. This is most likely due to incorrect implementation "
-        "of the model's `get_multimodal_embeddings` method."
+        "Expected number of multimodal embeddings to match number of input "
+        f"items: {expected_num_items}, but got {len(mm_embeddings)=} instead. "
+        "This is most likely due to incorrect implementation of the model's "
+        "`embed_multimodal` method."
     )
 
-    assert all(e.ndim == 2 for e in mm_embeddings), (
-        "Expected multimodal embeddings to be a sequence of 2D tensors, "
-        f"but got tensors with shapes {[e.shape for e in mm_embeddings]} "
-        "instead. This is most likely due to incorrect implementation "
-        "of the model's `get_multimodal_embeddings` method."
+    assert all(embed.ndim == 2 for embed in mm_embeddings), (
+        "Expected multimodal embeddings to be a sequence of 2D tensors, but "
+        f"got tensors with shapes {[embed.shape for embed in mm_embeddings]} "
+        "instead. This is most likely due to incorrect implementation of the "
+        "model's `embed_multimodal` method."
     )
+
+
+def request_memory(init_snapshot: MemorySnapshot, cache_config: CacheConfig) -> int:
+    """Validate that startup free memory satisfies the requested utilization."""
+    requested_memory = math.ceil(
+        init_snapshot.total_memory * cache_config.gpu_memory_utilization
+    )
+
+    if init_snapshot.free_memory < requested_memory:
+        if hasattr(current_platform, "is_kunlun") and current_platform.is_kunlun():
+            logger.warning(
+                "Kunlun reported free memory %s GiB below requested %s GiB; "
+                "clamping requested memory to the observed free memory and "
+                "continuing initialization.",
+                format_gib(init_snapshot.free_memory),
+                format_gib(requested_memory),
+            )
+            return int(init_snapshot.free_memory)
+        raise ValueError(
+            f"Free memory on device {init_snapshot.device_} "
+            f"({format_gib(init_snapshot.free_memory)}/"
+            f"{format_gib(init_snapshot.total_memory)} GiB) on startup "
+            f"is less than desired GPU memory utilization "
+            f"({cache_config.gpu_memory_utilization}, "
+            f"{format_gib(requested_memory)} GiB). Decrease GPU memory "
+            f"utilization or reduce GPU memory used by other processes."
+        )
+
+    return requested_memory
 
 
 def scatter_mm_placeholders(
@@ -191,17 +450,7 @@ def scatter_mm_placeholders(
     is_embed: Optional[torch.Tensor],
 ) -> torch.Tensor:
     """
-    Scatter the multimodal embeddings into a contiguous tensor that represents
-    the placeholder tokens.
-
-    [`vllm.multimodal.processing.PromptUpdateDetails.is_embed`][].
-
-    Args:
-        embeds: The multimodal embeddings.
-            Shape: `(num_embeds, embed_dim)`
-        is_embed: A boolean mask indicating which positions in the placeholder
-            tokens need to be filled with multimodal embeddings.
-            Shape: `(num_placeholders, num_embeds)`
+    Scatter multimodal embeddings into a contiguous placeholder tensor.
     """
     if is_embed is None:
         return embeds
@@ -218,35 +467,19 @@ def gather_mm_placeholders(
     placeholders: torch.Tensor,
     is_embed: Optional[torch.Tensor],
 ) -> torch.Tensor:
-    """
-    Reconstructs the embeddings from the placeholder tokens.
-
-    This is the operation of [`scatter_mm_placeholders`]
-    [vllm.v1.worker.utils.scatter_mm_placeholders].
-    """
+    """Reconstruct embeddings from placeholder tokens."""
     if is_embed is None:
         return placeholders
-
     return placeholders[is_embed]
 
 
 def add_kv_sharing_layers_to_kv_cache_groups(
     shared_kv_cache_layers: dict[str, str],
     kv_cache_groups: list[KVCacheGroupSpec],
-    runner_only_attn_layers: Optional[set[str]] = None,
+    runner_only_attn_layers: set[str] | None = None,
 ) -> None:
     """
-    Sets up KV cache sharing by reusing the allocated KV caches in `kv_caches`
-    for layers that do not allocate its own KV cache, based on the mapping in
-    `shared_kv_cache_layers`. Adds these layers to the corresponding KV cache
-    group, which is needed to ensure that attention metadata is assigned later.
-
-    Args:
-        shared_kv_cache_layers: Layer pairings for cross-layer KV sharing.
-            If an Attention layer `layer_name` is in the keys of this dict, it
-            means this layer will perform attention using the keys and values
-            from the KV cache of `shared_kv_cache_layers[layer_name]`.
-        kv_cache_groups: The KV cache groups of the model.
+    Reuse allocated KV caches for layers participating in KV sharing.
     """
     layer_to_kv_cache_group: dict[str, KVCacheGroupSpec] = {}
     for kv_cache_group in kv_cache_groups:
@@ -268,25 +501,10 @@ def bind_kv_cache(
     num_attn_module: Optional[int] = 1,
 ) -> None:
     """
-    Bind the allocated KV cache to both ModelRunner and forward context so
-    that the KV cache can be used in the forward pass.
-
-    This function:
-      1) Fills the ModelRunner's kv cache list (`runner_kv_caches`) with
-         kv_caches.
-      2) Associates each attention layer in the `forward_context` with its
-         corresponding KV cache in kv_caches.
-
-    Args:
-        kv_caches: The allocated kv_caches with layer names as keys.
-        forward_context: The global forward context containing all Attention
-            layers with layer names as keys.
-        runner_kv_caches: The kv_cache declared by ModelRunner.
+    Bind allocated KV cache tensors to the runner and forward context.
     """
-    # Bind kv_caches to ModelRunner
     assert len(runner_kv_caches) == 0
 
-    # Convert kv_caches dict to a list of tensors in the order of layer_index.
     index2name = defaultdict(list)
     for layer_name in kv_caches:
         index2name[extract_layer_index(layer_name, num_attn_module)].append(layer_name)
@@ -294,53 +512,42 @@ def bind_kv_cache(
     for layer_index in sorted(index2name.keys()):
         layer_names = index2name[layer_index]
         if len(layer_names) > 1:
-            # One typical case is encoder-decoder model, e.g., bart.
-            # The cross attention and self attention in the same decoder layer
-            # has different layer_name but the same layer_index.
-
-            # TODO - analyze where runner_kv_caches is used and the right
-            # way to ensure it properly reflects multiple attention layers
-            # in the same decoder block.
             if (
                 current_platform.is_kunlun()
-                or current_platform.is_cuda()
+                or current_platform.is_cuda_alike()
                 or current_platform.is_xpu()
+                or current_platform.is_cpu()
             ):
-                # We know that the GPU runner is not impacted by this
-                # case. Some test code depends on runner_kv_caches, but
-                # not in a way that's impacted by ignoring this.
                 pass
             else:
                 raise NotImplementedError
-        layer_name = layer_names[0]
-        runner_kv_caches.append(kv_caches[layer_name])
+        for layer_name in layer_names:
+            runner_kv_caches.append(kv_caches[layer_name])
 
-    # Bind kv_caches to forward context
     for layer_name, kv_cache in kv_caches.items():
-        # NOTE: Use list because of v0 PP virtual engine.
-        forward_context[layer_name].kv_cache = [kv_cache]
+        forward_context[layer_name].kv_cache = kv_cache
 
 
 def is_residual_scattered_for_sp(
     vllm_config: VllmConfig, num_input_tokens: int
 ) -> bool:
-    """Check if the residual tensor is scattered for sequence parallelism.
-
-    The residual tensor is scattered across tensor parallel ranks when sequence
-    parallelism and tensor parallelism is enabled, and the number of
-    input tokens is one of the compilation sizes.
-    """
-    if not vllm_config.compilation_config.pass_config.enable_sequence_parallelism:
+    """Check whether the residual tensor is sequence-parallel scattered."""
+    if not vllm_config.compilation_config.pass_config.enable_sp:
         return False
 
     tp = vllm_config.parallel_config.tensor_parallel_size
-
     if tp == 1:
         return False
 
-    # When sequence parallelism is enabled, we always pad num_input_tokens
-    # to be a multiple of tensor_parallel_size (tp) earlier.
     assert num_input_tokens % tp == 0
 
-    # Currently, SP is only enabled for static size fx graphs.
-    return num_input_tokens in vllm_config.compilation_config.compile_sizes
+    if (
+        not vllm_config.compilation_config.splitting_ops
+        or vllm_config.compilation_config.use_inductor_graph_partition
+    ):
+        return True
+
+    compile_sizes = vllm_config.compilation_config.compile_sizes
+    if compile_sizes is None:
+        return False
+    return num_input_tokens in compile_sizes

--- a/vllm_kunlun/v1/worker/utils.py
+++ b/vllm_kunlun/v1/worker/utils.py
@@ -83,7 +83,7 @@ class KVBlockZeroer:
     def init_meta(
         self,
         attn_groups_iter: Iterable["AttentionGroup"],
-        kernel_block_sizes: list[int],
+        kernel_block_sizes: list[int | None],
         cache_dtype: str,
         runner_only_attn_layers: set[str],
         static_forward_context: dict[str, Any],
@@ -99,6 +99,8 @@ class KVBlockZeroer:
             if group.kv_cache_group_id >= len(kernel_block_sizes):
                 continue
             kernel_bs = kernel_block_sizes[group.kv_cache_group_id]
+            if kernel_bs is None:
+                continue
             ratio = spec.block_size // kernel_bs
             block_dim = group.backend.get_kv_cache_block_dim(
                 kernel_bs,
@@ -362,14 +364,15 @@ def select_common_block_size(
 
 def prepare_kernel_block_sizes(
     kv_cache_config: KVCacheConfig, attn_groups: list[list[AttentionGroup]]
-) -> list[int]:
+) -> list[int | None]:
     """Generate kernel block sizes matching each KV cache group."""
-    kernel_block_sizes = []
+    kernel_block_sizes: list[int | None] = []
     for kv_cache_gid, kv_cache_group in enumerate(kv_cache_config.kv_cache_groups):
         kv_cache_spec = kv_cache_group.kv_cache_spec
         if isinstance(kv_cache_spec, UniformTypeKVCacheSpecs):
             kv_cache_spec = next(iter(kv_cache_spec.kv_cache_specs.values()))
         if isinstance(kv_cache_spec, EncoderOnlyAttentionSpec):
+            kernel_block_sizes.append(None)
             continue
         if isinstance(kv_cache_spec, AttentionSpec):
             kv_manager_block_size = kv_cache_group.kv_cache_spec.block_size


### PR DESCRIPTION
## Summary
- upgrade `vllm-kunlun` from `0.15.1` to `0.19.0`
- align package metadata, docs, and CI references with `vllm 0.19.0`
- add the missing `0.19.x` compatibility shims and request-path fixes needed to start the OpenAI server successfully on the provided Kunlun environment

<details>
<summary>Before</summary>

### Readiness
```text
mode=before
launcher_pid=196063
WAIT attempt=1 2026-04-10T12:29:46+08:00
EXITED attempt=2 2026-04-10T12:29:56+08:00
client_status=999
```

### Service Log
```text
/root/miniconda/envs/python310_torch25_cuda/lib/python3.10/site-packages/xpytorch_import_hook.py:6: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
  import pkg_resources
Traceback (most recent call last):
  File "/root/miniconda/envs/python310_torch25_cuda/lib/python3.10/site-packages/xpytorch_import_hook.py", line 80, in _custom_import
    import torch_xmlir
  File "/root/miniconda/envs/python310_torch25_cuda/lib/python3.10/site-packages/xpytorch_import_hook.py", line 134, in _custom_import
    module = builtins.__origin__import__(
  File "/root/miniconda/envs/python310_torch25_cuda/lib/python3.10/site-packages/torch_xmlir/__init__.py", line 52, in <module>
    from . import _XMLIRC
  File "/root/miniconda/envs/python310_torch25_cuda/lib/python3.10/site-packages/xpytorch_import_hook.py", line 134, in _custom_import
    module = builtins.__origin__import__(
ImportError: /root/miniconda/envs/python310_torch25_cuda/lib/python3.10/site-packages/torch_xmlir/_XMLIRC.cpython-310-x86_64-linux-gnu.so: undefined symbol: cudaHostPointerGetAttributes, version libcudart.so.11.0
WARNING: import hook error: /root/miniconda/envs/python310_torch25_cuda/lib/python3.10/site-packages/torch_xmlir/_XMLIRC.cpython-310-x86_64-linux-gnu.so: undefined symbol: cudaHostPointerGetAttributes, version libcudart.so.11.0
================================================================================
WARNING: Libraries loaded from different directories!
This may cause version mismatch issues.
--------------------------------------------------------------------------------
Directory: /root/miniconda/envs/python310_torch25_cuda/xcudart/lib
  - libcuda.so.1
  - libcuda.so.1
  - libxpurt.so.2
  - libcupti.so.11
  - libxpuml.so.1
Directory: /usr/local/cuda/lib64
  - libcudart.so
================================================================================
INFO 04-10 12:29:47 [__init__.py:44] Available plugins for group vllm.platform_plugins:
INFO 04-10 12:29:47 [__init__.py:46] - kunlun -> vllm_kunlun:register
INFO 04-10 12:29:47 [__init__.py:49] All plugins in this group will be loaded. Set `VLLM_PLUGINS` to control which plugins to load.
INFO 04-10 12:29:47 [__init__.py:64] [KunlunPlugin] register() pid=196070
INFO 04-10 12:29:47 [__init__.py:70] [KunlunPlugin] _kunlun native extension loaded
INFO 04-10 12:29:47 [__init__.py:79] [KunlunPlugin] vllm_utils_wrapper loaded and patched
INFO 04-10 12:29:47 [__init__.py:104] [KunlunPlugin] import_hook() ok
INFO 04-10 12:29:48 [__init__.py:123] [KunlunPlugin] registered Qwen3ReasoningParser override (lazy)
INFO 04-10 12:29:48 [__init__.py:128] [KunlunPlugin] register() done
INFO 04-10 12:29:48 [__init__.py:64] [KunlunPlugin] register() pid=196070
INFO 04-10 12:29:48 [__init__.py:70] [KunlunPlugin] _kunlun native extension loaded
INFO 04-10 12:29:48 [__init__.py:79] [KunlunPlugin] vllm_utils_wrapper loaded and patched
INFO 04-10 12:29:48 [__init__.py:104] [KunlunPlugin] import_hook() ok
INFO 04-10 12:29:48 [__init__.py:123] [KunlunPlugin] registered Qwen3ReasoningParser override (lazy)
INFO 04-10 12:29:48 [__init__.py:128] [KunlunPlugin] register() done
INFO 04-10 12:29:48 [__init__.py:239] Platform plugin kunlun is activated
/root/miniconda/envs/python310_torch25_cuda/lib/python3.10/site-packages/torch/cuda/__init__.py:905: UserWarning: CUDA initialization: The NVIDIA driver on your system is too old (found version 10020). Please update your GPU driver by downloading and installing a new version from the URL: http://www.nvidia.com/Download/index.aspx Alternatively, go to: https://pytorch.org to install a PyTorch version that has been compiled with your version of the CUDA driver. (Triggered internally at ../c10/cuda/CUDAFunctions.cpp:108.)
  r = torch._C._cuda_getDeviceCount() if nvml_count < 0 else nvml_count
No CUDA runtime is found, using CUDA_HOME='/usr/local/cuda'
WARNING 04-10 12:29:51 [registry.py:915] Model architecture Qwen2VLForConditionalGeneration is already registered, and will be overwritten by the new model class vllm_kunlun.models.qwen2_vl:Qwen2VLForConditionalGeneration.
WARNING 04-10 12:29:51 [registry.py:915] Model architecture Qwen2_5_VLForConditionalGeneration is already registered, and will be overwritten by the new model class vllm_kunlun.models.qwen2_5_vl:Qwen2_5_VLForConditionalGeneration.
WARNING 04-10 12:29:51 [registry.py:915] Model architecture Qwen3NextForCausalLM is already registered, and will be overwritten by the new model class vllm_kunlun.models.qwen3_next:Qwen3NextForCausalLM.
WARNING 04-10 12:29:51 [registry.py:915] Model architecture GptOssForCausalLM is already registered, and will be overwritten by the new model class vllm_kunlun.models.gpt_oss:GptOssForCausalLM.
WARNING 04-10 12:29:51 [registry.py:915] Model architecture InternLM2ForCausalLM is already registered, and will be overwritten by the new model class vllm_kunlun.models.internlm2:InternLM2ForCausalLM.
WARNING 04-10 12:29:51 [registry.py:915] Model architecture InternVLChatModel is already registered, and will be overwritten by the new model class vllm_kunlun.models.internvl:InternVLChatModel.
WARNING 04-10 12:29:51 [registry.py:915] Model architecture InternS1ForConditionalGeneration is already registered, and will be overwritten by the new model class vllm_kunlun.models.interns1:InternS1ForConditionalGeneration.
WARNING 04-10 12:29:51 [registry.py:915] Model architecture SeedOssForCausalLM is already registered, and will be overwritten by the new model class vllm_kunlun.models.seed_oss:SeedOssForCausalLM.
WARNING 04-10 12:29:51 [registry.py:915] Model architecture MiMoV2FlashForCausalLM is already registered, and will be overwritten by the new model class vllm_kunlun.models.mimo_v2_flash:MiMoV2FlashForCausalLM.
WARNING 04-10 12:29:51 [registry.py:915] Model architecture GptOssForCausalLM is already registered, and will be overwritten by the new model class vllm_kunlun.models.gpt_oss:GptOssForCausalLM.
WARNING 04-10 12:29:51 [registry.py:915] Model architecture DeepseekV3ForCausalLM is already registered, and will be overwritten by the new model class vllm_kunlun.models.deepseek_v2:DeepseekV3ForCausalLM.
WARNING 04-10 12:29:51 [registry.py:915] Model architecture DeepseekV32ForCausalLM is already registered, and will be overwritten by the new model class vllm_kunlun.models.deepseek_v2:DeepseekV3ForCausalLM.
WARNING 04-10 12:29:51 [registry.py:915] Model architecture DeepSeekMTPModel is already registered, and will be overwritten by the new model class vllm_kunlun.models.deepseek_mtp:DeepSeekMTP.
WARNING 04-10 12:29:51 [registry.py:915] Model architecture GlmMoeDsaForCausalLM is already registered, and will be overwritten by the new model class vllm_kunlun.models.deepseek_v2:GlmMoeDsaForCausalLM.
WARNING 04-10 12:29:51 [registry.py:915] Model architecture Qwen3_5MoeForConditionalGeneration is already registered, and will be overwritten by the new model class vllm_kunlun.models.qwen3_5:Qwen3_5MoeForConditionalGeneration.
ERROR 04-10 12:29:51 [config.py:29] Failed to import Triton kernels. Please make sure your triton version is compatible. Error: No module named 'triton.language.target_info'
WARNING 04-10 12:29:51 [interface.py:229] Failed to import from vllm._C: ImportError('libcudart.so.12: cannot open shared object file: No such file or directory')
INFO 04-10 12:29:51 [importing.py:44] Triton is installed but 0 active driver(s) found (expected 1). Disabling Triton to prevent runtime errors.
INFO 04-10 12:29:51 [importing.py:68] Triton not installed or not compatible; certain GPU-related functions will not be available.
ERROR 04-10 12:29:53 [mxfp4.py:39] Failed to import Triton kernels. Please make sure your triton version is compatible. Error: No module named 'triton.language.target_info'
Traceback (most recent call last):
  File "/root/miniconda/envs/python310_torch25_cuda/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/root/miniconda/envs/python310_torch25_cuda/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/root/miniconda/envs/python310_torch25_cuda/lib/python3.10/site-packages/vllm/entrypoints/openai/api_server.py", line 706, in <module>
    parser = make_arg_parser(parser)
  File "/root/miniconda/envs/python310_torch25_cuda/lib/python3.10/site-packages/vllm/entrypoints/openai/cli_args.py", line 349, in make_arg_parser
    parser = AsyncEngineArgs.add_cli_args(parser)
  File "/root/miniconda/envs/python310_torch25_cuda/lib/python3.10/site-packages/vllm/engine/arg_utils.py", line 2274, in add_cli_args
    current_platform.pre_register_and_update(parser)
  File "/tmp/vllm-kunlun-before/vllm_kunlun/platforms/kunlun.py", line 385, in pre_register_and_update
    from vllm_kunlun.quantization.compressed_tensors import (  # noqa
  File "/tmp/vllm-kunlun-before/vllm_kunlun/__init__.py", line 50, in _custom_import
    return OLD_IMPORT_HOOK(
  File "/root/miniconda/envs/python310_torch25_cuda/lib/python3.10/site-packages/xpytorch_import_hook.py", line 134, in _custom_import
    module = builtins.__origin__import__(
  File "/tmp/vllm-kunlun-before/vllm_kunlun/quantization/compressed_tensors/__init__.py", line 19, in <module>
    from .compressed_tensors import KunlunCompressedTensorsConfig
  File "/tmp/vllm-kunlun-before/vllm_kunlun/__init__.py", line 50, in _custom_import
    return OLD_IMPORT_HOOK(
  File "/root/miniconda/envs/python310_torch25_cuda/lib/python3.10/site-packages/xpytorch_import_hook.py", line 134, in _custom_import
    module = builtins.__origin__import__(
  File "/tmp/vllm-kunlun-before/vllm_kunlun/quantization/compressed_tensors/compressed_tensors.py", line 40, in <module>
    from .compressed_tensors_moe import KunlunCompressedTensorsMoEMethod
  File "/tmp/vllm-kunlun-before/vllm_kunlun/__init__.py", line 50, in _custom_import
    return OLD_IMPORT_HOOK(
  File "/root/miniconda/envs/python310_torch25_cuda/lib/python3.10/site-packages/xpytorch_import_hook.py", line 134, in _custom_import
    module = builtins.__origin__import__(
  File "/tmp/vllm-kunlun-before/vllm_kunlun/quantization/compressed_tensors/compressed_tensors_moe.py", line 36, in <module>
    from vllm_kunlun.ops._kunlun_ops import KunlunOps as ops
  File "/tmp/vllm-kunlun-before/vllm_kunlun/__init__.py", line 50, in _custom_import
    return OLD_IMPORT_HOOK(
  File "/root/miniconda/envs/python310_torch25_cuda/lib/python3.10/site-packages/xpytorch_import_hook.py", line 134, in _custom_import
    module = builtins.__origin__import__(
  File "/tmp/vllm-kunlun-before/vllm_kunlun/ops/__init__.py", line 18, in <module>
    import vllm_kunlun.ops._custom_ops
  File "/tmp/vllm-kunlun-before/vllm_kunlun/__init__.py", line 50, in _custom_import
    return OLD_IMPORT_HOOK(
  File "/root/miniconda/envs/python310_torch25_cuda/lib/python3.10/site-packages/xpytorch_import_hook.py", line 134, in _custom_import
    module = builtins.__origin__import__(
  File "/tmp/vllm-kunlun-before/vllm_kunlun/ops/_custom_ops.py", line 250, in <module>
    import kunlun_ops  # noqa: E402
  File "/tmp/vllm-kunlun-before/vllm_kunlun/__init__.py", line 50, in _custom_import
    return OLD_IMPORT_HOOK(
  File "/root/miniconda/envs/python310_torch25_cuda/lib/python3.10/site-packages/xpytorch_import_hook.py", line 134, in _custom_import
    module = builtins.__origin__import__(
  File "/root/miniconda/envs/python310_torch25_cuda/lib/python3.10/site-packages/kunlun_ops/__init__.py", line 5, in <module>
    import torch_xmlir
  File "/tmp/vllm-kunlun-before/vllm_kunlun/__init__.py", line 50, in _custom_import
    return OLD_IMPORT_HOOK(
  File "/root/miniconda/envs/python310_torch25_cuda/lib/python3.10/site-packages/xpytorch_import_hook.py", line 134, in _custom_import
    module = builtins.__origin__import__(
  File "/root/miniconda/envs/python310_torch25_cuda/lib/python3.10/site-packages/torch_xmlir/__init__.py", line 52, in <module>
    from . import _XMLIRC
  File "/tmp/vllm-kunlun-before/vllm_kunlun/__init__.py", line 50, in _custom_import
    return OLD_IMPORT_HOOK(
  File "/root/miniconda/envs/python310_torch25_cuda/lib/python3.10/site-packages/xpytorch_import_hook.py", line 134, in _custom_import
    module = builtins.__origin__import__(
ImportError: /root/miniconda/envs/python310_torch25_cuda/lib/python3.10/site-packages/torch_xmlir/_XMLIRC.cpython-310-x86_64-linux-gnu.so: undefined symbol: cudaHostPointerGetAttributes, version libcudart.so.11.0
```

### Client Log
```text
Service never reached `/v1/models`, so no client request was sent.
```

</details>

<details>
<summary>After</summary>

### Readiness
```text
mode=after
launcher_script=/ssd1/jianglidang/workspace/Qwen3-30B-A3B-Instruct-2507-longText/start_service_p800.sh
client_script=/ssd1/jianglidang/workspace/Qwen3-30B-A3B-Instruct-2507-longText/test_service.py
server_pid=8991
engine_pid=9217
curl_v1_models=200
chat_completion=200
```

### Service Excerpt
```text
(APIServer pid=8991) INFO 04-10 19:30:33 [utils.py:299]  ▄▄ ▄█ █     █     █ ▀▄▀ █  version 0.19.0
(APIServer pid=8991) INFO 04-10 19:30:33 [utils.py:299]   █▄█▀ █     █     █     █  model   /ssd1/models/Qwen3-30B-A3B
(APIServer pid=8991) INFO:     Started server process [8991]
(APIServer pid=8991) INFO:     127.0.0.1:49166 - "GET /v1/models HTTP/1.1" 200 OK
(APIServer pid=8991) INFO:     127.0.0.1:49274 - "GET /v1/models HTTP/1.1" 200 OK
(APIServer pid=8991) INFO:     127.0.0.1:49276 - "POST /v1/chat/completions HTTP/1.1" 200 OK
```

### `/v1/models` Response
```json
{"object":"list","data":[{"id":"Qwen3-30B-A3B","object":"model","created":1775820715,"owned_by":"vllm","root":"/ssd1/models/Qwen3-30B-A3B","parent":null,"max_model_len":132096,"permission":[{"id":"modelperm-955ad2f704553297","object":"model_permission","created":1775820715,"allow_create_engine":false,"allow_sampling":true,"allow_logprobs":true,"allow_search_indices":false,"allow_view":true,"allow_fine_tuning":false,"organization":"*","group":null,"is_blocking":false}]}]}
```

### Client Log
```text
[Config] Using host from VLLM_SERVER_HOST: 127.0.0.1
[Config] Chat completion endpoint: http://127.0.0.1:8566/v1/chat/completions
[Config] Model: Qwen3-30B-A3B
[Result] HTTP status: 200
[Result] Prompt: Reply with exactly: OK
[Result] Raw response: {"id":"chatcmpl-ae37479b47769ac7","object":"chat.completion","created":1775820715,"model":"Qwen3-30B-A3B","choices":[{"index":0,"message":{"role":"assistant","content":"OK","refusal":null,"annotations":null,"audio":null,"function_call":null,"tool_calls":[],"reasoning":null},"logprobs":null,"finish_reason":"stop","stop_reason":null,"token_ids":null}],"service_tier":null,"system_fingerprint":null,"usage":{"prompt_tokens":13,"total_tokens":15,"completion_tokens":2,"prompt_tokens_details":null},"prompt_logprobs":null,"prompt_token_ids":null,"kv_transfer_params":null}
[Result] Parsed content: OK
```

### Full Log Files
Full after log files are uploaded here:
https://gist.github.com/Lidang-Jiang/b83df8b8b0b762b2b6bf69615c4528ce

Files:
- `output_p800.log`
- `pr315_models_response.json`
- `test_service_success.log`

</details>

## Test plan
- [x] `pytest tests/ut/test.py -q`
- [x] `bash /ssd1/jianglidang/workspace/Qwen3-30B-A3B-Instruct-2507-longText/start_service_p800.sh`
- [x] `curl http://127.0.0.1:8566/v1/models`
- [x] `VLLM_SERVER_HOST=127.0.0.1 python /ssd1/jianglidang/workspace/Qwen3-30B-A3B-Instruct-2507-longText/test_service.py`

## Notes
- The request-path blockers fixed during this refresh are: native MoE routing fallback on large warmup inputs, `mistral_common` `ReasoningEffort` compatibility, the vLLM v1 `block_table` Triton slot-mapping fallback, and the missing `Attention` re-export used by `qwen3_next`.
- The updated client health-check is now deterministic and English-only so the PR log shows a stable `OK` completion instead of random long-form generations.
