### PR TITLE
[Doc] Clarify Docker image tags and pull checks

### DIFF
--- a/docs/source/faqs.md
+++ b/docs/source/faqs.md
@@ -20,7 +20,23 @@ We will support the kunlun4 M100 platform in early 2026.
 
 ### 2. How to get our docker containers?
 
-**base**:`docker pull wjie520/vllm_kunlun:v0.0.1`.
+Use the public Docker Hub image:
+
+```bash
+docker pull wjie520/vllm_kunlun:uv_base
+```
+
+To check whether the tag exists before downloading the full image, run:
+
+```bash
+docker manifest inspect wjie520/vllm_kunlun:uv_base >/dev/null
+```
+
+If the manifest check succeeds but `docker pull` times out, the tag exists and
+the failure is usually caused by Docker Hub connectivity, proxy, or registry
+mirror configuration. If the manifest check also times out, configure your
+Docker network access first and retry the check. The internal registry image
+listed in the installation guide is only available from the Baidu intranet.
 
 ### 3. How vllm-kunlun work with vLLM?
 

--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -11,11 +11,26 @@ This document describes how to install vllm-kunlun manually.
   - vLLM (same version as vllm-kunlun)
 
 ## Setup environment using container
-We provide a clean and minimal base image for your use.You can pull it using the docker pull command.
-- **Internal registry (Baidu intranet only)**  
-  `iregistry.baidu-int.com/hac_test/aiak-inference-llm:vLLM-Kunlun-Base`
-- **Public registry**  
+We provide clean and minimal base images for your use. Choose the image source
+based on your network:
+
+- **Public registry**:
   `wjie520/vllm_kunlun:uv_base`
+- **Internal registry (Baidu intranet only)**:
+  `iregistry.baidu-int.com/hac_test/aiak-inference-llm:vLLM-Kunlun-Base`
+
+Before pulling the image, you can verify that the public tag exists without
+downloading the full image:
+
+```bash
+docker manifest inspect wjie520/vllm_kunlun:uv_base >/dev/null
+```
+
+If the manifest check succeeds but `docker pull` times out, the image tag is
+available and the failure is usually caused by Docker Hub connectivity, proxy, or
+registry mirror configuration. If the manifest check also times out, configure
+your Docker network access first and retry the check. The internal registry is
+only reachable from the Baidu intranet.
 
 ### Container startup script
 
@@ -37,7 +52,7 @@ if [ $XPU_NUM -gt 0 ]; then
     DOCKER_DEVICE_CONFIG="${DOCKER_DEVICE_CONFIG} --device=/dev/xpuctrl:/dev/xpuctrl"
 fi
 export build_image="wjie520/vllm_kunlun:uv_base"
-# or export build_image="iregistry.baidu-int.com/xmlir/xmlir_ubuntu_2004_x86_64:v0.32"
+# or export build_image="iregistry.baidu-int.com/hac_test/aiak-inference-llm:vLLM-Kunlun-Base"
 
 docker run -itd ${DOCKER_DEVICE_CONFIG} \
     --net=host \


### PR DESCRIPTION
## Summary

- Clarify the public Docker Hub image and the Baidu intranet-only image in the installation guide.
- Replace the outdated FAQ pull example with `wjie520/vllm_kunlun:uv_base`.
- Add a lightweight manifest check and explain how to distinguish tag existence from network/proxy/mirror pull failures.
- Align the internal image in the container startup script example.

Fixes #323.

<details>
<summary>Before</summary>

````text
$ git show HEAD^:docs/source/faqs.md | sed -n '21,27p'
### 2. How to get our docker containers?

**base**:`docker pull wjie520/vllm_kunlun:v0.0.1`.

### 3. How vllm-kunlun work with vLLM?

vllm-kunlun is a hardware plugin for vLLM. Basically, the version of vllm-kunlun is the same as the version of vllm. For example, if you use vllm 0.15.1, you should use vllm-kunlun 0.15.1 as well. For main branch, we will make sure `vllm-kunlun` and `vllm` are compatible by each commit.

$ git show HEAD^:docs/source/installation.md | sed -n '13,42p'
## Setup environment using container
We provide a clean and minimal base image for your use.You can pull it using the docker pull command.
- **Internal registry (Baidu intranet only)**  
  `iregistry.baidu-int.com/hac_test/aiak-inference-llm:vLLM-Kunlun-Base`
- **Public registry**  
  `wjie520/vllm_kunlun:uv_base`

### Container startup script

:::::{tab-set}
:sync-group: install

::::{tab-item} start_docker.sh
:selected:
:sync: uv pip

