### PR TITLE
[Feature][Core] Workaround: Align KVCache precision with GDN forward pass

### DIFF
--- a/vllm_kunlun/models/config.py
+++ b/vllm_kunlun/models/config.py
@@ -585,27 +585,19 @@ class NemotronHForCausalLMConfig(VerifyAndUpdateConfig):
 class Qwen3_5ForConditionalGenerationConfig(VerifyAndUpdateConfig):
     @staticmethod
     def verify_and_update_config(vllm_config: "VllmConfig") -> None:
-        """Update mamba_ssm_cache_dtype for Qwen3.5 models when set to 'auto'
-        (or not explicitly set), to the value specified in the HF config's
-        mamba_ssm_dtype field. Warn if the user explicitly overrides it to a
-        different value.
-        """
-        cache_config = vllm_config.cache_config
+        # TODO: Once vllm_kunlun supports float32 GDN forward, restore
+        # propagation of hf_text_config.mamba_ssm_dtype to
+        # cache_config.mamba_ssm_cache_dtype so that temporal_state can
+        # be allocated at float32 as the HF config specifies.
         hf_text_config = vllm_config.model_config.hf_text_config
         mamba_ssm_dtype = getattr(hf_text_config, "mamba_ssm_dtype", None)
-        if cache_config.mamba_ssm_cache_dtype == "auto":
-            if mamba_ssm_dtype is not None:
-                cache_config.mamba_ssm_cache_dtype = mamba_ssm_dtype
-        elif (
-            mamba_ssm_dtype is not None
-            and cache_config.mamba_ssm_cache_dtype != mamba_ssm_dtype
-        ):
+        if mamba_ssm_dtype is not None and mamba_ssm_dtype == "float32":
             logger.warning(
                 "Qwen3.5 model specifies mamba_ssm_dtype='%s' in its config, "
-                "but --mamba-ssm-cache-dtype='%s' was passed. "
-                "Using the user-specified value.",
+                "but vllm_kunlun does not support float32 GDN forward. "
+                "Ignoring this setting; KVCache will use model_dtype instead "
+                "to avoid wasting memory.",
                 mamba_ssm_dtype,
-                cache_config.mamba_ssm_cache_dtype,
             )
 
 

--- a/vllm_kunlun/models/qwen3_5.py
+++ b/vllm_kunlun/models/qwen3_5.py
@@ -746,10 +746,16 @@ class Qwen3_5ForConditionalGeneration(Qwen3VLForConditionalGeneration, IsHybrid)
         cls,
         vllm_config: "VllmConfig",
     ) -> tuple[torch.dtype, torch.dtype]:
+        # TODO: Once vllm_kunlun supports float32 GDN forward, switch to
+        # using hf_text_config.mamba_ssm_dtype and the kunlun version of
+        # mamba_utils (3-param gated_delta_net_state_dtype) to allow
+        # separate dtype control for conv_state and temporal_state.
+        # Currently we use cache_config.mamba_cache_dtype (default "auto"
+        # -> model_dtype) because kunlun always runs GDN in float16.
+        # Allocating KVCache as float32 would waste half the memory.
         return MambaStateDtypeCalculator.gated_delta_net_state_dtype(
             vllm_config.model_config.dtype,
             vllm_config.cache_config.mamba_cache_dtype,
-            vllm_config.cache_config.mamba_ssm_cache_dtype,
         )
 
     @classmethod


### PR DESCRIPTION
## PR Description

**What problem does it solve?**
The Qwen3.5-35B-A3B model's HF config specifies "mamba_ssm_dtype": "float32". vllm's mamba_utils allocates KVCache based on this dtype, using float32 (4 bytes/element). However, vllm_kunlun does not
   support float32 GDN (Gated Delta Net) forward — the actual computation always runs in float16 (2 bytes/element). This causes 50% memory waste in mamba state KVCache.

**Why is this change needed?**
qwen3_5.py's get_mamba_state_dtype_from_config reads "float32" directly from hf_text_config.mamba_ssm_dtype and passes it as mamba_cache_dtype to gated_delta_net_state_dtype, causing both conv_state
   and temporal_state to be allocated as float32. In contrast, qwen3_next.py and other models use cache_config.mamba_cache_dtype (default "auto" → model_dtype), which does not have this issue.
  Additionally, Qwen3_5ForConditionalGenerationConfig in config.py propagates "float32" to cache_config.mamba_ssm_cache_dtype, further hardcoding the incorrect dtype.

**What is the overall approach?**
- models/qwen3_5.py: Change get_mamba_state_dtype_from_config to use cache_config.mamba_cache_dtype (consistent with qwen3_next.py) instead of reading mamba_ssm_dtype from HF config directly.
  - models/config.py: Qwen3_5ForConditionalGenerationConfig.verify_and_update_config no longer propagates HF config's mamba_ssm_dtype to cache_config.mamba_ssm_cache_dtype. It only logs a warning when
   float32 is detected to inform users that the setting is ignored.
  - Both changes include # TODO comments indicating that the original logic should be restored once vllm_kunlun supports float32 GDN forward, switching to the kunlun version of mamba_utils (3-param
  gated_delta_net_state_dtype with separate dtype control for conv_state and temporal_state).

FIX # N/A

---

## Checklist (Required)

Before submitting this PR, please ensure that all the following items are completed:

- [x] All code changes pass the [`pre-commit`](https://github.com/baidu/vLLM-Kunlun/blob/main/CONTRIBUTING.md) checks.
- [x] Commits are signed off using `git commit -s`.
- [x] The PR title is properly classified (see below).

---

## PR Type

Please prefix the PR title with one or more of the following labels to help reviewers quickly understand the nature of the change:

- `[Feature]` – New features or enhancements (e.g. Attention, Communicator, Kernel, Worker, etc.)
- `[Bugfix]` – Bug fixes
- `[CI/Build]` – CI, build system, or infrastructure improvements
- `[Doc]` – Documentation updates or fixes
- `[Misc]` – Other changes that do not fit the above categories (use sparingly)

> **Note:** If the PR spans multiple categories, include all relevant prefixes.