### PR TITLE
[Kernel] Add moe_pre_small kernel for compressed_tensors_moe

### DIFF
--- a/vllm_kunlun/quantization/compressed_tensors/compressed_tensors_moe.py
+++ b/vllm_kunlun/quantization/compressed_tensors/compressed_tensors_moe.py
@@ -169,30 +169,42 @@ class KunlunCompressedTensorsW8A8Int8MoEMethod(CompressedTensorsW8A8Int8MoEMetho
                 scale=routed_scaling_factor,
             )
 
-        moe_expand = torch.empty(
-            (M * top_k, N), dtype=hidden_states.dtype, device=hidden_states.device
-        )  # [M, top_k, N], float
-        expert_m = torch.zeros(
-            global_num_experts, dtype=torch.int32, device=hidden_states.device
-        )  # [E]
-        sorted_tokens_num_lod = torch.zeros(
-            global_num_experts + 1, dtype=torch.int32, device=hidden_states.device
-        )  # [E+1]
-        sorted_tokens_idx = torch.zeros(
-            M * top_k, dtype=torch.int32, device=hidden_states.device
-        )
+        if M * top_k > 768:
+            moe_expand = torch.empty(
+                (M * top_k, N), dtype=hidden_states.dtype, device=hidden_states.device
+            )  # [M, top_k, N], float
+            expert_m = torch.zeros(
+                global_num_experts, dtype=torch.int32, device=hidden_states.device
+            )  # [E]
+            sorted_tokens_num_lod = torch.zeros(
+                global_num_experts + 1, dtype=torch.int32, device=hidden_states.device
+            )  # [E+1]
+            sorted_tokens_idx = torch.zeros(
+                M * top_k, dtype=torch.int32, device=hidden_states.device
+            )
 
-        torch.ops._C.gen_block_statistic(topk_ids, block_statistic)
+            torch.ops._C.gen_block_statistic(topk_ids, block_statistic)
 
-        torch.ops._C.moe_pre_sorted(
-            x=hidden_states,
-            topk_index=topk_ids,
-            block_statistic=block_statistic,
-            moe_expand=moe_expand,
-            moe_index=sorted_tokens_idx,
-            expert_m=expert_m,
-            sorted_tokens_num_lod=sorted_tokens_num_lod,
-        )
+            torch.ops._C.moe_pre_sorted(
+                x=hidden_states,
+                topk_index=topk_ids,
+                block_statistic=block_statistic,
+                moe_expand=moe_expand,
+                moe_index=sorted_tokens_idx,
+                expert_m=expert_m,
+                sorted_tokens_num_lod=sorted_tokens_num_lod,
+            )
+            del expert_m
+        else:
+            sorted_tokens_idx, sorted_tokens_num_lod, moe_expand = (
+                torch.ops.xspeedgate_ops.moe_pre_small(
+                    topk_ids,
+                    global_num_experts,
+                    index_have_neg=False,
+                    sort_mode=True,
+                    x=hidden_states,
+                )
+            )
 
         y = torch.empty(
             M,
@@ -261,7 +273,7 @@ class KunlunCompressedTensorsW8A8Int8MoEMethod(CompressedTensorsW8A8Int8MoEMetho
             # sort_mode=False,
             act=None,
         )
-        del x_q, x_scale, sorted_tokens_num_lod, expert_m
+        del x_q, x_scale, sorted_tokens_num_lod
 
         dequant_scale = torch.ones([M, top_k], dtype=torch.float32, device=out.device)
         output = torch.empty(


### PR DESCRIPTION
## PR Description

<!--
Please provide a clear and concise description of this PR:
- What problem does it solve?
- Why is this change needed?
- What is the overall approach?
-->
This PR optimizes the MoE pre-processing stage in apply_monolithic by introducing a specialized execution path for small workloads.

A conditional branch is introduced based on workload size:
Large workload (M * top_k > 768), Keep the original path:
_C.gen_block_statistic
_C.moe_pre_sorted

Small workload (M * top_k <= 768), Use a lightweight kernel:
xspeedgate_ops.moe_pre_small

<!-- Link the existing issue(s) this PR resolves, e.g.:
FIX #1234
-->

---

## Verification
single curl test result:
<img width="1255" height="534" alt="image" src="https://github.com/user-attachments/assets/72878016-7fdc-433a-9ac9-9ab0584fad71" />
accuracy / output check:
<img width="958" height="270" alt="image" src="https://github.com/user-attachments/assets/de7e6dd7-430e-4a97-8800-ce66cb03cb6a" />

origin performance testting:
<img width="804" height="464" alt="image" src="https://github.com/user-attachments/assets/a16fa561-b90e-49c3-954b-48b986287f80" />

performance optimization:
<img width="778" height="285" alt="image" src="https://github.com/user-attachments/assets/e958e968-0369-4eae-951d-71ffe4395dd9" />