```{code-block} bash
#!/bin/bash
XPU_NUM=8
DOCKER_DEVICE_CONFIG=""
if [ $XPU_NUM -gt 0 ]; then
    for idx in $(seq 0 $((XPU_NUM-1))); do
        DOCKER_DEVICE_CONFIG="${DOCKER_DEVICE_CONFIG} --device=/dev/xpu${idx}:/dev/xpu${idx}"
    done
    DOCKER_DEVICE_CONFIG="${DOCKER_DEVICE_CONFIG} --device=/dev/xpuctrl:/dev/xpuctrl"
fi
export build_image="wjie520/vllm_kunlun:uv_base"
# or export build_image="iregistry.baidu-int.com/xmlir/xmlir_ubuntu_2004_x86_64:v0.32"

docker run -itd ${DOCKER_DEVICE_CONFIG} \
````

</details>

<details>
<summary>After</summary>

````text
$ git diff --check HEAD^..HEAD
(no output)

$ /workspace/python310_torch25_cuda/bin/sphinx-build -b html source _build/html
/workspace/python310_torch25_cuda/lib/python3.10/site-packages/xpytorch_import_hook.py:6: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
  import pkg_resources
Running Sphinx v8.1.3
loading translations [en]... done
making output directory... done
[autosummary] generating autosummary for: community/contributors.md, community/governance.md, community/user_stories/index.md, community/versioning_policy.md, developer_guide/contribution/contributing.md, developer_guide/contribution/index.md, developer_guide/evaluation/accuracy/accuracy_kernel.md, developer_guide/evaluation/accuracy/accuracy_server.md, developer_guide/evaluation/accuracy/index.md, developer_guide/evaluation/accuracy_report/GLM-4.5-Air.md, ..., user_guide/configuration/env_vars.md, user_guide/configuration/index.md, user_guide/feature_guide/graph_mode.md, user_guide/feature_guide/index.md, user_guide/feature_guide/lora.md, user_guide/feature_guide/quantization.md, user_guide/release_notes.md, user_guide/support_matrix/index.md, user_guide/support_matrix/supported_features.md, user_guide/support_matrix/supported_models.md
myst v4.0.1: MdParserConfig(commonmark_only=False, gfm_only=False, enable_extensions={'colon_fence', 'substitution'}, disable_syntax=[], all_links_external=False, links_external_new_tab=False, url_schemes=('http', 'https', 'mailto', 'ftp'), ref_domains=None, fence_as_directive=set(), number_code_blocks=[], title_to_header=False, heading_anchors=5, heading_slug_func=None, html_meta={}, footnote_sort=True, footnote_transition=True, words_per_minute=200, substitutions={vllm_version: ..., vllm_kunlun_version: ..., pip_vllm_kunlun_version: ..., pip_vllm_version: ..., ci_vllm_version: ...}, linkify_fuzzy_links=True, dmath_allow_labels=True, dmath_allow_space=True, dmath_allow_digits=True, dmath_double_inline=False, update_mathjax=True, mathjax_classes='tex2jax_process|mathjax_process|math|output_area', enable_checkboxes=False, suppress_warnings=[], highlight_code_blocks=True)
building [mo]: targets for 0 po files that are out of date
writing output... 
building [html]: targets for 45 source files that are out of date
updating environment: [new config] 45 added, 0 changed, 0 removed
reading sources... [  2%] community/contributors
reading sources... [  4%] community/governance
reading sources... [  7%] community/user_stories/index
reading sources... [  9%] community/versioning_policy
reading sources... [ 11%] developer_guide/contribution/contributing
reading sources... [ 13%] developer_guide/contribution/index
reading sources... [ 16%] developer_guide/evaluation/accuracy/accuracy_kernel
reading sources... [ 18%] developer_guide/evaluation/accuracy/accuracy_server
reading sources... [ 20%] developer_guide/evaluation/accuracy/index
reading sources... [ 22%] developer_guide/evaluation/accuracy_report/GLM-4.5
reading sources... [ 24%] developer_guide/evaluation/accuracy_report/GLM-4.5-Air
reading sources... [ 27%] developer_guide/evaluation/accuracy_report/InternVL3_5-30B-A3B
reading sources... [ 29%] developer_guide/evaluation/accuracy_report/Qwen2.5-VL-7B-Instruct
reading sources... [ 31%] developer_guide/evaluation/accuracy_report/index
reading sources... [ 33%] developer_guide/evaluation/index
reading sources... [ 36%] developer_guide/feature_guide/Kunlun_Graph
reading sources... [ 38%] developer_guide/feature_guide/index
reading sources... [ 40%] developer_guide/performance/index
reading sources... [ 42%] developer_guide/performance/performance_benchmark/benchmark_kernel
reading sources... [ 44%] developer_guide/performance/performance_benchmark/benchmark_server
reading sources... [ 47%] developer_guide/performance/performance_benchmark/index
reading sources... [ 49%] developer_guide/performance/performance_benchmark/profiling
reading sources... [ 51%] faqs
reading sources... [ 53%] index
reading sources... [ 56%] installation
reading sources... [ 58%] quick_start
reading sources... [ 60%] tutorials/index
reading sources... [ 62%] tutorials/multi_xpu_DeepSeek-V3.2-Exp-w8a8
reading sources... [ 64%] tutorials/multi_xpu_GLM-4.5
reading sources... [ 67%] tutorials/multi_xpu_GLM-5-W8A8-INT8
reading sources... [ 69%] tutorials/multi_xpu_Qwen2.5-VL-32B
reading sources... [ 71%] tutorials/multi_xpu_Qwen3-Coder-480B-A35B(W8A8)
reading sources... [ 73%] tutorials/single_xpu_InternVL2_5-26B
reading sources... [ 76%] tutorials/single_xpu_Qwen3-8B
reading sources... [ 78%] tutorials/single_xpu_Qwen3-VL-32B
reading sources... [ 80%] user_guide/configuration/env_vars
reading sources... [ 82%] user_guide/configuration/index
reading sources... [ 84%] user_guide/feature_guide/graph_mode
reading sources... [ 87%] user_guide/feature_guide/index
reading sources... [ 89%] user_guide/feature_guide/lora
reading sources... [ 91%] user_guide/feature_guide/quantization
reading sources... [ 93%] user_guide/release_notes
reading sources... [ 96%] user_guide/support_matrix/index
reading sources... [ 98%] user_guide/support_matrix/supported_features
reading sources... [100%] user_guide/support_matrix/supported_models

looking for now-outdated files... none found
pickling environment... done
checking consistency... done
preparing documents... done
copying assets... 
copying static files... 
Writing evaluated template result to /workspace/vLLM-Kunlun-issue-323/docs/_build/html/_static/language_data.js
Writing evaluated template result to /workspace/vLLM-Kunlun-issue-323/docs/_build/html/_static/documentation_options.js
Writing evaluated template result to /workspace/vLLM-Kunlun-issue-323/docs/_build/html/_static/basic.css
Writing evaluated template result to /workspace/vLLM-Kunlun-issue-323/docs/_build/html/_static/copybutton.js
copying static files: done
copying extra files... 
copying extra files: done
copying assets: done
writing output... [  2%] community/contributors
writing output... [  4%] community/governance
writing output... [  7%] community/user_stories/index
writing output... [  9%] community/versioning_policy
writing output... [ 11%] developer_guide/contribution/contributing
writing output... [ 13%] developer_guide/contribution/index
writing output... [ 16%] developer_guide/evaluation/accuracy/accuracy_kernel
writing output... [ 18%] developer_guide/evaluation/accuracy/accuracy_server
writing output... [ 20%] developer_guide/evaluation/accuracy/index
writing output... [ 22%] developer_guide/evaluation/accuracy_report/GLM-4.5
writing output... [ 24%] developer_guide/evaluation/accuracy_report/GLM-4.5-Air
writing output... [ 27%] developer_guide/evaluation/accuracy_report/InternVL3_5-30B-A3B
writing output... [ 29%] developer_guide/evaluation/accuracy_report/Qwen2.5-VL-7B-Instruct
writing output... [ 31%] developer_guide/evaluation/accuracy_report/index
writing output... [ 33%] developer_guide/evaluation/index
writing output... [ 36%] developer_guide/feature_guide/Kunlun_Graph
writing output... [ 38%] developer_guide/feature_guide/index
writing output... [ 40%] developer_guide/performance/index
writing output... [ 42%] developer_guide/performance/performance_benchmark/benchmark_kernel
writing output... [ 44%] developer_guide/performance/performance_benchmark/benchmark_server
writing output... [ 47%] developer_guide/performance/performance_benchmark/index
writing output... [ 49%] developer_guide/performance/performance_benchmark/profiling
writing output... [ 51%] faqs
writing output... [ 53%] index
writing output... [ 56%] installation
writing output... [ 58%] quick_start
writing output... [ 60%] tutorials/index
writing output... [ 62%] tutorials/multi_xpu_DeepSeek-V3.2-Exp-w8a8
writing output... [ 64%] tutorials/multi_xpu_GLM-4.5
writing output... [ 67%] tutorials/multi_xpu_GLM-5-W8A8-INT8
writing output... [ 69%] tutorials/multi_xpu_Qwen2.5-VL-32B
writing output... [ 71%] tutorials/multi_xpu_Qwen3-Coder-480B-A35B(W8A8)
writing output... [ 73%] tutorials/single_xpu_InternVL2_5-26B
writing output... [ 76%] tutorials/single_xpu_Qwen3-8B
writing output... [ 78%] tutorials/single_xpu_Qwen3-VL-32B
writing output... [ 80%] user_guide/configuration/env_vars
writing output... [ 82%] user_guide/configuration/index
writing output... [ 84%] user_guide/feature_guide/graph_mode
writing output... [ 87%] user_guide/feature_guide/index
writing output... [ 89%] user_guide/feature_guide/lora
writing output... [ 91%] user_guide/feature_guide/quantization
writing output... [ 93%] user_guide/release_notes
writing output... [ 96%] user_guide/support_matrix/index
writing output... [ 98%] user_guide/support_matrix/supported_features
writing output... [100%] user_guide/support_matrix/supported_models

generating indices... genindex done
writing additional pages... search done
copying images... [100%] logos/vllm-kunlun-logo-text-light.png

dumping search index in English (code: en)... done
dumping object inventory... done
build succeeded.

The HTML pages are in _build/html.

$ Docker Hub Registry API manifest checks for documented tags
v0.0.1 MANIFEST_HTTP_STATUS=200
schemaVersion=2
mediaType=application/vnd.docker.distribution.manifest.v2+json
config_digest=sha256:2fbaf9b190aed9dfde6abcdf42f23c1fbdf9ed97b276187d8efdad0376a16de9
uv_base MANIFEST_HTTP_STATUS=200
schemaVersion=2
mediaType=application/vnd.docker.distribution.manifest.v2+json
config_digest=sha256:1ad7e0859219aac315bccbb9a3d319fb4236660729ce976c6458a304e048a8cf

$ Docker Hub tag API for wjie520/vllm_kunlun:uv_base
tag_name=uv_base
last_updated=2026-02-09T08:54:47.591721Z
full_size=8120800756
digest=sha256:e295fcd8a52d44bf67cde8ddd9f91240f2d49e5c0e1dd2d67df0ea51d3a44d1e
platforms=linux/amd64

$ curl -sS --max-time 1200 http://127.0.0.1:8566/v1/chat/completions -H 'Content-Type: application/json' -d '{"model":"Qwen2.5-72B-Instruct","messages":[{"role":"user","content":"Reply with exactly: OK"}],"max_tokens":4,"temperature":0,"top_p":1.0,"stop":["\\n"]}' -o /tmp/vllm323_chat.json -w 'HTTP_STATUS=%{http_code}\\nTOTAL_TIME=%{time_total}\\n'
HTTP_STATUS=200
TOTAL_TIME=0.275906
{"id":"chatcmpl-bd56fc2f819a1f4d","object":"chat.completion","created":1776666065,"model":"Qwen2.5-72B-Instruct","choices":[{"index":0,"message":{"role":"assistant","content":"OK","refusal":null,"annotations":null,"audio":null,"function_call":null,"tool_calls":[],"reasoning":null},"logprobs":null,"finish_reason":"stop","stop_reason":null,"token_ids":null}],"service_tier":null,"system_fingerprint":null,"usage":{"prompt_tokens":34,"total_tokens":36,"completion_tokens":2,"prompt_tokens_details":null},"prompt_logprobs":null,"prompt_token_ids":null,"kv_transfer_params":null}
PARSED_CONTENT=OK

$ VLLM_SERVER_HOST=127.0.0.1 /workspace/python310_torch25_cuda/bin/python test_service.py
[Config] Using host from VLLM_SERVER_HOST: 127.0.0.1
[Config] Chat completion endpoint: http://127.0.0.1:8566/v1/chat/completions
[Config] Model: Qwen2.5-72B-Instruct
[Result] HTTP status: 200
[Result] Prompt: Reply with exactly: OK
[Result] Raw response: {"id":"chatcmpl-bb7fefd932075b32","object":"chat.completion","created":1776666071,"model":"Qwen2.5-72B-Instruct","choices":[{"index":0,"message":{"role":"assistant","content":"OK","refusal":null,"annotations":null,"audio":null,"function_call":null,"tool_calls":[],"reasoning":null},"logprobs":null,"finish_reason":"stop","stop_reason":null,"token_ids":null}],"service_tier":null,"system_fingerprint":null,"usage":{"prompt_tokens":34,"total_tokens":36,"completion_tokens":2,"prompt_tokens_details":null},"prompt_logprobs":null,"prompt_token_ids":null,"kv_transfer_params":null}
[Result] Parsed content: OK
````

</details>

## Test plan

- [x] `git diff --check HEAD^..HEAD`
- [x] `/workspace/python310_torch25_cuda/bin/sphinx-build -b html source _build/html`
- [x] Docker Hub Registry API manifest check for `wjie520/vllm_kunlun:uv_base`
- [x] Qwen2.5-72B-Instruct `/v1/chat/completions` curl smoke test returns `OK`
