### PR TITLE
[Kernel] Add MoE bias fused op

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,10 @@ ROOT_DIR = os.path.dirname(__file__)
 ext_modules = [
     CppExtension(
         name="vllm_kunlun._kunlun",
-        sources=["vllm_kunlun/csrc/utils.cpp"],
+        sources=[
+            "vllm_kunlun/csrc/utils.cpp",
+            "vllm_kunlun/csrc/moe_bias_fused.cpp",
+        ],
         include_dirs=[
             "vllm_kunlun/csrc",
             "/usr/local/cuda/include",
@@ -30,8 +33,9 @@ class CustomBuildExt(BuildExtension):
         for ext in self.extensions:
             ext_path = self.get_ext_fullpath(ext.name)
             file_name = os.path.basename(ext_path)
-            target_path = os.path.join("vllm_kunlun", file_name)
+            target_path = os.path.join(ROOT_DIR, "vllm_kunlun", file_name)
 
+            os.makedirs(os.path.dirname(target_path), exist_ok=True)
             if os.path.exists(target_path):
                 os.remove(target_path)
             shutil.copyfile(ext_path, target_path)

--- a/tests/ut/test_moe_bias_cpp_ops.py
+++ b/tests/ut/test_moe_bias_cpp_ops.py
@@ -1,0 +1,232 @@
+"""
+Copyright (c) 2026 Baidu, Inc. All Rights Reserved.
+
+This file is a part of the vllm-kunlun project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+from unittest.mock import patch
+
+import torch
+
+import vllm_kunlun._kunlun  # noqa: F401
+
+
+def _reference_swigluoai_and_mul(x: torch.Tensor) -> torch.Tensor:
+    gate, up = x[..., ::2], x[..., 1::2]
+    gate = gate.clamp(max=7.0)
+    up = up.clamp(min=-7.0, max=7.0)
+    glu = gate * torch.sigmoid(gate * 1.702)
+    return (up + 1) * glu
+
+
+def _reference_moe_bias_fused(
+    hidden_states: torch.Tensor,
+    w1: torch.Tensor,
+    w2: torch.Tensor,
+    topk_ids: torch.Tensor,
+    normed_score: torch.Tensor,
+    ep_rank: int,
+    w1_bias: torch.Tensor | None,
+    w2_bias: torch.Tensor | None,
+) -> torch.Tensor:
+    num_tokens, hidden_dim = hidden_states.shape
+    global_num_experts = w1.shape[0]
+    moe_top_k = topk_ids.shape[1]
+    out = torch.zeros(
+        num_tokens * moe_top_k,
+        hidden_dim,
+        dtype=hidden_states.dtype,
+        device=hidden_states.device,
+    )
+    repeat_x = hidden_states.repeat_interleave(moe_top_k, dim=0)
+    topk_ids_flat = topk_ids.flatten()
+    for expert_idx in range(global_num_experts):
+        expert_id = ep_rank * global_num_experts + expert_idx
+        selected = topk_ids_flat == expert_id
+        if not selected.any():
+            continue
+        cur_token = repeat_x[selected]
+        groupgemm1 = cur_token @ w1[expert_idx].T
+        if w1_bias is not None:
+            groupgemm1 = groupgemm1 + w1_bias[expert_idx]
+        up_gate = _reference_swigluoai_and_mul(groupgemm1)
+        groupgemm2 = up_gate @ w2[expert_idx].T
+        if w2_bias is not None:
+            groupgemm2 = groupgemm2 + w2_bias[expert_idx]
+        out[selected] = groupgemm2
+    return (
+        (out.view(num_tokens, moe_top_k, hidden_dim) * normed_score.unsqueeze(2))
+        .sum(dim=1)
+        .to(hidden_states.dtype)
+    )
+
+
+def test_moe_bias_fused_matches_reference_with_optional_biases():
+    hidden_states = torch.randn(3, 4)
+    w1 = torch.randn(2, 6, 4)
+    w2 = torch.randn(2, 4, 3)
+    topk_ids = torch.tensor([[0, 1], [1, 0], [0, 0]], dtype=torch.int32)
+    normed_score = torch.tensor(
+        [[0.6, 0.4], [0.2, 0.8], [0.5, 0.5]], dtype=hidden_states.dtype
+    )
+    w1_bias = torch.randn(2, 6)
+    w2_bias = torch.randn(2, 4)
+
+    result = torch.ops._C.moe_bias_fused(
+        hidden_states,
+        w1,
+        w2,
+        topk_ids,
+        normed_score,
+        0,
+        w1_bias,
+        w2_bias,
+    )
+
+    expected = _reference_moe_bias_fused(
+        hidden_states,
+        w1,
+        w2,
+        topk_ids,
+        normed_score,
+        0,
+        w1_bias,
+        w2_bias,
+    )
+    torch.testing.assert_close(result, expected)
+
+
+def test_moe_bias_fused_matches_reference_without_biases():
+    hidden_states = torch.randn(2, 3)
+    w1 = torch.randn(2, 4, 3)
+    w2 = torch.randn(2, 3, 2)
+    topk_ids = torch.tensor([[0, 1], [1, 1]], dtype=torch.int32)
+    normed_score = torch.tensor([[0.7, 0.3], [0.1, 0.9]], dtype=hidden_states.dtype)
+
+    result = torch.ops._C.moe_bias_fused(
+        hidden_states,
+        w1,
+        w2,
+        topk_ids,
+        normed_score,
+        0,
+        None,
+        None,
+    )
+
+    expected = _reference_moe_bias_fused(
+        hidden_states,
+        w1,
+        w2,
+        topk_ids,
+        normed_score,
+        0,
+        None,
+        None,
+    )
+    torch.testing.assert_close(result, expected)
+
+
+def test_moe_bias_fused_respects_ep_rank_global_ids():
+    hidden_states = torch.randn(2, 3)
+    w1 = torch.randn(2, 4, 3)
+    w2 = torch.randn(2, 3, 2)
+    topk_ids = torch.tensor([[2, 3], [3, 2]], dtype=torch.int32)
+    normed_score = torch.tensor([[0.4, 0.6], [0.5, 0.5]], dtype=hidden_states.dtype)
+
+    result = torch.ops._C.moe_bias_fused(
+        hidden_states,
+        w1,
+        w2,
+        topk_ids,
+        normed_score,
+        1,
+        None,
+        None,
+    )
+
+    expected = _reference_moe_bias_fused(
+        hidden_states,
+        w1,
+        w2,
+        topk_ids,
+        normed_score,
+        1,
+        None,
+        None,
+    )
+    torch.testing.assert_close(result, expected)
+
+
+def test_kunlun_fused_moe_uses_cpp_bias_fast_path():
+    module_name = "vllm_kunlun.ops._kunlun_ops"
+    fake_ops = {
+        "cocopod": types.SimpleNamespace(),
+        "xspeedgate_ops": types.SimpleNamespace(),
+        "kunlun_ops": types.SimpleNamespace(),
+    }
+    with patch.dict(sys.modules, fake_ops):
+        sys.modules.pop(module_name, None)
+        kunlun_ops_module = importlib.import_module(module_name)
+
+    hidden_states = torch.randn(2, 3)
+    w1 = torch.randn(2, 4, 3)
+    w2 = torch.randn(2, 3, 2)
+    router_logits = torch.randn(2, 2)
+    topk_ids = torch.tensor([[0, 1], [1, 0]], dtype=torch.int32)
+    normed_score = torch.tensor([[0.3, 0.7], [0.6, 0.4]], dtype=hidden_states.dtype)
+    w1_bias = torch.randn(2, 4)
+    w2_bias = torch.randn(2, 3)
+
+    def _fill_topk(*args, **kwargs):
+        kwargs["normed_score"].copy_(normed_score.float())
+        kwargs["topk_index"].copy_(topk_ids)
+
+    with (
+        patch.object(
+            kunlun_ops_module, "kunlun_ops", types.SimpleNamespace(), create=True
+        ),
+        patch.object(
+            torch.ops._C, "moe_softmax_topk_norm", side_effect=_fill_topk, create=True
+        ),
+    ):
+        result = kunlun_ops_module.KunlunOps.fused_moe(
+            hidden_states=hidden_states,
+            w1=w1,
+            w2=w2,
+            router_logits=router_logits,
+            ep_rank=0,
+            moe_top_k=2,
+            renormalize=True,
+            w1_bias=w1_bias,
+            w2_bias=w2_bias,
+        )
+
+    expected = _reference_moe_bias_fused(
+        hidden_states,
+        w1,
+        w2,
+        topk_ids,
+        normed_score,
+        0,
+        w1_bias,
+        w2_bias,
+    )
+    torch.testing.assert_close(result, expected)

--- a/tests/ut/test_moe_bias_cpp_ops.py
+++ b/tests/ut/test_moe_bias_cpp_ops.py
@@ -23,6 +23,7 @@ import sys
 import types
 from unittest.mock import patch
 
+import pytest
 import torch
 
 import vllm_kunlun._kunlun  # noqa: F401
@@ -173,6 +174,73 @@ def test_moe_bias_fused_respects_ep_rank_global_ids():
         None,
     )
     torch.testing.assert_close(result, expected)
+
+
+def test_moe_bias_fused_rejects_mismatched_token_dimensions():
+    hidden_states = torch.randn(2, 3)
+    w1 = torch.randn(2, 4, 3)
+    w2 = torch.randn(2, 3, 2)
+    topk_ids = torch.tensor([[0, 1]], dtype=torch.int32)
+    normed_score = torch.tensor([[0.7, 0.3], [0.1, 0.9]], dtype=hidden_states.dtype)
+
+    with pytest.raises(
+        RuntimeError,
+        match="topk_ids.size\\(0\\) must equal hidden_states.size\\(0\\)",
+    ):
+        torch.ops._C.moe_bias_fused(
+            hidden_states,
+            w1,
+            w2,
+            topk_ids,
+            normed_score,
+            0,
+            None,
+            None,
+        )
+
+
+def test_moe_bias_fused_rejects_incompatible_expert_shapes():
+    hidden_states = torch.randn(2, 3)
+    w1 = torch.randn(2, 6, 3)
+    w2 = torch.randn(3, 3, 3)
+    topk_ids = torch.tensor([[0, 1], [1, 0]], dtype=torch.int32)
+    normed_score = torch.tensor([[0.7, 0.3], [0.1, 0.9]], dtype=hidden_states.dtype)
+
+    with pytest.raises(RuntimeError, match="w2.size\\(0\\) must equal w1.size\\(0\\)"):
+        torch.ops._C.moe_bias_fused(
+            hidden_states,
+            w1,
+            w2,
+            topk_ids,
+            normed_score,
+            0,
+            None,
+            None,
+        )
+
+
+def test_moe_bias_fused_rejects_incompatible_bias_shapes():
+    hidden_states = torch.randn(2, 3)
+    w1 = torch.randn(2, 4, 3)
+    w2 = torch.randn(2, 3, 2)
+    topk_ids = torch.tensor([[0, 1], [1, 0]], dtype=torch.int32)
+    normed_score = torch.tensor([[0.7, 0.3], [0.1, 0.9]], dtype=hidden_states.dtype)
+    w1_bias = torch.randn(2, 3)
+    w2_bias = torch.randn(2, 4)
+
+    with pytest.raises(
+        RuntimeError, match="w1_bias.size\\(1\\) must equal w1.size\\(1\\)"
+    ):
+        torch.ops._C.moe_bias_fused(
+            hidden_states,
+            w1,
+            w2,
+            topk_ids,
+            normed_score,
+            0,
+            w1_bias,
+            w2_bias,
+        )
 
 
 def test_kunlun_fused_moe_uses_cpp_bias_fast_path():

--- a/vllm_kunlun/csrc/moe_bias_fused.cpp
+++ b/vllm_kunlun/csrc/moe_bias_fused.cpp
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2026 Baidu, Inc. All Rights Reserved.
+ *
+ * This file is a part of the vllm-kunlun project.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <torch/extension.h>
+
+namespace {
+
+torch::Tensor swigluoai_and_mul_native(const torch::Tensor& x) {
+    auto gate = x.index({torch::indexing::Slice(), torch::indexing::Slice(
+        torch::indexing::None, torch::indexing::None, 2)});
+    auto up = x.index({torch::indexing::Slice(), torch::indexing::Slice(
+        1, torch::indexing::None, 2)});
+    gate = torch::clamp_max(gate, 7.0);
+    up = torch::clamp(up, -7.0, 7.0);
+    auto glu = gate * torch::sigmoid(gate * 1.702);
+    return (up + 1) * glu;
+}
+
+}  // namespace
+
+torch::Tensor moe_bias_fused(
+    const torch::Tensor& hidden_states,
+    const torch::Tensor& w1,
+    const torch::Tensor& w2,
+    const torch::Tensor& topk_ids,
+    const torch::Tensor& normed_score,
+    int64_t ep_rank,
+    const c10::optional<torch::Tensor>& w1_bias,
+    const c10::optional<torch::Tensor>& w2_bias) {
+    TORCH_CHECK(hidden_states.dim() == 2, "hidden_states must be 2D");
+    TORCH_CHECK(w1.dim() == 3, "w1 must be 3D");
+    TORCH_CHECK(w2.dim() == 3, "w2 must be 3D");
+    TORCH_CHECK(topk_ids.dim() == 2, "topk_ids must be 2D");
+    TORCH_CHECK(normed_score.dim() == 2, "normed_score must be 2D");
+
+    const auto global_num_experts = w1.size(0);
+    const auto moe_top_k = topk_ids.size(1);
+    const auto hidden_dim = hidden_states.size(1);
+    const auto num_tokens = hidden_states.size(0);
+
+    auto repeated_hidden = hidden_states.repeat_interleave(moe_top_k, 0);
+    auto topk_ids_flat = topk_ids.reshape({-1});
+    auto out = torch::zeros(
+        {num_tokens * moe_top_k, hidden_dim},
+        hidden_states.options());
+
+    for (int64_t expert_idx = 0; expert_idx < global_num_experts; ++expert_idx) {
+        auto expert_id = ep_rank * global_num_experts + expert_idx;
+        auto selected_mask = topk_ids_flat.eq(expert_id);
+        auto selected_indices = torch::nonzero(selected_mask).reshape({-1});
+        if (selected_indices.numel() == 0) {
+            continue;
+        }
+
+        auto cur_token = repeated_hidden.index_select(0, selected_indices);
+        auto groupgemm1 = torch::matmul(cur_token, w1[expert_idx].transpose(0, 1));
+        if (w1_bias.has_value() && w1_bias->defined()) {
+            groupgemm1 = groupgemm1 + (*w1_bias)[expert_idx];
+        }
+
+        auto up_gate = swigluoai_and_mul_native(groupgemm1);
+        auto groupgemm2 = torch::matmul(up_gate, w2[expert_idx].transpose(0, 1));
+        if (w2_bias.has_value() && w2_bias->defined()) {
+            groupgemm2 = groupgemm2 + (*w2_bias)[expert_idx];
+        }
+
+        out.index_copy_(0, selected_indices, groupgemm2);
+    }
+
+    return (out.view({num_tokens, moe_top_k, hidden_dim}) *
+            normed_score.unsqueeze(2))
+        .sum(1)
+        .to(hidden_states.scalar_type());
+}
+
+TORCH_LIBRARY_FRAGMENT(_C, m) {
+    m.def("moe_bias_fused", &moe_bias_fused);
+}

--- a/vllm_kunlun/csrc/moe_bias_fused.cpp
+++ b/vllm_kunlun/csrc/moe_bias_fused.cpp
@@ -47,11 +47,106 @@ torch::Tensor moe_bias_fused(
     TORCH_CHECK(w2.dim() == 3, "w2 must be 3D");
     TORCH_CHECK(topk_ids.dim() == 2, "topk_ids must be 2D");
     TORCH_CHECK(normed_score.dim() == 2, "normed_score must be 2D");
+    TORCH_CHECK(
+        w1.device() == hidden_states.device(),
+        "w1 must be on the same device as hidden_states");
+    TORCH_CHECK(
+        w2.device() == hidden_states.device(),
+        "w2 must be on the same device as hidden_states");
+    TORCH_CHECK(
+        topk_ids.device() == hidden_states.device(),
+        "topk_ids must be on the same device as hidden_states");
+    TORCH_CHECK(
+        normed_score.device() == hidden_states.device(),
+        "normed_score must be on the same device as hidden_states");
 
     const auto global_num_experts = w1.size(0);
     const auto moe_top_k = topk_ids.size(1);
     const auto hidden_dim = hidden_states.size(1);
     const auto num_tokens = hidden_states.size(0);
+    TORCH_CHECK(
+        w2.size(0) == global_num_experts,
+        "w2.size(0) must equal w1.size(0), but got ",
+        w2.size(0),
+        " and ",
+        global_num_experts);
+    TORCH_CHECK(
+        topk_ids.size(0) == num_tokens,
+        "topk_ids.size(0) must equal hidden_states.size(0), but got ",
+        topk_ids.size(0),
+        " and ",
+        num_tokens);
+    TORCH_CHECK(
+        normed_score.size(0) == num_tokens,
+        "normed_score.size(0) must equal hidden_states.size(0), but got ",
+        normed_score.size(0),
+        " and ",
+        num_tokens);
+    TORCH_CHECK(
+        normed_score.size(1) == moe_top_k,
+        "normed_score.size(1) must equal topk_ids.size(1), but got ",
+        normed_score.size(1),
+        " and ",
+        moe_top_k);
+    TORCH_CHECK(
+        w1.size(2) == hidden_dim,
+        "w1.size(2) must equal hidden_states.size(1), but got ",
+        w1.size(2),
+        " and ",
+        hidden_dim);
+    TORCH_CHECK(
+        w2.size(1) == hidden_dim,
+        "w2.size(1) must equal hidden_states.size(1), but got ",
+        w2.size(1),
+        " and ",
+        hidden_dim);
+    TORCH_CHECK(
+        w1.size(1) % 2 == 0,
+        "w1.size(1) must be even for SwiGLU split, but got ",
+        w1.size(1));
+    TORCH_CHECK(
+        w1.size(1) / 2 == w2.size(2),
+        "w1.size(1) / 2 must equal w2.size(2), but got ",
+        w1.size(1) / 2,
+        " and ",
+        w2.size(2));
+
+    if (w1_bias.has_value() && w1_bias->defined()) {
+        TORCH_CHECK(w1_bias->dim() == 2, "w1_bias must be 2D");
+        TORCH_CHECK(
+            w1_bias->device() == hidden_states.device(),
+            "w1_bias must be on the same device as hidden_states");
+        TORCH_CHECK(
+            w1_bias->size(0) == global_num_experts,
+            "w1_bias.size(0) must equal w1.size(0), but got ",
+            w1_bias->size(0),
+            " and ",
+            global_num_experts);
+        TORCH_CHECK(
+            w1_bias->size(1) == w1.size(1),
+            "w1_bias.size(1) must equal w1.size(1), but got ",
+            w1_bias->size(1),
+            " and ",
+            w1.size(1));
+    }
+    if (w2_bias.has_value() && w2_bias->defined()) {
+        TORCH_CHECK(w2_bias->dim() == 2, "w2_bias must be 2D");
+        TORCH_CHECK(
+            w2_bias->device() == hidden_states.device(),
+            "w2_bias must be on the same device as hidden_states");
+        TORCH_CHECK(
+            w2_bias->size(0) == global_num_experts,
+            "w2_bias.size(0) must equal w2.size(0), but got ",
+            w2_bias->size(0),
+            " and ",
+            global_num_experts);
+        TORCH_CHECK(
+            w2_bias->size(1) == hidden_dim,
+            "w2_bias.size(1) must equal hidden_states.size(1), but got ",
+            w2_bias->size(1),
+            " and ",
+            hidden_dim);
+    }
 
     auto repeated_hidden = hidden_states.repeat_interleave(moe_top_k, 0);
     auto topk_ids_flat = topk_ids.reshape({-1});

--- a/vllm_kunlun/ops/_kunlun_ops.py
+++ b/vllm_kunlun/ops/_kunlun_ops.py
@@ -431,41 +431,18 @@ class KunlunOps:
             )
 
         if w1_bias is not None or w2_bias is not None:
-            # Rignt now this branch is for gpt oss
+            # Right now this branch is for gpt oss
             # TODO (@xyDong23): faster here using moe_fc kernel
-            normed_score = normed_score.to(hidden_states.dtype)
-            out = torch.zeros(
-                M * moe_top_k, N, dtype=hidden_states.dtype, device=hidden_states.device
+            return torch.ops._C.moe_bias_fused(
+                hidden_states,
+                w1,
+                w2,
+                topk_ids,
+                normed_score.to(hidden_states.dtype),
+                ep_rank,
+                w1_bias,
+                w2_bias,
             )
-            repeat_x = hidden_states.repeat_interleave(moe_top_k, dim=0)
-            topk_ids_flat = topk_ids.flatten()
-            for i in range(global_num_experts):
-                experts_id = ep_rank * global_num_experts + i
-                selected_token = topk_ids_flat == experts_id
-                if selected_token.sum():
-                    cur_token = repeat_x[selected_token]
-                    up_gate = torch.empty(
-                        selected_token.sum(),
-                        up_gate_size // 2,
-                        dtype=cur_token.dtype,
-                        device=cur_token.device,
-                    )
-                    groupgemm1 = cur_token @ w1[i].T
-                    # Add w13 bias
-                    if w1_bias is not None:
-                        groupgemm1 = groupgemm1 + w1_bias[i]
-                    up_gate = torch.ops._C.swigluoai_and_mul(groupgemm1)
-                    groupgemm2 = up_gate @ w2[i].T
-                    # Add w2 bias
-                    if w2_bias is not None:
-                        groupgemm2 = groupgemm2 + w2_bias[i]
-                    out[selected_token] = groupgemm2
-            ouput = (
-                (out.view(M, moe_top_k, N) * normed_score.unsqueeze(2))
-                .sum(dim=1)
-                .to(hidden_states.dtype)
-            )
-            return ouput
         else:
             # from vllm.forward_context import get_forward_context
             # forward_context = get_forward_context()


### PR DESCRIPTION
## Summary
- add a repo-local `_C.moe_bias_fused` op for the GPT-OSS MoE bias path in `KunlunOps.fused_moe`
- keep the existing closed-source fast path untouched and only replace the in-repo Python expert loop
- add unit coverage for optional biases, `ep_rank` handling, and the `_kunlun_ops` wiring path
- verify on `origin/main` / `vllm 0.15.1` that `/v1/chat/completions` starts successfully and returns a normal natural-language response with `Qwen2.5-72B-Instruct`

## Correctness
- Unit tests cover optional `w1_bias`/`w2_bias`, `ep_rank` offset handling, and the new `_kunlun_ops` wiring path.
- The `Qwen2.5-72B-Instruct` smoke test is a non-regression check for serving on `main/0.15.1`; it does not claim to exercise the separate Qwen3 MoE loader path.
- On the current Kunlun runtime, the `main/0.15.1` serving command also needs `LD_LIBRARY_PATH=$CONDA_PREFIX/xcudart/lib:$LD_LIBRARY_PATH` and `TORCHDYNAMO_SUPPRESS_ERRORS=1` so runtime compile failures fall back cleanly to eager.

<details>
<summary>Before</summary>

```text
Exception: Error loading library libcuda.so.1: libcuda.so.1: cannot open shared object file: No such file or directory
Traceback (most recent call last):
  File "$WORKSPACE/python310_torch25_cuda_moe/lib/python3.10/site-packages/xpytorch_import_hook.py", line 77, in _custom_import
    torch_plugin.initialize_runtime()
RuntimeError: Failed to initialize runtime libraries. Check C++ logs for details.
WARNING: import hook error: Failed to initialize runtime libraries. Check C++ logs for details.
No CUDA runtime is found, using CUDA_HOME='/usr/local/cuda'
running build_ext
building 'vllm_kunlun._kunlun' extension
...
has_moe_bias_fused = False
missing_op = '_OpNamespace' '_C' object has no attribute 'moe_bias_fused' 
```

</details>

<details>
<summary>After</summary>

```text
$ cd $WORKSPACE/vLLM-Kunlun-wt-moe-bias
$ source /root/miniconda/etc/profile.d/conda.sh
$ conda activate $WORKSPACE/python310_torch25_cuda_moe0151
$ source ./setup_env.sh
$ export VLLM_USE_V1=1
$ export TORCHDYNAMO_SUPPRESS_ERRORS=1
$ export LD_LIBRARY_PATH="$WORKSPACE/python310_torch25_cuda_moe0151/xcudart/lib:${LD_LIBRARY_PATH:-}"
$ python setup.py build_ext
XCCL $WORKSPACE/python310_torch25_cuda_moe0151/lib/python3.10/site-packages/torch_xmlir/libbkcl.so loaded
SYMBOL_REWRITE torch success
running build_ext
building 'vllm_kunlun._kunlun' extension
Emitting ninja build file $WORKSPACE/vLLM-Kunlun-wt-moe-bias/build/temp.linux-x86_64-cpython-310/build.ninja...
Compiling objects...
Allowing ninja to set a default number of workers... (overridable by setting the environment variable MAX_JOBS=N)
ninja: no work to do.
g++ -pthread -B $WORKSPACE/python310_torch25_cuda_moe0151/compiler_compat -Wno-unused-result -Wsign-compare -DNDEBUG -fwrapv -O2 -Wall -fPIC -O2 -isystem $WORKSPACE/python310_torch25_cuda_moe0151/include -fPIC -O2 -isystem $WORKSPACE/python310_torch25_cuda_moe0151/include -pthread -B $WORKSPACE/python310_torch25_cuda_moe0151/compiler_compat -shared $WORKSPACE/vLLM-Kunlun-wt-moe-bias/build/temp.linux-x86_64-cpython-310/vllm_kunlun/csrc/moe_bias_fused.o $WORKSPACE/vLLM-Kunlun-wt-moe-bias/build/temp.linux-x86_64-cpython-310/vllm_kunlun/csrc/utils.o -L/usr/local/cuda/lib64 -L$WORKSPACE/python310_torch25_cuda_moe0151/lib/python3.10/site-packages/torch/lib -lc10 -ltorch -ltorch_cpu -ltorch_python -o build/lib.linux-x86_64-cpython-310/vllm_kunlun/_kunlun.cpython-310-x86_64-linux-gnu.so
[BuildExt] Copied build/lib.linux-x86_64-cpython-310/vllm_kunlun/_kunlun.cpython-310-x86_64-linux-gnu.so -> $WORKSPACE/vLLM-Kunlun-wt-moe-bias/vllm_kunlun/_kunlun.cpython-310-x86_64-linux-gnu.so

$ python -m pytest tests/ut/test_moe_bias_cpp_ops.py -q
....                                                                     [100%]
4 passed in 5.18s

$ USE_ORI_ROPE=0 python -m vllm.entrypoints.openai.api_server --host 127.0.0.1 --port 8571 --model /ssd1/models/Qwen2.5-72B-Instruct --served-model-name Qwen2.5-72B-Instruct --tensor-parallel-size 8 --dtype float16 --max-model-len 8192 --trust-remote-code --enforce-eager --disable-log-requests --disable-log-stats
(APIServer pid=95094) INFO 04-20 10:51:29 [utils.py:325]  ▄▄ ▄█ █     █     █ ▀▄▀ █  version 0.15.1
(APIServer pid=95094) INFO 04-20 10:51:29 [utils.py:325]   █▄█▀ █     █     █     █  model   /ssd1/models/Qwen2.5-72B-Instruct
(Worker_TP0 pid=95802) INFO 04-20 10:52:07 [default_loader.py:291] Loading weights took 20.04 seconds
(Worker_TP0 pid=95802) INFO 04-20 10:52:11 [gpu_worker.py:356] Available KV cache memory: 67.21 GiB
(EngineCore_DP0 pid=95439) INFO 04-20 10:52:11 [kv_cache_utils.py:1307] GPU KV cache size: 1,761,952 tokens
(EngineCore_DP0 pid=95439) WARNING 04-20 10:52:13 [vllm.py:669] Inductor compilation was disabled by user settings, optimizations settings that are only active during inductor compilation will be ignored.
(APIServer pid=95094) INFO 04-20 10:52:14 [serving.py:212] Chat template warmup completed in 526.8ms
(APIServer pid=95094) INFO 04-20 10:52:14 [api_server.py:946] Starting vLLM API server 0 on http://127.0.0.1:8571
(APIServer pid=95094) INFO:     Application startup complete.
(APIServer pid=95094) INFO:     127.0.0.1:39476 - "GET /v1/models HTTP/1.1" 200 OK
(APIServer pid=95094) INFO:     127.0.0.1:39478 - "POST /v1/chat/completions HTTP/1.1" 200 OK
(APIServer pid=95094) INFO 04-20 10:52:19 [launcher.py:110] Shutting down FastAPI HTTP server.
(APIServer pid=95094) INFO:     Application shutdown complete.

$ curl -sS http://127.0.0.1:8571/v1/models
{"object":"list","data":[{"id":"Qwen2.5-72B-Instruct","object":"model","created":1776653535,"owned_by":"vllm","root":"/ssd1/models/Qwen2.5-72B-Instruct","parent":null,"max_model_len":8192,"permission":[{"id":"modelperm-8d1540084ab4826d","object":"model_permission","created":1776653535,"allow_create_engine":false,"allow_sampling":true,"allow_logprobs":true,"allow_search_indices":false,"allow_view":true,"allow_fine_tuning":false,"organization":"*","group":null,"is_blocking":false}]}]}

$ curl -sS -X POST http://127.0.0.1:8571/v1/chat/completions -H 'Content-Type: application/json' -d '{"model":"Qwen2.5-72B-Instruct","messages":[{"role":"user","content":"请用两句话介绍你自己，并说明你现在可以正常回答问题。"}],"temperature":0,"max_tokens":80}'
{"id":"chatcmpl-adb41fc03b6d12cc","object":"chat.completion","created":1776653535,"model":"Qwen2.5-72B-Instruct","choices":[{"index":0,"message":{"role":"assistant","content":"我是Qwen，由阿里云研发的超大规模语言模型，能够提供广泛的信息和帮助。现在我可以正常回答您的问题，有什么我可以协助您的吗？","refusal":null,"annotations":null,"audio":null,"function_call":null,"tool_calls":[],"reasoning":null,"reasoning_content":null},"logprobs":null,"finish_reason":"stop","stop_reason":null,"token_ids":null}],"service_tier":null,"system_fingerprint":null,"usage":{"prompt_tokens":43,"total_tokens":78,"completion_tokens":35,"prompt_tokens_details":null},"prompt_logprobs":null,"prompt_token_ids":null,"kv_transfer_params":null}
```


### Full Log Files
Full after log files are uploaded here:
https://gist.github.com/Lidang-Jiang/117d246a2784bbe9b378e8ca687ba646

Files:
- `pr326_output_qwen25_72b_instruct.log`
- `pr326_models_response.json`
- `pr326_chat_response.json`
</details>


## Test plan
- [x] `conda activate $WORKSPACE/python310_torch25_cuda_moe0151`
- [x] `python setup.py build_ext`
- [x] `python -m pytest tests/ut/test_moe_bias_cpp_ops.py -q`
- [x] `USE_ORI_ROPE=0 python -m vllm.entrypoints.openai.api_server ... --port 8571 --model /ssd1/models/Qwen2.5-72B-Instruct`
- [x] `curl -sS http://127.0.0.1:8571/v1/models`
- [x] `curl -sS -X POST http://127.0.0.1:8571/v1/chat/completions ...`


