### PR TITLE
[Doc] Fix invalid installation checkout reference

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -69,7 +69,7 @@ myst_substitutions = {
     # the branch of vllm-kunlun, used in vllm-kunlun clone and image tag
     # - main branch: 'main'
     # - vX.Y.Z branch: latest vllm-kunlun release tag
-    "vllm_kunlun_version": "v0.15.1",
+    "vllm_kunlun_version": "main",
     # the newest release version of vllm-kunlun and matched vLLM, used in pip install.
     # This value should be updated when cut down release.
     "pip_vllm_kunlun_version": "0.15.1",
@@ -116,7 +116,7 @@ html_logo = "logos/vllm-kunlun-logo-text-light.png"
 html_theme_options = {
     "path_to_docs": "docs/source",
     "repository_url": "https://github.com/baidu/vLLM-Kunlun",
-    "repository_branch": "v0.15.1-dev",
+    "repository_branch": "main",
     "use_repository_button": True,
     "use_edit_page_button": True,
 }

--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -53,21 +53,25 @@ docker run -itd ${DOCKER_DEVICE_CONFIG} \
 ::::
 :::::
 ## Install vLLM-kunlun
-### Install vLLM 0.15.1
+### Install vLLM
 
-```
-uv pip install vllm==0.15.1 --no-build-isolation --no-deps
+```{code-block} bash
+:substitutions:
+
+uv pip install vllm==|pip_vllm_version| --no-build-isolation --no-deps
 ```
 
 ### Build and Install
 Navigate to the vllm-kunlun directory and build the package:
 
-```
+```{code-block} bash
+:substitutions:
+
 git clone https://github.com/baidu/vLLM-Kunlun
 
 cd vLLM-Kunlun
 
-git checkout v0.15.1-dev
+git checkout |vllm_kunlun_version|
 
 uv pip install -r requirements.txt
 


### PR DESCRIPTION
## Summary

- Fixes #324 by replacing the invalid public checkout reference with `main`
- Update Sphinx doc substitutions so the installation guide and repository links resolve to an existing public branch
- Replace hardcoded installation literals in `installation.md` with the existing substitution variables to reduce future drift

<details>
<summary>Before</summary>

```text
$ git ls-remote --heads --tags https://github.com/baidu/vLLM-Kunlun.git | rg 'refs/(heads|tags)/(main|v0\\.15\\.1-dev|v0\\.19\\.0-dev|releases/v0\\.11\\.0)$'
a9bf223b7cefde23bda7b22e311b594508e9ffef	refs/heads/main
e9f03229090034fcd96fbbfb885a1ac3327dc1a1	refs/heads/releases/v0.11.0
7eccb203f737cd78527cb9bab277dd2b3eea5911	refs/heads/v0.19.0-dev

$ git show HEAD:docs/source/installation.md | sed -n '53,80p'
## Install vLLM-kunlun
### Install vLLM 0.15.1

```
uv pip install vllm==0.15.1 --no-build-isolation --no-deps
```

### Build and Install
Navigate to the vllm-kunlun directory and build the package:

```
git clone https://github.com/baidu/vLLM-Kunlun

cd vLLM-Kunlun

git checkout v0.15.1-dev

uv pip install -r requirements.txt

python setup.py build

python setup.py install
```

$ git show HEAD:docs/source/conf.py | sed -n '64,120p'
myst_substitutions = {
    # the branch of vllm, used in vllm clone
    # - main branch: 'main'
    # - vX.Y.Z branch: 'vX.Y.Z'
    "vllm_version": "v0.15.1",
    # the branch of vllm-kunlun, used in vllm-kunlun clone and image tag
    # - main branch: 'main'
    # - vX.Y.Z branch: latest vllm-kunlun release tag
    "vllm_kunlun_version": "v0.15.1",
    # the newest release version of vllm-kunlun and matched vLLM, used in pip install.
    # This value should be updated when cut down release.
    "pip_vllm_kunlun_version": "0.15.1",
    "pip_vllm_version": "0.15.1",
    # vllm version in ci
    "ci_vllm_version": "v0.15.1",
}

html_theme_options = {
    "path_to_docs": "docs/source",
    "repository_url": "https://github.com/baidu/vLLM-Kunlun",
    "repository_branch": "v0.15.1-dev",
    "use_repository_button": True,
    "use_edit_page_button": True,
}
```

</details>

<details>
<summary>After</summary>

```text
$ git diff -- docs/source/conf.py docs/source/installation.md
diff --git a/docs/source/conf.py b/docs/source/conf.py
index 2ec0150..af88a3e 100644
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -69,7 +69,7 @@ myst_substitutions = {
     # the branch of vllm-kunlun, used in vllm-kunlun clone and image tag
     # - main branch: 'main'
     # - vX.Y.Z branch: latest vllm-kunlun release tag
-    "vllm_kunlun_version": "v0.15.1",
+    "vllm_kunlun_version": "main",
     # the newest release version of vllm-kunlun and matched vLLM, used in pip install.
     # This value should be updated when cut down release.
     "pip_vllm_kunlun_version": "0.15.1",
@@ -116,7 +116,7 @@ html_logo = "logos/vllm-kunlun-logo-text-light.png"
 html_theme_options = {
     "path_to_docs": "docs/source",
     "repository_url": "https://github.com/baidu/vLLM-Kunlun",
-    "repository_branch": "v0.15.1-dev",
+    "repository_branch": "main",
     "use_repository_button": True,
     "use_edit_page_button": True,
 }
diff --git a/docs/source/installation.md b/docs/source/installation.md
index 875eb86..151dd89 100644
--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -53,21 +53,25 @@ docker run -itd ${DOCKER_DEVICE_CONFIG} \
 ::::
 :::::
 ## Install vLLM-kunlun
-### Install vLLM 0.15.1
+### Install vLLM
 
-```
-uv pip install vllm==0.15.1 --no-build-isolation --no-deps
+```{code-block} bash
+:substitutions:
+
+uv pip install vllm==|pip_vllm_version| --no-build-isolation --no-deps
 ```
 
 ### Build and Install
 Navigate to the vllm-kunlun directory and build the package:
 
-```
+```{code-block} bash
+:substitutions:
+
 git clone https://github.com/baidu/vLLM-Kunlun
 
 cd vLLM-Kunlun
 
-git checkout v0.15.1-dev
+git checkout |vllm_kunlun_version|
 
 uv pip install -r requirements.txt
 

$ sphinx-build -b html source _build/html
/ssd1/jianglidang/workspace/python310_torch25_cuda/lib/python3.10/site-packages/xpytorch_import_hook.py:6: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
  import pkg_resources
Running Sphinx v8.1.3
loading translations [en]... done
loading pickled environment... The configuration has changed (6 options: 'html_context', 'html_permalinks_icon', 'html_sourcelink_suffix', 'html_static_path', 'html_theme_options', ...)
done
[autosummary] generating autosummary for: community/contributors.md, community/governance.md, community/user_stories/index.md, community/versioning_policy.md, developer_guide/contribution/contributing.md, developer_guide/contribution/index.md, developer_guide/evaluation/accuracy/accuracy_kernel.md, developer_guide/evaluation/accuracy/accuracy_server.md, developer_guide/evaluation/accuracy/index.md, developer_guide/evaluation/accuracy_report/GLM-4.5-Air.md, ..., user_guide/configuration/env_vars.md, user_guide/configuration/index.md, user_guide/feature_guide/graph_mode.md, user_guide/feature_guide/index.md, user_guide/feature_guide/lora.md, user_guide/feature_guide/quantization.md, user_guide/release_notes.md, user_guide/support_matrix/index.md, user_guide/support_matrix/supported_features.md, user_guide/support_matrix/supported_models.md
myst v4.0.1: MdParserConfig(commonmark_only=False, gfm_only=False, enable_extensions={'colon_fence', 'substitution'}, disable_syntax=[], all_links_external=False, links_external_new_tab=False, url_schemes=('http', 'https', 'mailto', 'ftp'), ref_domains=None, fence_as_directive=set(), number_code_blocks=[], title_to_header=False, heading_anchors=5, heading_slug_func=None, html_meta={}, footnote_sort=True, footnote_transition=True, words_per_minute=200, substitutions={vllm_version: ..., vllm_kunlun_version: ..., pip_vllm_kunlun_version: ..., pip_vllm_version: ..., ci_vllm_version: ...}, linkify_fuzzy_links=True, dmath_allow_labels=True, dmath_allow_space=True, dmath_allow_digits=True, dmath_double_inline=False, update_mathjax=True, mathjax_classes='tex2jax_process|mathjax_process|math|output_area', enable_checkboxes=False, suppress_warnings=[], highlight_code_blocks=True)
building [mo]: targets for 0 po files that are out of date
writing output... 
building [html]: targets for 0 source files that are out of date
updating environment: 0 added, 0 changed, 0 removed
reading sources... 
looking for now-outdated files... none found
no targets are out of date.
build succeeded.

The HTML pages are in _build/html.

$ python check_render.py
v0.15.1-dev: False
|vllm_kunlun_version|: False
|pip_vllm_version|: False
```

</details>

## Test plan

- [x] `sphinx-build -b html source _build/html`
- [x] Confirm rendered `installation.html` no longer contains `v0.15.1-dev`
- [x] Confirm no existing PR uses `Lidang-Jiang:fix/issue-324-doc-installation-ref`
