### PR TITLE
[Feature] Add DeepSeek V3.2 W8A8 INT8 model support

### DIFF
--- a/.github/workflows/ut.yml
+++ b/.github/workflows/ut.yml
@@ -40,7 +40,7 @@
 
 #       - name: Install vLLM
 #         run: |
-#           pip install vllm==0.11.0 --no-build-isolation --no-deps --no-deps --index-url https://pip.baidu-int.com/simple/
+#           pip install vllm==0.19.0 --no-build-isolation --no-deps --no-deps --index-url https://pip.baidu-int.com/simple/
 
 #       - name: Run Unit Test
 #         run: |

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ Please use the following recommended versions to get started quickly:
 
 | Version | Release type | Doc |
 |----------|---------------|-----|
-| v0.15.1 | Latest development version | [QuickStart](https://vllm-kunlun.readthedocs.io/en/latest/quick_start.html) and [Installation](https://vllm-kunlun.readthedocs.io/en/latest/installation.html) for more details |
+| v0.19.0 | Target development version | [QuickStart](https://vllm-kunlun.readthedocs.io/en/latest/quick_start.html) and [Installation](https://vllm-kunlun.readthedocs.io/en/latest/installation.html) for more details |
 
 ---
 

--- a/ci/scripts/docker/start_docker.sh
+++ b/ci/scripts/docker/start_docker.sh
@@ -76,7 +76,7 @@ docker run \
   --name="${DOCKER_NAME}" \
   -v /home:/home \
   -v "${WORKSPACE_MOUNT}" \
-  -v /ssd2:/ssd2 \
+  -v /ssd1:/ssd1 \
   -v /ssd1:/ssd1 \
   -v /ssd3:/ssd3 \
   -v /dev/shm:/dev/shm \

--- a/ci/scripts/docker/start_docker.sh
+++ b/ci/scripts/docker/start_docker.sh
@@ -77,7 +77,6 @@ docker run \
   -v /home:/home \
   -v "${WORKSPACE_MOUNT}" \
   -v /ssd1:/ssd1 \
-  -v /ssd1:/ssd1 \
   -v /ssd3:/ssd3 \
   -v /dev/shm:/dev/shm \
   -v /usr/lib64/libcuda.so.1:/usr/lib64/libcuda.so.1 \

--- a/ci/scripts/env/install_env.sh
+++ b/ci/scripts/env/install_env.sh
@@ -71,6 +71,7 @@ docker exec "${DOCKER_NAME}" bash -lc "
   pip install \
     \"https://baidu-kunlun-public.su.bcebos.com/v1/baidu-kunlun-share/1130/xtorch_ops-0.1.2209%2B6752ad20-cp310-cp310-linux_x86_64.whl?authorization=bce-auth-v1%2FALTAKypXxBzU7gg4Mk4K4c6OYR%2F2025-12-05T06%3A18%3A00Z%2F-1%2Fhost%2F14936c2b7e7c557c1400e4c467c79f7a9217374a7aa4a046711ac4d948f460cd\"
 
+  # TODO: replace this transitional Triton wheel once the 0.19.0 artifact is published.
   pip install \
     \"https://cce-ai-models.bj.bcebos.com/v1/vllm-kunlun-0.11.0/triton-3.0.0%2Bb2cde523-cp310-cp310-linux_x86_64.whl\"
 
@@ -87,14 +88,14 @@ docker exec "${DOCKER_NAME}" bash -lc "
   source \"${GITHUB_WORKSPACE}/vLLM-Kunlun/setup_env.sh\"
 
   ########################################
-  # 3. Install upstream vLLM 0.11.0
+  # 3. Install upstream vLLM 0.19.0
   ########################################
-  echo '===== Installing vLLM==0.11.0 ====='
+  echo '===== Installing vLLM==0.19.0 ====='
 
   pip uninstall -y vllm || true
   env | grep -i proxy || true
 
-  pip install vllm==0.11.0 \
+  pip install vllm==0.19.0 \
     --no-build-isolation \
     --no-deps \
     --index-url https://pip.baidu-int.com/simple/

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -65,17 +65,17 @@ myst_substitutions = {
     # the branch of vllm, used in vllm clone
     # - main branch: 'main'
     # - vX.Y.Z branch: 'vX.Y.Z'
-    "vllm_version": "v0.15.1",
+    "vllm_version": "v0.19.0",
     # the branch of vllm-kunlun, used in vllm-kunlun clone and image tag
     # - main branch: 'main'
     # - vX.Y.Z branch: latest vllm-kunlun release tag
-    "vllm_kunlun_version": "v0.15.1",
+    "vllm_kunlun_version": "main",
     # the newest release version of vllm-kunlun and matched vLLM, used in pip install.
     # This value should be updated when cut down release.
-    "pip_vllm_kunlun_version": "0.15.1",
-    "pip_vllm_version": "0.15.1",
+    "pip_vllm_kunlun_version": "0.19.0",
+    "pip_vllm_version": "0.19.0",
     # vllm version in ci
-    "ci_vllm_version": "v0.15.1",
+    "ci_vllm_version": "v0.19.0",
 }
 
 # For cross-file header anchors
@@ -116,7 +116,7 @@ html_logo = "logos/vllm-kunlun-logo-text-light.png"
 html_theme_options = {
     "path_to_docs": "docs/source",
     "repository_url": "https://github.com/baidu/vLLM-Kunlun",
-    "repository_branch": "v0.15.1-dev",
+    "repository_branch": "main",
     "use_repository_button": True,
     "use_edit_page_button": True,
 }

--- a/docs/source/faqs.md
+++ b/docs/source/faqs.md
@@ -2,7 +2,7 @@
 
 ## Version Specific FAQs
 
-- [[v0.15.1] FAQ & Feedback]
+- [[v0.19.0] FAQ & Feedback]
 
 ## General FAQs
 
@@ -24,7 +24,7 @@ We will support the kunlun4 M100 platform in early 2026.
 
 ### 3. How vllm-kunlun work with vLLM?
 
-vllm-kunlun is a hardware plugin for vLLM. Basically, the version of vllm-kunlun is the same as the version of vllm. For example, if you use vllm 0.15.1, you should use vllm-kunlun 0.15.1 as well. For main branch, we will make sure `vllm-kunlun` and `vllm` are compatible by each commit.
+vllm-kunlun is a hardware plugin for vLLM. Basically, the version of vllm-kunlun is the same as the version of vllm. For example, if you use vllm 0.19.0, you should use vllm-kunlun 0.19.0 as well. For main branch, we will make sure `vllm-kunlun` and `vllm` are compatible by each commit.
 
 ### 4. How to handle the out-of-memory issue?
 

--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -53,10 +53,10 @@ docker run -itd ${DOCKER_DEVICE_CONFIG} \
 ::::
 :::::
 ## Install vLLM-kunlun
-### Install vLLM 0.15.1
+### Install vLLM 0.19.0
 
 ```
-uv pip install vllm==0.15.1 --no-build-isolation --no-deps
+uv pip install vllm==0.19.0 --no-build-isolation --no-deps
 ```
 
 ### Build and Install
@@ -67,13 +67,15 @@ git clone https://github.com/baidu/vLLM-Kunlun
 
 cd vLLM-Kunlun
 
-git checkout v0.15.1-dev
+git checkout main
 
 uv pip install -r requirements.txt
 
 python setup.py build
 
 python setup.py install
+
+python vllm_kunlun/patches/patch_torch251.py
 ```
 
 ### Replace eval_frame.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "vllm-kunlun"
-version = "0.15.1.dev0"
+version = "0.19.0"
 description = "vLLM Kunlun3 backend plugin"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -12,19 +12,24 @@ license = { text = "MIT" }
 authors = [{ name = "kunlun"}]
 dependencies = []
 
-[project.scripts]
-vllm-kunlun = "vllm_kunlun.cmdline:main"
-
 [project.entry-points."vllm.platform_plugins"]
 kunlun = "vllm_kunlun:register"
 
 [project.entry-points."vllm.general_plugins"]
 kunlun_model = "vllm_kunlun:register_model"
+kunlun_quant = "vllm_kunlun.models:register_quant_method"
+
+[project.entry-points."vllm.plugins"]
+kunlun_fused_moe = "vllm_kunlun.ops.fused_moe:register_kunlun_fused_moe_ops"
 
 [tool.hatch.build]
 packages = ["vllm_kunlun"]
 include = ["vllm_kunlun/conf/*", "vllm_kunlun/data/*"]
 
+[tool.hatch.build.targets.sdist]
+artifacts = ["vllm_kunlun/*.so"]
+
 [tool.hatch.build.targets.wheel]
 packages = ["vllm_kunlun"]
+artifacts = ["vllm_kunlun/*.so"]
 output-dir = "output/dist"

--- a/setup.py
+++ b/setup.py
@@ -30,8 +30,9 @@ class CustomBuildExt(BuildExtension):
         for ext in self.extensions:
             ext_path = self.get_ext_fullpath(ext.name)
             file_name = os.path.basename(ext_path)
-            target_path = os.path.join("vllm_kunlun", file_name)
+            target_path = os.path.join(ROOT_DIR, "vllm_kunlun", file_name)
 
+            os.makedirs(os.path.dirname(target_path), exist_ok=True)
             if os.path.exists(target_path):
                 os.remove(target_path)
             shutil.copyfile(ext_path, target_path)
@@ -42,12 +43,12 @@ if __name__ == "__main__":
 
     setup(
         name="vllm_kunlun",
-        version="0.15.1",
+        version="0.19.0",
         author="vLLM-Kunlun team",
         license="Apache 2.0",
         description="vLLM Kunlun3 backend plugin",
         packages=find_packages(exclude=("docs", "examples", "tests*")),
-        package_data={"vllm_kunlun": ["_kunlun.so", "so/*.so", "include/*.h"]},
+        package_data={"vllm_kunlun": ["_kunlun*.so", "so/*.so", "include/*.h"]},
         python_requires=">=3.10",
         ext_modules=ext_modules,
         cmdclass={
@@ -63,6 +64,5 @@ if __name__ == "__main__":
             "vllm.plugins": [
                 "kunlun_fused_moe = vllm_kunlun.ops.fused_moe:register_kunlun_fused_moe_ops"
             ],
-            "console_scripts": ["vllm_kunlun = vllm_kunlun.entrypoints.main:main"],
         },
     )

--- a/tests/ut/test.py
+++ b/tests/ut/test.py
@@ -119,6 +119,153 @@ def test_import_patches_v1_block_table_slot_mapping_kernel():
     assert slot_mapping.tolist() == [16, 17, 29, -1, -1]
 
 
+def test_register_imports_python_custom_ops_when_missing(monkeypatch):
+    import vllm_kunlun
+
+    imported_modules = []
+    monkeypatch.setattr(vllm_kunlun, "_has_required_python_custom_ops", lambda: False)
+    monkeypatch.setattr(
+        vllm_kunlun.importlib,
+        "import_module",
+        lambda name: imported_modules.append(name),
+    )
+
+    vllm_kunlun._ensure_python_custom_ops_registered(
+        SimpleNamespace(info=lambda *args, **kwargs: None)
+    )
+
+    assert imported_modules == ["vllm_kunlun.ops._custom_ops"]
+
+
+def test_register_skips_python_custom_ops_when_present(monkeypatch):
+    import vllm_kunlun
+
+    monkeypatch.setattr(vllm_kunlun, "_has_required_python_custom_ops", lambda: True)
+    monkeypatch.setattr(
+        vllm_kunlun.importlib,
+        "import_module",
+        lambda name: pytest.fail(f"unexpected import: {name}"),
+    )
+
+    vllm_kunlun._ensure_python_custom_ops_registered(
+        SimpleNamespace(info=lambda *args, **kwargs: None)
+    )
+
+
+def test_register_requires_vllm019_cache_mla_custom_op(monkeypatch):
+    import vllm_kunlun
+
+    monkeypatch.setattr(vllm_kunlun, "_has_scaled_int8_quant_op", lambda: True)
+    monkeypatch.setattr(vllm_kunlun, "_has_cache_concat_mla_op", lambda: False)
+
+    assert vllm_kunlun._has_required_python_custom_ops() is False
+
+
+def test_custom_ops_registers_vllm019_cache_mla_alias():
+    import vllm_kunlun
+
+    vllm_kunlun.register()
+
+    assert hasattr(torch.ops._C_cache_ops, "concat_and_cache_mla")
+
+
+def test_scaled_int8_quant_torch_fallback_uses_per_token_absmax():
+    from vllm_kunlun.ops import _custom_ops
+
+    x = torch.tensor(
+        [
+            [[0.0, 1.0, -2.0], [3.0, -3.0, 1.5]],
+            [[0.0, 0.0, 0.0], [1.2, -1.2, 0.6]],
+        ],
+        dtype=torch.float32,
+    )
+    x_q = torch.empty_like(x, dtype=torch.int8)
+    scale = torch.empty((x.numel() // x.shape[-1], 1), dtype=torch.float32)
+
+    _custom_ops._scaled_int8_quant_torch_fallback(x, x_q, scale)
+
+    x_2d = x.reshape(-1, x.shape[-1])
+    expected_scale = torch.amax(torch.abs(x_2d), dim=-1, keepdim=True)
+    denom = torch.where(
+        expected_scale > 0,
+        expected_scale,
+        torch.ones_like(expected_scale),
+    )
+    expected_q = torch.round(x_2d * (127.0 / denom)).clamp_(-127, 127)
+
+    torch.testing.assert_close(scale, expected_scale)
+    assert x_q.reshape(-1, x.shape[-1]).tolist() == expected_q.to(torch.int8).tolist()
+
+
+def test_dynamic_scaled_int8_quant_falls_back_when_quant2d_fails(monkeypatch):
+    from vllm_kunlun.ops import _custom_ops
+
+    def fail_quant2d(**kwargs):
+        raise RuntimeError("quant2d failed")
+
+    monkeypatch.setattr(_custom_ops.kunlun_ops, "quant2d", fail_quant2d)
+    x = torch.tensor([[1.0, -2.0, 0.5]], dtype=torch.float32)
+    x_q = torch.empty_like(x, dtype=torch.int8)
+    scale = torch.empty((1, 1), dtype=torch.float32)
+
+    _custom_ops._dynamic_scaled_int8_quant(x, x_q, scale)
+
+    torch.testing.assert_close(scale, torch.tensor([[2.0]]))
+    assert x_q.tolist() == [[64, -127, 32]]
+
+
+def test_dynamic_scaled_int8_quant_uses_torch_after_sdnn_failure(monkeypatch):
+    from vllm_kunlun.ops import _custom_ops
+
+    calls = []
+
+    def quant2d(**kwargs):
+        calls.append(kwargs["force_sdnn"])
+        raise RuntimeError("sdnn quant2d failed")
+
+    monkeypatch.setattr(_custom_ops.kunlun_ops, "quant2d", quant2d)
+    x = torch.tensor([[1.0, -2.0, 0.5]], dtype=torch.float32)
+    x_q = torch.empty_like(x, dtype=torch.int8)
+    scale = torch.empty((1, 1), dtype=torch.float32)
+
+    _custom_ops._dynamic_scaled_int8_quant(x, x_q, scale)
+
+    assert calls == [True]
+    torch.testing.assert_close(scale, torch.tensor([[2.0]]))
+    assert x_q.tolist() == [[64, -127, 32]]
+
+
+def test_scaled_int8_mm_torch_fallback_dequantizes_per_token_and_channel():
+    import vllm_kunlun
+
+    vllm_kunlun.register()
+    from vllm_kunlun.quantization.kernels.scale_mm import (
+        _torch_scaled_int8_mm_fallback,
+    )
+
+    x_q = torch.tensor([[127, -64], [0, 127]], dtype=torch.int8)
+    w_q = torch.tensor([[127, 0, -64], [-127, 64, 127]], dtype=torch.int8)
+    x_max = torch.tensor([[2.0], [4.0]], dtype=torch.float32)
+    w_max = torch.tensor([[8.0], [6.0], [10.0]], dtype=torch.float32)
+    bias = torch.tensor([1.0, -1.0, 0.5], dtype=torch.float32)
+
+    out = _torch_scaled_int8_mm_fallback(
+        x_q=x_q,
+        w_q=w_q,
+        x_max=x_max,
+        w_max=w_max,
+        out_dtype=torch.float32,
+        bias=bias,
+    )
+
+    expected = torch.matmul(
+        x_q.to(torch.float32) * (x_max / 127.0),
+        w_q.to(torch.float32) * (w_max.reshape(1, -1) / 127.0),
+    )
+    expected = expected + bias
+    torch.testing.assert_close(out, expected)
+
+
 def test_default_unquantized_gemm_supports_torch_compile_with_vllm_parameter():
     from vllm.model_executor.layers import utils as layer_utils
     from vllm.model_executor.parameter import ModelWeightParameter
@@ -251,6 +398,580 @@ def test_register_model_imports_vllm_on_torch251():
         and call.args[1] == "vllm_kunlun.models.qwen3_moe:Qwen3MoeForCausalLM"
         for call in mock_register_model.call_args_list
     )
+    assert any(
+        call.args[0] == "DeepseekV32ForCausalLM"
+        and getattr(call.args[1], "__name__", None) == "DeepseekV3ForCausalLM"
+        for call in mock_register_model.call_args_list
+    )
+
+
+def test_kunlun_platform_allows_missing_vllm_attention_backend(monkeypatch):
+    from vllm_kunlun.platforms import kunlun
+
+    monkeypatch.delattr(kunlun.envs, "VLLM_ATTENTION_BACKEND", raising=False)
+    monkeypatch.delenv("VLLM_ATTENTION_BACKEND", raising=False)
+    assert kunlun._get_vllm_attention_backend() is None
+
+    monkeypatch.setenv("VLLM_ATTENTION_BACKEND", "FLASHMLA")
+    assert kunlun._get_vllm_attention_backend() == "FLASHMLA"
+    monkeypatch.delenv("VLLM_ATTENTION_BACKEND", raising=False)
+
+    monkeypatch.setattr(
+        kunlun.envs,
+        "VLLM_ATTENTION_BACKEND",
+        "FLASHMLA",
+        raising=False,
+    )
+    assert kunlun._get_vllm_attention_backend() == "FLASHMLA"
+
+
+def test_kunlun_platform_accepts_renamed_flashmla_support_check():
+    from vllm_kunlun.platforms import kunlun
+
+    legacy_module = SimpleNamespace(is_flashmla_supported=lambda: (True, None))
+    dense_module = SimpleNamespace(is_flashmla_dense_supported=lambda: (False, "x"))
+
+    assert kunlun._check_flashmla_supported(legacy_module) == (True, None)
+    assert kunlun._check_flashmla_supported(dense_module) == (False, "x")
+
+
+def test_kunlun_platform_flashmla_env_overrides_sparse_mla(monkeypatch):
+    from vllm_kunlun.platforms import kunlun
+
+    monkeypatch.setattr(kunlun, "_get_vllm_attention_backend", lambda: "FLASHMLA")
+
+    backend_cls = kunlun.KunlunPlatform.get_attn_backend_cls(
+        selected_backend=SimpleNamespace(),
+        attn_selector_config=SimpleNamespace(use_mla=True, use_sparse=True),
+    )
+
+    assert backend_cls == (
+        "vllm_kunlun.v1.attention.backends.mla.flashmla.FlashMLABackend"
+    )
+
+
+def test_kunlun_quantization_loader_skips_missing_optional_backends(monkeypatch):
+    from vllm_kunlun.platforms import kunlun
+
+    kunlun._patch_quantization_config_loader()
+
+    import vllm.model_executor.layers.quantization as quant_module
+
+    optional_backend = "vllm.model_executor.layers.quantization.bitblas"
+    if importlib.util.find_spec(optional_backend) is None:
+        assert "bitblas" not in quant_module.QUANTIZATION_METHODS
+
+    class FakeCompressedTensorsConfig:
+        pass
+
+    monkeypatch.setitem(
+        quant_module._CUSTOMIZED_METHOD_TO_QUANT_CONFIG,
+        "compressed-tensors",
+        FakeCompressedTensorsConfig,
+    )
+    quant_config = quant_module.get_quantization_config("compressed-tensors")
+    assert quant_config is FakeCompressedTensorsConfig
+
+    class FakeModelOptMxFp8Config:
+        pass
+
+    def fake_import_module(name):
+        if name == "vllm.model_executor.layers.quantization.modelopt":
+            return SimpleNamespace(ModelOptMxFp8Config=FakeModelOptMxFp8Config)
+        return importlib.import_module(name)
+
+    with patch.object(
+        kunlun.importlib, "import_module", side_effect=fake_import_module
+    ):
+        assert (
+            quant_module.get_quantization_config("modelopt_mxfp8")
+            is FakeModelOptMxFp8Config
+        )
+
+    weight_utils = SimpleNamespace(get_quantization_config=lambda _: None)
+    monkeypatch.setitem(
+        sys.modules,
+        "vllm.model_executor.model_loader.weight_utils",
+        weight_utils,
+    )
+    kunlun._patch_quantization_config_loader()
+    assert weight_utils.get_quantization_config is quant_module.get_quantization_config
+
+
+def test_kunlun_compressed_tensors_accepts_vllm019_attention_path():
+    import vllm_kunlun
+
+    vllm_kunlun.register()
+    from vllm_kunlun.quantization.compressed_tensors.compressed_tensors import (
+        KunlunCompressedTensorsConfig,
+    )
+
+    quant_config = KunlunCompressedTensorsConfig(
+        target_scheme_map={},
+        ignore=[],
+        quant_format="int-quantized",
+        sparsity_scheme_map={},
+        sparsity_ignore_list=[],
+    )
+
+    assert quant_config.get_quant_method(torch.nn.Module(), prefix="x") is None
+
+
+def test_deepseek_rope_compat_supports_vllm019_signature():
+    import vllm_kunlun
+
+    vllm_kunlun.register()
+    from vllm_kunlun.models.deepseek_v2 import _get_rope_compat
+
+    calls = {}
+
+    def fake_get_rope(
+        head_size,
+        max_position,
+        is_neox_style=True,
+        rope_parameters=None,
+        dtype=None,
+        dual_chunk_attention_config=None,
+    ):
+        calls.update(
+            head_size=head_size,
+            max_position=max_position,
+            is_neox_style=is_neox_style,
+            rope_parameters=rope_parameters,
+        )
+        return "rope"
+
+    result = _get_rope_compat(
+        64,
+        rotary_dim=64,
+        max_position=32768,
+        base=1000000.0,
+        rope_scaling={"factor": 40, "rope_type": "deepseek_yarn"},
+        is_neox_style=False,
+        rope_fn=fake_get_rope,
+    )
+
+    assert result == "rope"
+    assert calls["head_size"] == 64
+    assert calls["max_position"] == 32768
+    assert calls["is_neox_style"] is False
+    assert calls["rope_parameters"]["rope_theta"] == 1000000.0
+    assert calls["rope_parameters"]["rope_type"] == "deepseek_yarn"
+
+
+def test_deepseek_v32_mla_passes_indexer_rotary_emb(monkeypatch):
+    import vllm_kunlun
+
+    vllm_kunlun.register()
+    import vllm_kunlun.models.deepseek_v2 as deepseek_module
+
+    captured = {}
+
+    class FakeModule(torch.nn.Module):
+        def __init__(self, *args, **kwargs):
+            super().__init__()
+
+    class FakeIndexer(torch.nn.Module):
+        topk_tokens = 1
+
+        def __init__(self, *args, **kwargs):
+            super().__init__()
+
+    class FakeMLAWrapper(torch.nn.Module):
+        def __init__(
+            self,
+            _hidden_size,
+            _num_local_heads,
+            _scaling,
+            _qk_nope_head_dim,
+            _qk_rope_head_dim,
+            _v_head_dim,
+            _q_lora_rank,
+            _kv_lora_rank,
+            mla_modules,
+            *_args,
+            **_kwargs,
+        ):
+            super().__init__()
+            captured["mla_modules"] = mla_modules
+
+    def fake_get_rope_compat(*_args, is_neox_style, **_kwargs):
+        return f"rope-{is_neox_style}"
+
+    monkeypatch.setattr(
+        deepseek_module,
+        "get_tensor_model_parallel_world_size",
+        lambda: 1,
+    )
+    monkeypatch.setattr(deepseek_module, "_get_rope_compat", fake_get_rope_compat)
+    monkeypatch.setattr(deepseek_module, "MergedColumnParallelLinear", FakeModule)
+    monkeypatch.setattr(deepseek_module, "ReplicatedLinear", FakeModule)
+    monkeypatch.setattr(deepseek_module, "ColumnParallelLinear", FakeModule)
+    monkeypatch.setattr(deepseek_module, "RowParallelLinear", FakeModule)
+    monkeypatch.setattr(deepseek_module, "RMSNorm", FakeModule)
+    monkeypatch.setattr(deepseek_module, "LayerNorm", FakeModule)
+    monkeypatch.setattr(deepseek_module, "Indexer", FakeIndexer)
+    monkeypatch.setattr(
+        deepseek_module,
+        "MultiHeadLatentAttentionWrapper",
+        FakeMLAWrapper,
+    )
+
+    config = SimpleNamespace(
+        rms_norm_eps=1e-6,
+        index_topk=2048,
+        index_n_heads=64,
+        index_head_dim=128,
+        qk_rope_head_dim=64,
+    )
+
+    deepseek_module.DeepseekV2MLAAttention(
+        vllm_config=SimpleNamespace(),
+        config=config,
+        hidden_size=16,
+        num_heads=1,
+        qk_nope_head_dim=8,
+        qk_rope_head_dim=8,
+        v_head_dim=8,
+        q_lora_rank=4,
+        kv_lora_rank=4,
+        rope_scaling={"factor": 40},
+        cache_config=SimpleNamespace(),
+    )
+
+    mla_modules = captured["mla_modules"]
+    assert mla_modules.rotary_emb == "rope-False"
+    assert mla_modules.indexer_rotary_emb == "rope-True"
+
+
+def test_deepseek_v32_indexer_rope_outputs_restore_token_shapes():
+    from vllm_kunlun.models.deepseek_v2 import _reshape_indexer_rope_outputs
+
+    q_pe, k_pe = _reshape_indexer_rope_outputs(
+        torch.zeros(1, 2, 64, 64),
+        torch.zeros(1, 2, 1, 64),
+        n_head=64,
+        rope_dim=64,
+    )
+
+    assert q_pe.shape == (2, 64, 64)
+    assert k_pe.shape == (2, 1, 64)
+
+
+def test_deepseek_v32_indexer_passes_whole_kv_cache():
+    from vllm_kunlun.models.deepseek_v2 import _get_indexer_kv_cache
+
+    kv_cache = torch.tensor([])
+
+    assert _get_indexer_kv_cache(SimpleNamespace(kv_cache=kv_cache)) is kv_cache
+
+
+def test_flashmla_sparse_impl_uses_sparse_mla_interface():
+    import inspect as py_inspect
+
+    import vllm_kunlun
+
+    vllm_kunlun.register()
+    from vllm.v1.attention.backend import SparseMLAAttentionImpl
+
+    from vllm_kunlun.v1.attention.backends.mla.flashmla_sparse import (
+        FlashMLASparseImpl,
+    )
+
+    assert not py_inspect.isabstract(FlashMLASparseImpl)
+    assert issubclass(FlashMLASparseImpl, SparseMLAAttentionImpl)
+
+
+def test_flashmla_dense_backend_imports_vllm19_attention_symbols():
+    import inspect as py_inspect
+
+    import vllm_kunlun
+
+    vllm_kunlun.register()
+    from vllm.v1.attention.backend import AttentionCGSupport
+
+    from vllm_kunlun.v1.attention.backends.mla.flashmla import (
+        FlashMLABackend,
+        FlashMLAImpl,
+        FlashMLAMetadataBuilder,
+    )
+
+    assert FlashMLABackend.get_name() == "FLASHMLA"
+    assert not py_inspect.isabstract(FlashMLAImpl)
+    assert FlashMLAMetadataBuilder.cudagraph_support is AttentionCGSupport.UNIFORM_BATCH
+
+
+def test_flashmla_decode_paged_attention_splits_q_c_and_q_r(monkeypatch):
+    import vllm_kunlun
+
+    vllm_kunlun.register()
+    from vllm_kunlun.ops.attention import flashmla
+
+    captured = {}
+
+    def fake_paged_attention(
+        out,
+        x,
+        k_cache,
+        v_cache,
+        block_tables,
+        context_lens_cpu,
+        context_lens_xpu,
+        is_context,
+        is_causal,
+        vo_head_dim,
+        kv_lora_rank,
+        qk_rope_head_dim,
+        mla_scale,
+        **kwargs,
+    ):
+        captured.update(
+            out=out,
+            x=x,
+            k_cache=k_cache,
+            v_cache=v_cache,
+            block_tables=block_tables,
+            context_lens_cpu=context_lens_cpu,
+            context_lens_xpu=context_lens_xpu,
+            is_context=is_context,
+            is_causal=is_causal,
+            vo_head_dim=vo_head_dim,
+            kv_lora_rank=kv_lora_rank,
+            qk_rope_head_dim=qk_rope_head_dim,
+            mla_scale=mla_scale,
+            q_r=kwargs["q_r"],
+        )
+        return 0
+
+    monkeypatch.setattr(flashmla.kunlun_ops, "paged_attention", fake_paged_attention)
+
+    q = torch.arange(2 * 1 * 3 * 6, dtype=torch.float32).reshape(2, 1, 3, 6)
+    k_cache = torch.zeros(4, 8, 1, 6)
+    block_table = torch.zeros(2, 1, dtype=torch.int32)
+    cache_lens = torch.ones(2, dtype=torch.int32)
+
+    out, _ = flashmla.flash_mla_with_kvcache(
+        q=q,
+        k_cache=k_cache,
+        block_table=block_table,
+        cache_seqlens=cache_lens,
+        head_dim_v=4,
+        tile_scheduler_metadata=cache_lens.cpu(),
+        num_splits=cache_lens,
+        softmax_scale=0.5,
+        causal=True,
+    )
+
+    assert captured["out"] is out
+    assert captured["x"].shape == (2, 1, 3, 4)
+    assert captured["q_r"].shape == (2, 1, 3, 2)
+    assert torch.equal(captured["x"], q[..., :4])
+    assert torch.equal(captured["q_r"], q[..., 4:])
+    assert captured["k_cache"].shape == (4, 1, 8, 6)
+    assert captured["v_cache"] is None
+    assert captured["kv_lora_rank"] == 4
+    assert captured["qk_rope_head_dim"] == 2
+    assert captured["mla_scale"] == 0.5
+
+
+def test_flashmla_decode_torch_fallback_matches_reference(monkeypatch):
+    import vllm_kunlun
+
+    vllm_kunlun.register()
+    from vllm_kunlun.ops.attention import flashmla
+
+    monkeypatch.setenv("VLLM_KUNLUN_MLA_DECODE_FALLBACK", "1")
+
+    q = torch.tensor(
+        [[[[0.1, -0.2, 0.3, 0.4, 0.5, -0.6], [0.2, 0.1, -0.4, 0.3, -0.1, 0.7]]]],
+        dtype=torch.float32,
+    )
+    k_cache = torch.tensor(
+        [
+            [
+                [[0.2, 0.0, -0.1, 0.4, 0.1, -0.2]],
+                [[-0.3, 0.2, 0.5, 0.1, -0.4, 0.3]],
+            ],
+            [
+                [[0.6, -0.5, 0.2, 0.0, 0.2, 0.1]],
+                [[9.0, 9.0, 9.0, 9.0, 9.0, 9.0]],
+            ],
+        ],
+        dtype=torch.float32,
+    )
+    block_table = torch.tensor([[0, 1]], dtype=torch.int32)
+    cache_lens = torch.tensor([3], dtype=torch.int32)
+
+    out, _ = flashmla.flash_mla_with_kvcache(
+        q=q,
+        k_cache=k_cache,
+        block_table=block_table,
+        cache_seqlens=cache_lens,
+        head_dim_v=4,
+        tile_scheduler_metadata=cache_lens.cpu(),
+        num_splits=cache_lens,
+        softmax_scale=0.5,
+        causal=True,
+    )
+
+    kv_tokens = torch.cat([k_cache[0, :, 0], k_cache[1, :1, 0]], dim=0)
+    q_c = q[..., :4]
+    q_r = q[..., 4:]
+    kv_c = kv_tokens[:, :4]
+    k_pe = kv_tokens[:, 4:]
+    scores = torch.einsum("qhd,kd->qhk", q_c[0], kv_c)
+    scores = scores + torch.einsum("qhr,kr->qhk", q_r[0], k_pe)
+    probs = torch.softmax(scores * 0.5, dim=-1)
+    expected = torch.einsum("qhk,kd->qhd", probs, kv_c).unsqueeze(0)
+
+    assert torch.allclose(out, expected)
+
+
+def test_mla_common_prefill_env_flags_default_when_missing(monkeypatch):
+    import vllm_kunlun
+
+    vllm_kunlun.register()
+    from vllm_kunlun.v1.attention.backends.mla import common
+
+    assert "flash_attn_varlen_func" in vars(common)
+
+    monkeypatch.delattr(
+        common.envs,
+        "VLLM_DISABLE_FLASHINFER_PREFILL",
+        raising=False,
+    )
+    monkeypatch.delattr(common.envs, "VLLM_USE_CUDNN_PREFILL", raising=False)
+    monkeypatch.setattr(common, "flashinfer_available", True)
+    monkeypatch.setattr(
+        common,
+        "current_platform",
+        SimpleNamespace(is_device_capability=lambda capability: True),
+    )
+    monkeypatch.setattr(common, "has_nvidia_artifactory", lambda: True)
+
+    assert common.use_flashinfer_prefill() is True
+    assert common.use_cudnn_prefill() is False
+
+    monkeypatch.setattr(common.envs, "VLLM_USE_CUDNN_PREFILL", True, raising=False)
+
+    assert common.use_flashinfer_prefill() is False
+    assert common.use_cudnn_prefill() is True
+
+
+def test_mla_common_impl_defaults_dcp_world_size_when_group_missing(monkeypatch):
+    import vllm_kunlun
+
+    vllm_kunlun.register()
+    from vllm_kunlun.v1.attention.backends.mla import common
+
+    class FakeMLAImpl(common.MLACommonImpl):
+        def _forward_decode(self, *_args, **_kwargs):
+            raise NotImplementedError
+
+    def raise_missing_dcp_group():
+        raise AssertionError
+
+    monkeypatch.setattr(common, "get_dcp_group", raise_missing_dcp_group)
+    monkeypatch.setattr(common, "use_flashinfer_prefill", lambda: False)
+    monkeypatch.setattr(common, "use_cudnn_prefill", lambda: False)
+    monkeypatch.setattr(
+        common.MLACommonMetadataBuilder,
+        "determine_chunked_prefill_workspace_size",
+        staticmethod(lambda _config: 1),
+    )
+    monkeypatch.setattr(common, "get_current_vllm_config", lambda: SimpleNamespace())
+
+    impl = FakeMLAImpl(
+        num_heads=1,
+        head_size=6,
+        scale=1.0,
+        num_kv_heads=1,
+        alibi_slopes=None,
+        sliding_window=None,
+        kv_cache_dtype="auto",
+        logits_soft_cap=None,
+        attn_type="decoder",
+        kv_sharing_target_layer_name=None,
+        q_lora_rank=None,
+        kv_lora_rank=4,
+        qk_nope_head_dim=2,
+        qk_rope_head_dim=2,
+        qk_head_dim=4,
+        v_head_dim=4,
+        kv_b_proj=SimpleNamespace(),
+    )
+
+    assert impl.dcp_world_size == 1
+
+
+def test_mla_common_torch_prefill_attention_matches_reference():
+    import vllm_kunlun
+
+    vllm_kunlun.register()
+    from vllm_kunlun.v1.attention.backends.mla import common
+
+    class FakeMLAImpl(common.MLACommonImpl):
+        def _forward_decode(self, *_args, **_kwargs):
+            raise NotImplementedError
+
+    impl = object.__new__(FakeMLAImpl)
+    impl._pad_v = True
+
+    q = torch.tensor(
+        [
+            [[0.2, -0.1, 0.3], [0.5, 0.1, -0.4]],
+            [[-0.3, 0.4, 0.2], [0.2, -0.5, 0.6]],
+            [[0.1, 0.3, -0.2], [-0.2, 0.4, 0.5]],
+        ],
+        dtype=torch.float32,
+    )
+    k = torch.tensor(
+        [
+            [[0.4, -0.2, 0.1], [0.3, 0.2, -0.1]],
+            [[-0.2, 0.5, 0.3], [0.1, -0.4, 0.6]],
+            [[0.6, 0.1, -0.3], [-0.5, 0.2, 0.4]],
+        ],
+        dtype=torch.float32,
+    )
+    v = torch.tensor(
+        [
+            [[0.7, -0.1], [0.2, 0.5]],
+            [[-0.4, 0.3], [0.6, -0.2]],
+            [[0.1, 0.8], [-0.3, 0.4]],
+        ],
+        dtype=torch.float32,
+    )
+    seq_lens = torch.tensor([0, 2, 3], dtype=torch.int32)
+
+    out, lse = impl._torch_prefill_attention(
+        q=q,
+        k=k,
+        v=v,
+        context_seq_lod_xpu=None,
+        context_seq_lod_cpu=seq_lens,
+        return_softmax_lse=True,
+        causal=True,
+        softmax_scale=0.5,
+    )
+
+    padded_v = F.pad(v, [0, q.shape[-1] - v.shape[-1]], value=0)
+    expected_out = torch.empty_like(q)
+    expected_lse = torch.full((q.size(1), q.size(0)), float("-inf"))
+    for start, end in [(0, 2), (2, 3)]:
+        scores = torch.einsum("qhd,khd->hqk", q[start:end], k[start:end]) * 0.5
+        mask = torch.triu(
+            torch.ones(end - start, end - start, dtype=torch.bool),
+            diagonal=1,
+        )
+        scores = scores.masked_fill(mask.unsqueeze(0), float("-inf"))
+        probs = torch.softmax(scores, dim=-1)
+        expected_out[start:end] = torch.einsum(
+            "hqk,khd->qhd", probs, padded_v[start:end]
+        )
+        expected_lse[:, start:end] = torch.logsumexp(scores, dim=-1)
+
+    torch.testing.assert_close(out, expected_out)
+    torch.testing.assert_close(lse, expected_lse)
 
 
 def test_import_hook_installs_kunlun_fused_moe_override():
@@ -556,6 +1277,50 @@ def test_import_hook_maps_attention_backend_abstract_alias():
         assert sys.modules[alias_name] is sentinel_module
         assert sys.modules[target_module_name] is sentinel_module
         assert mock_import_module.call_count == 1
+    finally:
+        for module_name, module in backups.items():
+            if module is None:
+                sys.modules.pop(module_name, None)
+            else:
+                sys.modules[module_name] = module
+
+
+def test_import_hook_maps_attention_ops_aliases():
+    import vllm_kunlun
+
+    alias_pairs = [
+        ("vllm.attention.ops.common", "vllm.v1.attention.ops.common"),
+        ("vllm.attention.ops.flashmla", "vllm.v1.attention.ops.flashmla"),
+    ]
+    module_names = [module_name for pair in alias_pairs for module_name in pair]
+    backups = {
+        module_name: sys.modules.get(module_name) for module_name in module_names
+    }
+
+    for module_name in module_names:
+        sys.modules.pop(module_name, None)
+
+    try:
+        with patch.object(vllm_kunlun.importlib, "import_module") as mock_import_module:
+            with patch.object(
+                vllm_kunlun,
+                "OLD_IMPORT_HOOK",
+                side_effect=AssertionError("mapped imports must not fall back"),
+            ):
+                for alias_name, target_module_name in alias_pairs:
+                    sentinel_module = types.ModuleType(target_module_name)
+                    mock_import_module.return_value = sentinel_module
+
+                    imported_module = vllm_kunlun._custom_import(
+                        alias_name, fromlist=["sentinel"]
+                    )
+
+                    assert imported_module is sentinel_module
+                    assert sys.modules[alias_name] is sentinel_module
+                    assert sys.modules[target_module_name] is sentinel_module
+                    mock_import_module.assert_called_with(target_module_name)
+
+        assert mock_import_module.call_count == len(alias_pairs)
     finally:
         for module_name, module in backups.items():
             if module is None:
@@ -881,6 +1646,84 @@ def test_qwen3_moe_loader_compat_patch_skips_unmatched_expert_weights(
     assert "layers.47.mlp.experts.0.down_proj.weight" in loaded
 
 
+def test_mla_attention_weight_device_patch_runs_after_processing(monkeypatch):
+    from vllm_kunlun import compat
+
+    class FakeMLAAttention:
+        def __init__(self):
+            self.called = None
+            self.W_UK_T = torch.zeros(1, dtype=torch.float16)
+
+        def process_weights_after_loading(self, act_dtype):
+            self.called = act_dtype
+            return "processed"
+
+        def forward_impl(self, q, marker=None):
+            return ("forwarded", q, marker)
+
+    fake_module = SimpleNamespace(MLAAttention=FakeMLAAttention)
+    moved = []
+    device = torch.device("cpu")
+
+    monkeypatch.setattr(compat, "_current_cuda_device", lambda: device)
+    monkeypatch.setattr(
+        compat,
+        "_move_mla_runtime_tensor_attrs",
+        lambda instance, target_device: moved.append((instance, target_device)),
+    )
+
+    compat._patch_mla_attention_runtime_weight_device(fake_module)
+    attention = FakeMLAAttention()
+
+    assert attention.process_weights_after_loading(torch.bfloat16) == "processed"
+    assert attention.called is torch.bfloat16
+    assert moved == [(attention, device)]
+    assert getattr(
+        FakeMLAAttention.process_weights_after_loading,
+        "_vllm_kunlun_patched",
+        False,
+    )
+
+    q = torch.empty(1, dtype=torch.float32)
+    result, runtime_q, marker = attention.forward_impl(q, marker="x")
+    assert result == "forwarded"
+    assert runtime_q.dtype is torch.float16
+    assert marker == "x"
+    assert moved[-1] == (attention, q.device)
+    assert getattr(
+        FakeMLAAttention.forward_impl,
+        "_vllm_kunlun_patched",
+        False,
+    )
+
+
+def test_mla_attention_weight_patch_copies_runtime_output_to_original_dtype():
+    from vllm_kunlun import compat
+
+    class FakeMLAAttention:
+        def __init__(self):
+            self.W_UK_T = torch.zeros(1, dtype=torch.float16)
+
+        def forward_impl(self, q, output=None):
+            assert q.dtype is torch.float16
+            assert output.dtype is torch.float16
+            output.fill_(2)
+            return output
+
+    fake_module = SimpleNamespace(MLAAttention=FakeMLAAttention)
+    compat._patch_mla_attention_runtime_weight_device(fake_module)
+
+    attention = FakeMLAAttention()
+    q = torch.empty(1, dtype=torch.float32)
+    output = torch.empty(1, dtype=torch.float32)
+
+    result = attention.forward_impl(q, output=output)
+
+    assert result is output
+    assert output.dtype is torch.float32
+    assert output.item() == 2
+
+
 def test_custom_qwen3_moe_model_skips_unmatched_expert_weights(monkeypatch):
     from vllm_kunlun.models.qwen3_moe import Qwen3MoeModel
 
@@ -938,6 +1781,47 @@ def test_custom_qwen3_moe_model_skips_unmatched_expert_weights(monkeypatch):
     assert loaded_names == [("model.layers.47.mlp.experts.w2_weight", "w2", 0)]
     assert "model.layers.47.mlp.experts.w2_weight" in loaded
     assert all("layers.48" not in name for name in loaded)
+
+
+def test_fused_moe_expert_mapping_accepts_vllm019_model_arg():
+    from vllm_kunlun.models.fused_moe_compat import make_expert_params_mapping
+
+    class FakeModel(torch.nn.Module):
+        pass
+
+    class FakeNewFusedMoE:
+        @classmethod
+        def make_expert_params_mapping(cls, model, **kwargs):
+            return [("new", model, kwargs["num_experts"])]
+
+    model = FakeModel()
+
+    assert make_expert_params_mapping(
+        FakeNewFusedMoE,
+        model,
+        ckpt_gate_proj_name="gate_proj",
+        ckpt_down_proj_name="down_proj",
+        ckpt_up_proj_name="up_proj",
+        num_experts=4,
+    ) == [("new", model, 4)]
+
+
+def test_fused_moe_expert_mapping_keeps_legacy_signature():
+    from vllm_kunlun.models.fused_moe_compat import make_expert_params_mapping
+
+    class FakeOldFusedMoE:
+        @classmethod
+        def make_expert_params_mapping(cls, **kwargs):
+            return [("old", kwargs["num_experts"])]
+
+    assert make_expert_params_mapping(
+        FakeOldFusedMoE,
+        torch.nn.Module(),
+        ckpt_gate_proj_name="gate_proj",
+        ckpt_down_proj_name="down_proj",
+        ckpt_up_proj_name="up_proj",
+        num_experts=4,
+    ) == [("old", 4)]
 
 
 if __name__ == "__main__":

--- a/tests/ut/test.py
+++ b/tests/ut/test.py
@@ -1,157 +1,943 @@
-from unittest.mock import MagicMock, Mock, patch
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+from types import SimpleNamespace
+from unittest.mock import patch
 
 import pytest
 import torch
+import torch.nn.functional as F
 
 
-def test_import():
-    """Test that the module can be imported successfully."""
-    from vllm_kunlun.compilation.wrapper import TorchCompileWrapperWithCustomDispatcher
+def _load_wrapper_module():
+    import vllm_kunlun  # noqa: F401
 
-    assert TorchCompileWrapperWithCustomDispatcher is not None
-
-
-def test_basic_instantiation():
-    """Test basic wrapper instantiation with mocked dependencies."""
-    from vllm_kunlun.compilation.wrapper import TorchCompileWrapperWithCustomDispatcher
-
-    # Create a concrete implementation
-    class TestWrapper(TorchCompileWrapperWithCustomDispatcher):
-        def forward(self, x):
-            return x * 2
-
-    # Mock all the dependencies
-    mock_config = MagicMock()
-    mock_config.compilation_config.init_backend.return_value = "eager"
-    mock_config.compilation_config.inductor_compile_config = None
-
-    with patch("vllm.config.get_current_vllm_config", return_value=mock_config):
-        with patch("vllm.config.CompilationLevel") as mock_level:
-            mock_level.DYNAMO_ONCE = 1
-            with patch("torch.compile", side_effect=lambda func, **kwargs: func):
-                with patch("torch._dynamo.convert_frame.register_bytecode_hook"):
-                    wrapper = TestWrapper(compilation_level=0)
-
-                    # Verify basic attributes exist
-                    assert hasattr(wrapper, "vllm_config")
-                    assert hasattr(wrapper, "compiled_callable")
-                    assert hasattr(wrapper, "original_code_object")
-                    assert hasattr(wrapper, "compiled_codes")
-                    assert isinstance(wrapper.compiled_codes, list)
+    return importlib.import_module("vllm_kunlun.compilation.wrapper")
 
 
-def test_forward_call():
-    """Test that the forward method can be called."""
-    from vllm_kunlun.compilation.wrapper import TorchCompileWrapperWithCustomDispatcher
-
-    class TestWrapper(TorchCompileWrapperWithCustomDispatcher):
-        def forward(self, x):
-            return x * 2
-
-    mock_config = MagicMock()
-    mock_config.compilation_config.init_backend.return_value = "eager"
-    mock_config.compilation_config.inductor_compile_config = None
-
-    with patch("vllm.config.get_current_vllm_config", return_value=mock_config):
-        with patch("vllm.config.CompilationLevel") as mock_level:
-            mock_level.DYNAMO_ONCE = 1
-            with patch("torch.compile", side_effect=lambda func, **kwargs: func):
-                with patch("torch._dynamo.convert_frame.register_bytecode_hook"):
-                    wrapper = TestWrapper(compilation_level=0)
-
-                    # Test calling the wrapper
-                    input_tensor = torch.tensor([1.0, 2.0, 3.0])
-                    result = wrapper(input_tensor)
-
-                    expected = input_tensor * 2
-                    assert torch.allclose(result, expected)
+def _make_mock_config(wrapper_module):
+    dynamic_shapes_config = SimpleNamespace(
+        evaluate_guards=False,
+        type=wrapper_module.DynamicShapesType.BACKED,
+    )
+    compilation_config = SimpleNamespace(
+        mode=wrapper_module.CompilationMode.DYNAMO_TRACE_ONCE,
+        init_backend=lambda _cfg: "eager",
+        inductor_compile_config={},
+        dynamic_shapes_config=dynamic_shapes_config,
+        cudagraph_mode=wrapper_module.CUDAGraphMode.NONE,
+    )
+    observability_config = SimpleNamespace(enable_layerwise_nvtx_tracing=False)
+    return SimpleNamespace(
+        compilation_config=compilation_config,
+        observability_config=observability_config,
+        compile_debug_dump_path=lambda: None,
+    )
 
 
-def test_custom_callable():
-    """Test wrapper with custom compiled callable."""
-    from vllm_kunlun.compilation.wrapper import TorchCompileWrapperWithCustomDispatcher
+def test_import_installs_torch251_compat_shims():
+    wrapper_module = _load_wrapper_module()
+    custom_graph_pass = importlib.import_module("torch._inductor.custom_graph_pass")
+    graph_pickler_module = importlib.import_module("torch.fx._graph_pickler")
+    dynamo_torch_module = importlib.import_module("torch._dynamo.variables.torch")
+    mistral_request_module = importlib.import_module(
+        "mistral_common.protocol.instruct.request"
+    )
+    from torch.fx import Graph
+    from vllm.model_executor.parameter import BasevLLMParameter, ModelWeightParameter
 
-    class TestWrapper(TorchCompileWrapperWithCustomDispatcher):
-        def forward(self, x):
-            return x * 2
+    assert hasattr(custom_graph_pass, "CustomGraphPass")
+    assert hasattr(graph_pickler_module, "GraphPickler")
+    assert hasattr(graph_pickler_module, "Options")
+    assert hasattr(mistral_request_module, "ReasoningEffort")
+    assert hasattr(Graph, "output_node")
+    assert hasattr(torch.compiler, "set_stance")
+    assert hasattr(torch._functorch.config, "bundled_autograd_cache")
+    assert hasattr(torch._functorch.config, "autograd_cache_normalize_inputs")
+    assert hasattr(torch._functorch.config, "enable_remote_autograd_cache")
+    assert "_cache_config_ignore_prefix" in torch._functorch.config._config
+    assert "_save_config_ignore" in torch._functorch.config._config
+    assert "_compile_ignored_keys" in torch._functorch.config._config
+    assert isinstance(torch._functorch.config.save_config_portable(), dict)
+    assert wrapper_module.TorchCompileWithNoGuardsWrapper is not None
+    assert BasevLLMParameter in torch._dynamo.config.traceable_tensor_subclasses
+    assert ModelWeightParameter in torch._dynamo.config.traceable_tensor_subclasses
+    assert getattr(
+        dynamo_torch_module.can_dispatch_torch_function,
+        "_vllm_kunlun_patched",
+        False,
+    )
 
-    custom_func = Mock(return_value=torch.tensor([5.0]))
-    mock_config = MagicMock()
-    mock_config.compilation_config.init_backend.return_value = "eager"
+    graph = Graph()
+    input_node = graph.placeholder("x")
+    graph.output(input_node)
+    assert graph.output_node().op == "output"
 
-    with patch("vllm.config.get_current_vllm_config", return_value=mock_config):
-        with patch("vllm.config.CompilationLevel") as mock_level:
-            mock_level.DYNAMO_ONCE = 1
-            with patch("torch._dynamo.convert_frame.register_bytecode_hook"):
-                wrapper = TestWrapper(
-                    compiled_callable=custom_func, compilation_level=0
+
+def test_import_allows_vllm_mistral_tokenizer_on_older_mistral_common():
+    import vllm_kunlun  # noqa: F401
+
+    mistral_tokenizer_module = importlib.import_module("vllm.tokenizers.mistral")
+
+    assert hasattr(mistral_tokenizer_module, "MistralTokenizer")
+
+
+def test_import_patches_v1_block_table_slot_mapping_kernel():
+    import vllm_kunlun
+
+    block_table_module = vllm_kunlun._custom_import("vllm.v1.worker.block_table")
+
+    assert getattr(
+        block_table_module._compute_slot_mapping_kernel,
+        "_vllm_kunlun_patched",
+        False,
+    )
+
+    query_start_loc = torch.tensor([0, 3], dtype=torch.int32)
+    positions = torch.tensor([0, 1, 5], dtype=torch.int64)
+    block_table = torch.tensor([[4, 7]], dtype=torch.int32)
+    slot_mapping = torch.empty(5, dtype=torch.int64)
+
+    block_table_module._compute_slot_mapping_kernel[(2,)](
+        3,
+        5,
+        query_start_loc,
+        positions,
+        block_table,
+        2,
+        4,
+        slot_mapping,
+        TOTAL_CP_WORLD_SIZE=1,
+        TOTAL_CP_RANK=0,
+        CP_KV_CACHE_INTERLEAVE_SIZE=1,
+        PAD_ID=-1,
+        BLOCK_SIZE=1024,
+    )
+
+    assert slot_mapping.tolist() == [16, 17, 29, -1, -1]
+
+
+def test_default_unquantized_gemm_supports_torch_compile_with_vllm_parameter():
+    from vllm.model_executor.layers import utils as layer_utils
+    from vllm.model_executor.parameter import ModelWeightParameter
+
+    import vllm_kunlun  # noqa: F401
+
+    with (
+        patch(
+            "vllm.model_executor.parameter.get_tensor_model_parallel_rank",
+            return_value=0,
+        ),
+        patch(
+            "vllm.model_executor.parameter.get_tensor_model_parallel_world_size",
+            return_value=1,
+        ),
+    ):
+        weight = ModelWeightParameter(
+            input_dim=1,
+            output_dim=0,
+            data=torch.full((4, 4), 2.0),
+            weight_loader=lambda *args, **kwargs: None,
+        )
+
+    compiled = torch.compile(
+        lambda x, param: layer_utils.default_unquantized_gemm(None, x, param, None),
+        backend="inductor",
+        fullgraph=True,
+    )
+
+    torch.testing.assert_close(
+        compiled(torch.ones((1, 4)), weight),
+        torch.full((1, 4), 8.0),
+    )
+
+
+def test_get_fx_graph_outputs_falls_back_to_last_node_without_output():
+    from torch.fx import Graph
+
+    import vllm_kunlun  # noqa: F401
+    from vllm_kunlun.compat import _get_fx_graph_outputs
+
+    graph = Graph()
+    input_node = graph.placeholder("x")
+    last_node = graph.call_function(torch.neg, (input_node,))
+
+    assert _get_fx_graph_outputs(graph) is last_node
+
+    graph.output(last_node)
+    assert _get_fx_graph_outputs(graph) is last_node
+
+
+def test_get_fx_graph_outputs_uses_mutated_args_for_inplace_custom_op():
+    from torch.fx import Graph
+
+    import vllm_kunlun  # noqa: F401
+    from vllm_kunlun.compat import _get_fx_graph_outputs
+
+    importlib.import_module("vllm.model_executor.layers.attention.attention")
+
+    graph = Graph()
+    query = graph.placeholder("query")
+    key = graph.placeholder("key")
+    value = graph.placeholder("value")
+    output = graph.placeholder("output")
+    attention_node = graph.call_function(
+        torch.ops.vllm.unified_attention_with_output.default,
+        (query, key, value, output, "layer_name", None, None, None),
+    )
+
+    assert attention_node.op == "call_function"
+    assert _get_fx_graph_outputs(graph) is output
+
+
+def test_get_fx_graph_outputs_uses_name_based_mutated_arg_fallback():
+    from torch.fx import Graph
+
+    import vllm_kunlun  # noqa: F401
+    from vllm_kunlun.compat import _get_fx_graph_outputs
+
+    def unified_attention_with_output(*args, **kwargs):
+        raise AssertionError("FX test should not execute the target")
+
+    graph = Graph()
+    query = graph.placeholder("query")
+    key = graph.placeholder("key")
+    value = graph.placeholder("value")
+    output = graph.placeholder("output")
+    output_block_scale = graph.placeholder("output_block_scale")
+    attention_node = graph.call_function(
+        unified_attention_with_output,
+        (
+            query,
+            key,
+            value,
+            output,
+            "layer_name",
+            None,
+            output_block_scale,
+            None,
+        ),
+    )
+
+    assert attention_node.op == "call_function"
+    assert _get_fx_graph_outputs(graph) == (output, output_block_scale)
+
+
+def test_import_patches_piecewise_compile_interpreter_call_module():
+    import vllm_kunlun  # noqa: F401
+
+    backends_module = importlib.import_module("vllm.compilation.backends")
+
+    assert getattr(
+        backends_module.PiecewiseCompileInterpreter.call_module,
+        "_vllm_kunlun_patched",
+        False,
+    )
+
+
+def test_register_model_imports_vllm_on_torch251():
+    from vllm import ModelRegistry
+
+    import vllm_kunlun
+
+    with patch.object(ModelRegistry, "register_model") as mock_register_model:
+        vllm_kunlun.register_model()
+
+    assert mock_register_model.call_count > 0
+    assert any(
+        call.args[0] == "Qwen3MoeForCausalLM"
+        and call.args[1] == "vllm_kunlun.models.qwen3_moe:Qwen3MoeForCausalLM"
+        for call in mock_register_model.call_args_list
+    )
+
+
+def test_import_hook_installs_kunlun_fused_moe_override():
+    from vllm.model_executor.custom_op import op_registry_oot
+
+    import vllm_kunlun
+
+    vllm_kunlun.register()
+    vllm_kunlun._custom_import("vllm.model_executor.layers.fused_moe.layer")
+
+    override_cls = op_registry_oot["UnquantizedFusedMoEMethod"]
+    assert override_cls.__module__ == "vllm_kunlun.ops.fused_moe.layer"
+
+
+def test_kunlun_unquantized_fused_moe_method_forces_kunlun_monolithic_entry():
+    from vllm_kunlun.ops.fused_moe.layer import KunlunUnquantizedFusedMoEMethod
+
+    with patch(
+        "vllm_kunlun.ops.fused_moe.layer.UnquantizedFusedMoEMethod.__init__",
+        autospec=True,
+        side_effect=lambda self, moe: setattr(self, "_is_monolithic", False),
+    ):
+        method = KunlunUnquantizedFusedMoEMethod(SimpleNamespace())
+
+    assert method.is_monolithic is True
+    assert (
+        method.apply_monolithic.__func__
+        is KunlunUnquantizedFusedMoEMethod._apply_monolithic_kunlun
+    )
+
+
+def test_kunlun_fused_moe_native_fallback_matches_reference():
+    module_name = "vllm_kunlun.ops._kunlun_ops"
+    backups = {
+        name: sys.modules.get(name)
+        for name in [module_name, "cocopod", "xspeedgate_ops"]
+    }
+
+    sys.modules.pop(module_name, None)
+
+    try:
+        with patch.dict(
+            sys.modules,
+            {
+                "cocopod": types.ModuleType("cocopod"),
+                "xspeedgate_ops": types.ModuleType("xspeedgate_ops"),
+            },
+        ):
+            from vllm_kunlun.ops._kunlun_ops import KunlunOps
+
+            hidden_states = torch.tensor([[1.0, -0.5]], dtype=torch.float32)
+            w1 = torch.tensor(
+                [
+                    [
+                        [1.0, 0.0],
+                        [0.0, 1.0],
+                        [0.5, 0.0],
+                        [0.0, 0.5],
+                    ],
+                    [
+                        [0.3, 0.2],
+                        [0.4, -0.1],
+                        [0.2, 0.1],
+                        [-0.5, 0.3],
+                    ],
+                ],
+                dtype=torch.float32,
+            )
+            w2 = torch.tensor(
+                [
+                    [
+                        [1.0, 0.0],
+                        [0.0, 1.0],
+                    ],
+                    [
+                        [0.5, -0.2],
+                        [0.1, 0.4],
+                    ],
+                ],
+                dtype=torch.float32,
+            )
+            router_logits = torch.tensor([[3.0, 1.0]], dtype=torch.float32)
+
+            result = KunlunOps.fused_moe(
+                hidden_states=hidden_states,
+                w1=w1,
+                w2=w2,
+                router_logits=router_logits,
+                ep_rank=0,
+                moe_top_k=2,
+                renormalize=True,
+            )
+    finally:
+        for name, module in backups.items():
+            if module is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = module
+
+    topk_logits, topk_ids = torch.topk(router_logits, k=2, dim=-1, sorted=False)
+    topk_weights = torch.softmax(topk_logits, dim=-1)
+    expected = torch.zeros_like(hidden_states)
+
+    for token_idx in range(hidden_states.shape[0]):
+        token_hidden_state = hidden_states[token_idx : token_idx + 1]
+        for route_idx in range(topk_ids.shape[1]):
+            expert_id = int(topk_ids[token_idx, route_idx])
+            gate_up = token_hidden_state @ w1[expert_id].transpose(0, 1)
+            half = gate_up.shape[-1] // 2
+            activated = F.silu(gate_up[..., :half]) * gate_up[..., half:]
+            expert_output = activated @ w2[expert_id].transpose(0, 1)
+            expected[token_idx] += topk_weights[
+                token_idx, route_idx
+            ] * expert_output.squeeze(0)
+
+    torch.testing.assert_close(result, expected)
+
+
+def test_kunlun_fused_moe_native_fallback_maps_global_expert_ids_to_local_weights():
+    module_name = "vllm_kunlun.ops._kunlun_ops"
+    backups = {
+        name: sys.modules.get(name)
+        for name in [module_name, "cocopod", "xspeedgate_ops"]
+    }
+
+    sys.modules.pop(module_name, None)
+
+    try:
+        with patch.dict(
+            sys.modules,
+            {
+                "cocopod": types.ModuleType("cocopod"),
+                "xspeedgate_ops": types.ModuleType("xspeedgate_ops"),
+            },
+        ):
+            from vllm_kunlun.ops._kunlun_ops import KunlunOps
+
+            hidden_states = torch.tensor(
+                [
+                    [0.5, -1.0],
+                    [1.5, 0.25],
+                ],
+                dtype=torch.float32,
+            )
+            w1 = torch.tensor(
+                [
+                    [
+                        [1.0, 0.0],
+                        [0.0, 1.0],
+                        [0.5, 0.0],
+                        [0.0, 0.5],
+                    ],
+                    [
+                        [0.6, -0.2],
+                        [0.3, 0.4],
+                        [0.2, 0.1],
+                        [-0.4, 0.3],
+                    ],
+                ],
+                dtype=torch.float32,
+            )
+            w2 = torch.tensor(
+                [
+                    [
+                        [0.7, 0.0],
+                        [0.0, 0.9],
+                    ],
+                    [
+                        [0.4, -0.1],
+                        [0.2, 0.5],
+                    ],
+                ],
+                dtype=torch.float32,
+            )
+            router_logits = torch.tensor(
+                [
+                    [0.1, -0.8, 4.0, 2.0],
+                    [-0.5, 0.2, 1.2, 3.8],
+                ],
+                dtype=torch.float32,
+            )
+
+            result = KunlunOps.fused_moe(
+                hidden_states=hidden_states,
+                w1=w1,
+                w2=w2,
+                router_logits=router_logits,
+                ep_rank=1,
+                moe_top_k=2,
+                renormalize=True,
+            )
+    finally:
+        for name, module in backups.items():
+            if module is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = module
+
+    topk_logits, topk_ids = torch.topk(router_logits, k=2, dim=-1, sorted=False)
+    topk_weights = torch.softmax(topk_logits, dim=-1)
+    expected = torch.zeros_like(hidden_states)
+    local_expert_offset = w1.shape[0]
+
+    for token_idx in range(hidden_states.shape[0]):
+        token_hidden_state = hidden_states[token_idx : token_idx + 1]
+        for route_idx in range(topk_ids.shape[1]):
+            local_expert_id = int(topk_ids[token_idx, route_idx]) - local_expert_offset
+            gate_up = token_hidden_state @ w1[local_expert_id].transpose(0, 1)
+            half = gate_up.shape[-1] // 2
+            activated = F.silu(gate_up[..., :half]) * gate_up[..., half:]
+            expert_output = activated @ w2[local_expert_id].transpose(0, 1)
+            expected[token_idx] += topk_weights[
+                token_idx, route_idx
+            ] * expert_output.squeeze(0)
+
+    torch.testing.assert_close(result, expected)
+
+
+def test_import_hook_overrides_vllm_compilation_wrapper():
+    import vllm_kunlun
+
+    vllm_kunlun.import_hook()
+
+    assert __import__ is vllm_kunlun._custom_import
+
+
+def test_import_hook_maps_merge_attn_states_aliases():
+    import vllm_kunlun
+
+    target_module_name = "vllm_kunlun.ops.attention.merge_attn_states"
+    alias_names = [
+        "vllm.attention.ops.merge_attn_states",
+        "vllm.v1.attention.ops.merge_attn_states",
+    ]
+    sentinel_module = types.ModuleType(target_module_name)
+    module_names = [target_module_name, *alias_names]
+    backups = {
+        module_name: sys.modules.get(module_name) for module_name in module_names
+    }
+
+    for module_name in module_names:
+        sys.modules.pop(module_name, None)
+
+    try:
+        with patch.object(
+            vllm_kunlun.importlib,
+            "import_module",
+            return_value=sentinel_module,
+        ) as mock_import_module:
+            with patch.object(
+                vllm_kunlun,
+                "OLD_IMPORT_HOOK",
+                side_effect=AssertionError("mapped imports must not fall back"),
+            ):
+                for alias_name in alias_names:
+                    imported_module = vllm_kunlun._custom_import(
+                        alias_name, fromlist=["merge_attn_states"]
+                    )
+                    assert imported_module is sentinel_module
+                    assert sys.modules[alias_name] is sentinel_module
+
+        assert sys.modules[target_module_name] is sentinel_module
+        assert mock_import_module.call_count == len(alias_names)
+    finally:
+        for module_name, module in backups.items():
+            if module is None:
+                sys.modules.pop(module_name, None)
+            else:
+                sys.modules[module_name] = module
+
+
+def test_import_hook_maps_attention_backend_abstract_alias():
+    import vllm_kunlun
+
+    target_module_name = "vllm.v1.attention.backend"
+    alias_name = "vllm.attention.backends.abstract"
+    sentinel_module = types.ModuleType(target_module_name)
+    backups = {
+        module_name: sys.modules.get(module_name)
+        for module_name in [target_module_name, alias_name]
+    }
+
+    for module_name in [target_module_name, alias_name]:
+        sys.modules.pop(module_name, None)
+
+    try:
+        with patch.object(
+            vllm_kunlun.importlib,
+            "import_module",
+            return_value=sentinel_module,
+        ) as mock_import_module:
+            with patch.object(
+                vllm_kunlun,
+                "OLD_IMPORT_HOOK",
+                side_effect=AssertionError("mapped imports must not fall back"),
+            ):
+                imported_module = vllm_kunlun._custom_import(
+                    alias_name,
+                    fromlist=["AttentionBackend"],
                 )
 
-                # Verify custom callable is used
-                assert wrapper.compiled_callable is custom_func
+        assert imported_module is sentinel_module
+        assert sys.modules[alias_name] is sentinel_module
+        assert sys.modules[target_module_name] is sentinel_module
+        assert mock_import_module.call_count == 1
+    finally:
+        for module_name, module in backups.items():
+            if module is None:
+                sys.modules.pop(module_name, None)
+            else:
+                sys.modules[module_name] = module
 
-                # Call should use custom callable
-                result = wrapper(torch.tensor([1.0]))  # noqa
-                assert custom_func.called
+
+def test_merge_attn_states_import_is_lazy():
+    import vllm_kunlun
+
+    module_names = [
+        "kunlun_ops",
+        "vllm_kunlun.ops",
+        "vllm_kunlun.ops._custom_ops",
+        "vllm_kunlun.ops.attention",
+        "vllm_kunlun.ops.attention.merge_attn_states",
+        "vllm.v1.attention.ops.merge_attn_states",
+    ]
+
+    for module_name in module_names:
+        sys.modules.pop(module_name, None)
+
+    imported_module = vllm_kunlun._custom_import(
+        "vllm.v1.attention.ops.merge_attn_states",
+        fromlist=["merge_attn_states"],
+    )
+
+    assert imported_module.__name__ == "vllm_kunlun.ops.attention.merge_attn_states"
+    assert "kunlun_ops" not in sys.modules
+    assert "vllm_kunlun.ops._custom_ops" not in sys.modules
 
 
-def test_bytecode_hook_basic():
-    """Test that bytecode hook can be called without errors."""
-    from types import CodeType
+def test_topk_topp_sampler_import_is_lazy():
+    import vllm_kunlun
 
-    from vllm_kunlun.compilation.wrapper import TorchCompileWrapperWithCustomDispatcher
+    module_names = [
+        "kunlun_ops",
+        "vllm_kunlun.v1.sample.ops.topk_topp_sampler",
+        "vllm.v1.sample.ops.topk_topp_sampler",
+    ]
+    backups = {
+        module_name: sys.modules.get(module_name) for module_name in module_names
+    }
 
-    class TestWrapper(TorchCompileWrapperWithCustomDispatcher):
+    for module_name in module_names:
+        sys.modules.pop(module_name, None)
+
+    try:
+        imported_module = vllm_kunlun._custom_import(
+            "vllm.v1.sample.ops.topk_topp_sampler",
+            fromlist=["TopKTopPSampler"],
+        )
+
+        assert imported_module.__name__ == "vllm_kunlun.v1.sample.ops.topk_topp_sampler"
+        assert "kunlun_ops" not in sys.modules
+    finally:
+        for module_name, module in backups.items():
+            if module is None:
+                sys.modules.pop(module_name, None)
+            else:
+                sys.modules[module_name] = module
+
+
+def test_topk_topp_sampler_falls_back_when_kunlun_ops_import_fails():
+    sampler_module = importlib.import_module(
+        "vllm_kunlun.v1.sample.ops.topk_topp_sampler"
+    )
+    sampler = sampler_module.TopKTopPSampler("raw_logprobs")
+    logits = torch.tensor([[0.1, 0.2, 0.3]], dtype=torch.float32)
+    top_k = torch.tensor([2], dtype=torch.int32)
+    expected_ids = torch.tensor([1], dtype=torch.int64)
+
+    with patch.object(
+        sampler_module.importlib,
+        "import_module",
+        side_effect=ImportError("kunlun ops unavailable"),
+    ) as mock_import_module:
+        with patch.object(
+            sampler,
+            "forward_native",
+            return_value=(expected_ids, None),
+        ) as mock_forward_native:
+            token_ids, processed = sampler.forward_kunlun(logits, {}, top_k, None)
+            sampler.forward_kunlun(logits, {}, top_k, None)
+
+    assert mock_import_module.call_count == 1
+    assert mock_forward_native.call_count == 2
+    assert torch.equal(token_ids, expected_ids)
+    assert processed is None
+    assert sampler._disable_kunlun_sampling is True
+
+
+def test_quantization_kernels_import_registers_oot_entries():
+    from vllm.model_executor.kernels.linear import (
+        _POSSIBLE_INT8_KERNELS,
+        _POSSIBLE_KERNELS,
+    )
+    from vllm.platforms import PlatformEnum
+
+    kernels_module = importlib.import_module("vllm_kunlun.quantization.kernels")
+
+    assert (
+        kernels_module.KunlunScaledMMLinearKernel
+        in _POSSIBLE_INT8_KERNELS[PlatformEnum.OOT]
+    )
+    assert (
+        kernels_module.KunlunExllamaLinearKernel in _POSSIBLE_KERNELS[PlatformEnum.OOT]
+    )
+
+
+def test_attention_compat_exports_vllm019_attention():
+    compat_module = importlib.import_module("vllm_kunlun.attention_compat")
+    from vllm.model_executor.layers.attention import Attention as UpstreamAttention
+
+    assert compat_module.Attention is UpstreamAttention
+    assert compat_module.check_upstream_fa_availability(torch.float32) is False
+    assert isinstance(
+        compat_module.check_upstream_fa_availability(torch.float16),
+        bool,
+    )
+
+
+def test_kunlun_platform_uses_parallel_config_all2all_backend():
+    from vllm.config import CUDAGraphMode
+
+    from vllm_kunlun.platforms.kunlun import KunlunPlatform
+
+    vllm_config = SimpleNamespace(
+        parallel_config=SimpleNamespace(
+            worker_cls="worker",
+            data_parallel_size=2,
+            all2all_backend="deepep_high_throughput",
+        ),
+        model_config=SimpleNamespace(use_mla=False, enforce_eager=False),
+        speculative_config=None,
+        cache_config=SimpleNamespace(block_size=16),
+        compilation_config=SimpleNamespace(
+            cudagraph_mode=CUDAGraphMode.PIECEWISE,
+            custom_ops=[],
+            pass_config=SimpleNamespace(enable_fusion=True),
+            backend="inductor",
+        ),
+    )
+
+    KunlunPlatform.check_and_update_config(vllm_config)
+
+    assert vllm_config.compilation_config.cudagraph_mode == CUDAGraphMode.NONE
+    assert vllm_config.model_config.enforce_eager is True
+    assert vllm_config.compilation_config.backend == "eager"
+
+
+def test_kunlun_platform_get_attn_backend_cls_accepts_num_heads():
+    from vllm_kunlun.platforms.kunlun import KunlunPlatform
+
+    attn_selector_config = SimpleNamespace(use_mla=False, use_sparse=False)
+
+    with patch(
+        "vllm_kunlun.platforms.kunlun.importlib.import_module",
+        return_value=object(),
+    ):
+        backend_cls = KunlunPlatform.get_attn_backend_cls(
+            None,
+            attn_selector_config=attn_selector_config,
+            num_heads=32,
+        )
+
+    assert backend_cls.endswith("KunlunAttentionBackend")
+
+
+def test_kunlun_platform_get_attn_backend_cls_falls_back_to_triton():
+    from vllm_kunlun.platforms.kunlun import KunlunPlatform
+
+    attn_selector_config = SimpleNamespace(use_mla=False, use_sparse=False)
+
+    with patch(
+        "vllm_kunlun.platforms.kunlun.importlib.import_module",
+        side_effect=OSError("kunlun attention backend unavailable"),
+    ):
+        backend_cls = KunlunPlatform.get_attn_backend_cls(
+            None,
+            attn_selector_config=attn_selector_config,
+            num_heads=32,
+        )
+
+    assert backend_cls.endswith("TritonAttentionBackend")
+
+
+def test_kunlun_platform_preregistration_skips_compressed_tensors_failures():
+    import builtins
+
+    from vllm_kunlun.platforms.kunlun import KunlunPlatform
+
+    original_import = builtins.__import__
+
+    def guarded_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "vllm_kunlun.quantization.compressed_tensors":
+            raise ImportError("compressed tensors unavailable in test")
+        return original_import(name, globals, locals, fromlist, level)
+
+    with patch.object(builtins, "__import__", side_effect=guarded_import):
+        KunlunPlatform.pre_register_and_update()
+
+
+def test_qwen35_processing_info_accepts_upstream_hf_config():
+    from vllm.multimodal.processing.context import InputProcessingContext
+    from vllm.transformers_utils.configs.qwen3_5_moe import Qwen3_5MoeConfig
+
+    from vllm_kunlun.hf_config_compat import QWEN3_5_MOE_CONFIG_TYPES
+
+    ctx = SimpleNamespace(model_config=SimpleNamespace(hf_config=Qwen3_5MoeConfig()))
+    ctx.get_hf_config = InputProcessingContext.get_hf_config.__get__(ctx, type(ctx))
+    assert isinstance(ctx.get_hf_config(QWEN3_5_MOE_CONFIG_TYPES), Qwen3_5MoeConfig)
+
+
+def test_wrapper_can_initialize_and_run_twice():
+    wrapper_module = _load_wrapper_module()
+    mock_config = _make_mock_config(wrapper_module)
+
+    class TestWrapper(wrapper_module.TorchCompileWithNoGuardsWrapper):
         def forward(self, x):
             return x * 2
 
-    mock_config = MagicMock()
-    mock_config.compilation_config.init_backend.return_value = "eager"
-    mock_config.compilation_config.inductor_compile_config = None
-    mock_config.compilation_config.local_cache_dir = None
+    with patch.object(
+        wrapper_module, "get_current_vllm_config", return_value=mock_config
+    ):
+        with patch.object(wrapper_module.envs, "VLLM_USE_BYTECODE_HOOK", False):
+            with patch.object(wrapper_module.envs, "VLLM_USE_AOT_COMPILE", False):
+                with patch.object(
+                    wrapper_module.torch,
+                    "compile",
+                    side_effect=lambda fn, **kwargs: fn,
+                ):
+                    wrapper = TestWrapper()
+                    input_tensor = torch.tensor([1.0, 2.0, 3.0])
 
-    with patch("vllm.config.get_current_vllm_config", return_value=mock_config):
-        with patch("vllm.config.CompilationLevel") as mock_level:
-            mock_level.DYNAMO_ONCE = 1
-            with patch("torch.compile", side_effect=lambda func, **kwargs: func):
-                with patch("torch._dynamo.convert_frame.register_bytecode_hook"):
-                    wrapper = TestWrapper(compilation_level=0)
-
-                    # Test with wrong code object (should be ignored)
-                    wrong_code = MagicMock(spec=CodeType)
-                    new_code = MagicMock(spec=CodeType)
-
-                    initial_count = len(wrapper.compiled_codes)
-                    wrapper.bytecode_hook(wrong_code, new_code)
-
-                    # Should not add anything
-                    assert len(wrapper.compiled_codes) == initial_count
+                    assert torch.allclose(wrapper(input_tensor), input_tensor * 2)
+                    assert torch.allclose(wrapper(input_tensor), input_tensor * 2)
+                    assert wrapper.first_compile is False
 
 
-def test_use_custom_dispatcher_flag():
-    """Test that use_custom_dispatcher flag is set based on compilation_level."""
-    from vllm_kunlun.compilation.wrapper import TorchCompileWrapperWithCustomDispatcher
+def test_bytecode_hook_ignores_unrelated_code_objects():
+    wrapper_module = _load_wrapper_module()
+    mock_config = _make_mock_config(wrapper_module)
 
-    class TestWrapper(TorchCompileWrapperWithCustomDispatcher):
+    class TestWrapper(wrapper_module.TorchCompileWithNoGuardsWrapper):
         def forward(self, x):
-            return x * 2
+            return x
 
-    mock_config = MagicMock()
-    mock_config.compilation_config.init_backend.return_value = "eager"
-    mock_config.compilation_config.inductor_compile_config = None
+    with patch.object(
+        wrapper_module, "get_current_vllm_config", return_value=mock_config
+    ):
+        with patch.object(wrapper_module.envs, "VLLM_USE_BYTECODE_HOOK", True):
+            with patch.object(wrapper_module.envs, "VLLM_USE_AOT_COMPILE", False):
+                with patch.object(
+                    wrapper_module.torch,
+                    "compile",
+                    side_effect=lambda fn, **kwargs: fn,
+                ):
+                    with patch.object(
+                        wrapper_module.torch._dynamo.convert_frame,
+                        "register_bytecode_hook",
+                    ):
+                        wrapper = TestWrapper()
+                        wrong_code = (lambda: None).__code__
+                        new_code = (lambda: None).__code__
 
-    with patch("vllm.config.get_current_vllm_config", return_value=mock_config):
-        with patch("vllm.config.CompilationLevel") as mock_level:
-            mock_level.DYNAMO_ONCE = 1
-            with patch("torch.compile", side_effect=lambda func, **kwargs: func):
-                with patch("torch._dynamo.convert_frame.register_bytecode_hook"):
-                    # Test with low level
-                    wrapper_low = TestWrapper(compilation_level=0)
-                    assert wrapper_low.use_custom_dispatcher is False
+                        wrapper.bytecode_hook(wrong_code, new_code)
 
-                    # Test with high level
-                    wrapper_high = TestWrapper(compilation_level=2)
-                    assert wrapper_high.use_custom_dispatcher is True
+                        assert wrapper._compiled_bytecode is None
+
+
+def test_qwen3_moe_loader_compat_patch_skips_unmatched_expert_weights(
+    monkeypatch,
+):
+    from vllm_kunlun.compat import apply_qwen3_moe_loader_compat_patch
+
+    seen_weight_names = []
+
+    class FakeQwen3MoeModel:
+        def named_parameters(self):
+            return [
+                ("layers.47.mlp.experts.w2_weight", object()),
+            ]
+
+        def get_expert_mapping(self):
+            return [
+                (
+                    "layers.47.mlp.experts.w2_weight",
+                    "layers.47.mlp.experts.0.down_proj.weight",
+                    0,
+                    "w2",
+                ),
+                (
+                    "layers.48.mlp.experts.w2_weight",
+                    "layers.48.mlp.experts.0.down_proj.weight",
+                    0,
+                    "w2",
+                ),
+            ]
+
+        def load_weights(self, weights):
+            seen_weight_names.extend(name for name, _ in weights)
+            return set(seen_weight_names)
+
+    fake_module = type("FakeModule", (), {"Qwen3MoeModel": FakeQwen3MoeModel})
+    monkeypatch.setattr("vllm_kunlun.compat.import_module", lambda _: fake_module)
+
+    apply_qwen3_moe_loader_compat_patch()
+
+    model = FakeQwen3MoeModel()
+    loaded = model.load_weights(
+        [
+            ("layers.47.mlp.experts.0.down_proj.weight", torch.zeros(1)),
+            ("layers.48.mlp.experts.0.down_proj.weight", torch.zeros(1)),
+            ("layers.48.self_attn.q_proj.weight", torch.zeros(1)),
+        ]
+    )
+
+    assert "layers.47.mlp.experts.0.down_proj.weight" in seen_weight_names
+    assert "layers.48.mlp.experts.0.down_proj.weight" not in seen_weight_names
+    assert "layers.48.self_attn.q_proj.weight" in seen_weight_names
+    assert "layers.47.mlp.experts.0.down_proj.weight" in loaded
+
+
+def test_custom_qwen3_moe_model_skips_unmatched_expert_weights(monkeypatch):
+    from vllm_kunlun.models.qwen3_moe import Qwen3MoeModel
+
+    model = object.__new__(Qwen3MoeModel)
+    model.quant_config = None
+
+    loaded_names = []
+
+    class FakeParam:
+        def weight_loader(
+            self,
+            _param,
+            _loaded_weight,
+            name_mapped,
+            shard_id=None,
+            expert_id=None,
+            return_success=False,
+        ):
+            loaded_names.append((name_mapped, shard_id, expert_id))
+            if return_success:
+                return True
+            return None
+
+    monkeypatch.setattr(
+        "vllm_kunlun.models.qwen3_moe.upstream.is_pp_missing_parameter",
+        lambda *_args, **_kwargs: False,
+    )
+
+    model.named_parameters = lambda: [
+        ("model.layers.47.mlp.experts.w2_weight", FakeParam()),
+    ]
+    model.get_expert_mapping = lambda: [
+        (
+            "layers.47.mlp.experts.w2_weight",
+            "layers.47.mlp.experts.0.down_proj.weight",
+            0,
+            "w2",
+        ),
+        (
+            "layers.48.mlp.experts.w2_weight",
+            "layers.48.mlp.experts.0.down_proj.weight",
+            0,
+            "w2",
+        ),
+    ]
+
+    loaded = Qwen3MoeModel.load_weights(
+        model,
+        [
+            ("model.layers.47.mlp.experts.0.down_proj.weight", torch.zeros(1)),
+            ("model.layers.48.mlp.experts.0.down_proj.weight", torch.zeros(1)),
+        ],
+    )
+
+    assert loaded_names == [("model.layers.47.mlp.experts.w2_weight", "w2", 0)]
+    assert "model.layers.47.mlp.experts.w2_weight" in loaded
+    assert all("layers.48" not in name for name in loaded)
 
 
 if __name__ == "__main__":

--- a/tests/ut/test_v1_worker_utils.py
+++ b/tests/ut/test_v1_worker_utils.py
@@ -1,0 +1,128 @@
+"""
+Copyright (c) 2026 Baidu, Inc. All Rights Reserved.
+
+This file is a part of the vllm-kunlun project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from types import SimpleNamespace
+
+import torch
+
+
+class _FakeBackend:
+    @staticmethod
+    def get_supported_kernel_block_sizes():
+        return [8]
+
+    @staticmethod
+    def get_kv_cache_block_dim(
+        kernel_block_size,
+        num_kv_heads,
+        head_size,
+        cache_dtype_str=None,
+    ):
+        return 0
+
+
+def _ensure_torch251_compat_shims():
+    import vllm_kunlun  # noqa: F401
+    import vllm_kunlun.schema  # noqa: F401
+    from vllm_kunlun.compat import apply_torch251_compat_shims
+
+    apply_torch251_compat_shims()
+
+
+def test_prepare_kernel_block_sizes_preserves_kv_cache_group_ids():
+    _ensure_torch251_compat_shims()
+
+    from vllm.v1.kv_cache_interface import (
+        EncoderOnlyAttentionSpec,
+        FullAttentionSpec,
+        KVCacheConfig,
+        KVCacheGroupSpec,
+    )
+
+    from vllm_kunlun.v1.worker.utils import AttentionGroup, prepare_kernel_block_sizes
+
+    encoder_spec = EncoderOnlyAttentionSpec(
+        block_size=16,
+        num_kv_heads=1,
+        head_size=1,
+        dtype=torch.float32,
+    )
+    attn_spec = FullAttentionSpec(
+        block_size=16,
+        num_kv_heads=1,
+        head_size=1,
+        dtype=torch.float32,
+    )
+    kv_cache_config = KVCacheConfig(
+        num_blocks=0,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(layer_names=["encoder"], kv_cache_spec=encoder_spec),
+            KVCacheGroupSpec(layer_names=["decoder"], kv_cache_spec=attn_spec),
+        ],
+    )
+    attn_groups = [
+        [],
+        [
+            AttentionGroup(
+                backend=_FakeBackend,
+                layer_names=["decoder"],
+                kv_cache_spec=attn_spec,
+                kv_cache_group_id=1,
+            )
+        ],
+    ]
+
+    kernel_block_sizes = prepare_kernel_block_sizes(kv_cache_config, attn_groups)
+
+    assert kernel_block_sizes == [None, 8]
+
+
+def test_kv_block_zeroer_init_meta_uses_aligned_kernel_block_sizes():
+    _ensure_torch251_compat_shims()
+
+    from vllm.v1.kv_cache_interface import FullAttentionSpec
+
+    from vllm_kunlun.v1.worker.utils import AttentionGroup, KVBlockZeroer
+
+    attn_spec = FullAttentionSpec(
+        block_size=16,
+        num_kv_heads=1,
+        head_size=1,
+        dtype=torch.float32,
+    )
+    attn_group = AttentionGroup(
+        backend=_FakeBackend,
+        layer_names=["decoder"],
+        kv_cache_spec=attn_spec,
+        kv_cache_group_id=1,
+    )
+    zeroer = KVBlockZeroer(device=torch.device("cpu"), pin_memory=False)
+    static_forward_context = {
+        "decoder": SimpleNamespace(kv_cache=torch.zeros((4, 4), dtype=torch.float32))
+    }
+
+    zeroer.init_meta(
+        [attn_group],
+        [None, 8],
+        cache_dtype="auto",
+        runner_only_attn_layers=set(),
+        static_forward_context=static_forward_context,
+    )
+
+    assert zeroer._meta is not None

--- a/vllm_kunlun/__init__.py
+++ b/vllm_kunlun/__init__.py
@@ -6,13 +6,24 @@ import logging
 import os
 import sys
 
-from vllm.logger import init_logger as init_vllm_logger
+from .compat import (
+    _patch_piecewise_compile_interpreter_call_module,
+    _patch_traceable_vllm_parameter_subclasses,
+    _patch_v1_block_table_triton_kernel,
+    apply_qwen3_moe_loader_compat_patch,
+    apply_torch251_compat_shims,
+)
+from .ops.fused_moe import register_kunlun_fused_moe_ops
+
+apply_torch251_compat_shims()
 
 OLD_IMPORT_HOOK = builtins.__import__
 
 
 def _configure_kunlun_logger() -> logging.Logger:
     """Reuse vLLM's handler for the vllm_kunlun logger tree."""
+    from vllm.logger import init_logger as init_vllm_logger
+
     vllm_logger = init_vllm_logger("vllm")
     kunlun_logger = logging.getLogger("vllm_kunlun")
 
@@ -26,30 +37,73 @@ def _configure_kunlun_logger() -> logging.Logger:
 
 
 def _custom_import(module_name, globals=None, locals=None, fromlist=(), level=0):
-    try:
-        module_mappings = {
-            "vllm.compilation.wrapper": "vllm_kunlun.compilation.wrapper",
-            "vllm.v1.worker.utils": "vllm_kunlun.v1.worker.utils",
-            "vllm.model_executor.model_loader.bitsandbytes_loader": "vllm_kunlun.models.model_loader.bitsandbytes_loader",
-            "vllm.v1.sample.ops.topk_topp_sampler": "vllm_kunlun.v1.sample.ops.topk_topp_sampler",
-            "vllm.v1.sample.rejection_sampler": "vllm_kunlun.v1.sample.rejection_sampler",
-            "vllm.attention.ops.merge_attn_states": "vllm_kunlun.ops.attention.merge_attn_states",
-            "vllm.model_executor.models.config": "vllm_kunlun.models.config",
-        }
+    module_mappings = {
+        "vllm.compilation.wrapper": "vllm_kunlun.compilation.wrapper",
+        "vllm.v1.worker.utils": "vllm_kunlun.v1.worker.utils",
+        "vllm.attention.backends.abstract": "vllm.v1.attention.backend",
+        "vllm.model_executor.model_loader.bitsandbytes_loader": "vllm_kunlun.models.model_loader.bitsandbytes_loader",
+        "vllm.v1.sample.ops.topk_topp_sampler": "vllm_kunlun.v1.sample.ops.topk_topp_sampler",
+        "vllm.v1.sample.rejection_sampler": "vllm_kunlun.v1.sample.rejection_sampler",
+        "vllm.attention.ops.merge_attn_states": "vllm_kunlun.ops.attention.merge_attn_states",
+        "vllm.v1.attention.ops.merge_attn_states": "vllm_kunlun.ops.attention.merge_attn_states",
+        "vllm.model_executor.models.config": "vllm_kunlun.models.config",
+    }
 
-        if module_name in module_mappings:
-            if module_name in sys.modules:
-                return sys.modules[module_name]
-            target_module = module_mappings[module_name]
-            module = importlib.import_module(target_module)
-            sys.modules[module_name] = module
-            sys.modules[target_module] = module
-    except Exception:
-        pass
+    if module_name in module_mappings:
+        if module_name in sys.modules:
+            return sys.modules[module_name]
+        target_module = module_mappings[module_name]
+        module = importlib.import_module(target_module)
+        sys.modules[module_name] = module
+        sys.modules[target_module] = module
+        return module
 
-    return OLD_IMPORT_HOOK(
+    module = OLD_IMPORT_HOOK(
         module_name, globals=globals, locals=locals, fromlist=fromlist, level=level
     )
+
+    if module_name == "vllm.model_executor.models.qwen3_moe":
+        try:
+            apply_qwen3_moe_loader_compat_patch(module)
+        except Exception:
+            logging.getLogger("vllm_kunlun").exception(
+                "[KunlunPlugin] deferred Qwen3-MoE loader compat patch failed"
+            )
+            raise
+    elif module_name == "vllm.model_executor.parameter":
+        try:
+            _patch_traceable_vllm_parameter_subclasses(module)
+        except Exception:
+            logging.getLogger("vllm_kunlun").exception(
+                "[KunlunPlugin] deferred vLLM parameter Dynamo compat patch failed"
+            )
+            raise
+    elif module_name == "vllm.compilation.backends":
+        try:
+            _patch_piecewise_compile_interpreter_call_module(module)
+        except Exception:
+            logging.getLogger("vllm_kunlun").exception(
+                "[KunlunPlugin] deferred PiecewiseCompileInterpreter compat patch failed"
+            )
+            raise
+    elif module_name == "vllm.v1.worker.block_table":
+        try:
+            _patch_v1_block_table_triton_kernel(module)
+        except Exception:
+            logging.getLogger("vllm_kunlun").exception(
+                "[KunlunPlugin] deferred v1 block_table Triton compat patch failed"
+            )
+            raise
+    elif module_name == "vllm.model_executor.layers.fused_moe.layer":
+        try:
+            register_kunlun_fused_moe_ops()
+        except Exception:
+            logging.getLogger("vllm_kunlun").exception(
+                "[KunlunPlugin] deferred Kunlun FusedMoE override registration failed"
+            )
+            raise
+
+    return module
 
 
 def import_hook():

--- a/vllm_kunlun/__init__.py
+++ b/vllm_kunlun/__init__.py
@@ -20,6 +20,30 @@ apply_torch251_compat_shims()
 OLD_IMPORT_HOOK = builtins.__import__
 
 
+def _has_scaled_int8_quant_op() -> bool:
+    import torch
+
+    return hasattr(torch.ops._C, "scaled_int8_quant")
+
+
+def _has_cache_concat_mla_op() -> bool:
+    import torch
+
+    return hasattr(torch.ops._C_cache_ops, "concat_and_cache_mla")
+
+
+def _has_required_python_custom_ops() -> bool:
+    return _has_scaled_int8_quant_op() and _has_cache_concat_mla_op()
+
+
+def _ensure_python_custom_ops_registered(logger: logging.Logger) -> None:
+    if _has_required_python_custom_ops():
+        return
+
+    importlib.import_module("vllm_kunlun.ops._custom_ops")
+    logger.info("[KunlunPlugin] Python custom op definitions loaded")
+
+
 def _configure_kunlun_logger() -> logging.Logger:
     """Reuse vLLM's handler for the vllm_kunlun logger tree."""
     from vllm.logger import init_logger as init_vllm_logger
@@ -44,6 +68,8 @@ def _custom_import(module_name, globals=None, locals=None, fromlist=(), level=0)
         "vllm.model_executor.model_loader.bitsandbytes_loader": "vllm_kunlun.models.model_loader.bitsandbytes_loader",
         "vllm.v1.sample.ops.topk_topp_sampler": "vllm_kunlun.v1.sample.ops.topk_topp_sampler",
         "vllm.v1.sample.rejection_sampler": "vllm_kunlun.v1.sample.rejection_sampler",
+        "vllm.attention.ops.common": "vllm.v1.attention.ops.common",
+        "vllm.attention.ops.flashmla": "vllm.v1.attention.ops.flashmla",
         "vllm.attention.ops.merge_attn_states": "vllm_kunlun.ops.attention.merge_attn_states",
         "vllm.v1.attention.ops.merge_attn_states": "vllm_kunlun.ops.attention.merge_attn_states",
         "vllm.model_executor.models.config": "vllm_kunlun.models.config",
@@ -124,6 +150,12 @@ def register():
         logger.info("[KunlunPlugin] _kunlun native extension loaded")
     except ImportError as e:
         logger.warning("[KunlunPlugin] Failed to load _kunlun: %s", e)
+
+    try:
+        _ensure_python_custom_ops_registered(logger)
+    except Exception:
+        logger.exception("[KunlunPlugin] Python custom op registration failed")
+        raise
 
     # --- import wrapper & patch utils ---
     try:

--- a/vllm_kunlun/attention_compat.py
+++ b/vllm_kunlun/attention_compat.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import importlib.util
+
+import torch
+from vllm.model_executor.layers.attention import Attention
+
+_FLASH_ATTENTION_MODULES = (
+    "vllm.vllm_flash_attn",
+    "flash_attn",
+)
+_FLASH_ATTENTION_DTYPES = {
+    torch.float16,
+    torch.bfloat16,
+}
+
+__all__ = ["Attention", "check_upstream_fa_availability"]
+
+
+def check_upstream_fa_availability(dtype: torch.dtype) -> bool:
+    if dtype not in _FLASH_ATTENTION_DTYPES:
+        return False
+
+    return any(
+        importlib.util.find_spec(module_name) is not None
+        for module_name in _FLASH_ATTENTION_MODULES
+    )

--- a/vllm_kunlun/compat.py
+++ b/vllm_kunlun/compat.py
@@ -1,0 +1,633 @@
+"""Compatibility helpers for running vLLM 0.19.x on PyTorch 2.5.1."""
+
+from __future__ import annotations
+
+import logging
+import pickle
+import sys
+import types
+from contextlib import contextmanager, nullcontext
+from dataclasses import dataclass
+from enum import Enum
+from importlib import import_module
+from typing import Any, Iterable
+
+import torch
+
+_MISSING_OUTPUT_NODE_WARNING_EMITTED = False
+_MUTATED_OUTPUT_DEBUG_EMITTED = False
+_MISSING_EXAMPLE_VALUE_DEBUG_EMITTED = False
+
+
+def _ensure_custom_graph_pass_module() -> None:
+    """Provide torch._inductor.custom_graph_pass on older PyTorch builds."""
+    module_name = "torch._inductor.custom_graph_pass"
+    if module_name in sys.modules:
+        return
+
+    module = types.ModuleType(module_name)
+
+    class CustomGraphPass:
+        """Minimal fallback base class used by vLLM Inductor passes."""
+
+        def __call__(self, graph: Any) -> None:
+            return None
+
+        def uuid(self) -> str:
+            return self.__class__.__name__
+
+    module.CustomGraphPass = CustomGraphPass
+    sys.modules[module_name] = module
+
+
+def _ensure_graph_pickler_module() -> None:
+    """Backfill torch.fx._graph_pickler for PyTorch 2.5."""
+    module_name = "torch.fx._graph_pickler"
+    if module_name in sys.modules:
+        return
+
+    module = types.ModuleType(module_name)
+
+    @dataclass
+    class Options:
+        ops_filter: Any = None
+
+    class GraphPickler:
+        def reducer_override(self, obj: Any) -> Any:
+            return NotImplemented
+
+        @staticmethod
+        def dumps(obj: Any, options: Any | None = None) -> bytes:
+            del options
+            return pickle.dumps(obj, protocol=pickle.HIGHEST_PROTOCOL)
+
+        @staticmethod
+        def loads(data: bytes, fake_mode: Any | None = None) -> Any:
+            del fake_mode
+            return pickle.loads(data)
+
+    module.GraphPickler = GraphPickler
+    module.Options = Options
+    sys.modules[module_name] = module
+
+
+def _ensure_mistral_reasoning_effort_enum() -> None:
+    """Backfill mistral_common's ReasoningEffort for older releases."""
+    try:
+        request_module = import_module("mistral_common.protocol.instruct.request")
+    except ImportError:
+        return
+
+    if hasattr(request_module, "ReasoningEffort"):
+        return
+
+    class ReasoningEffort(str, Enum):
+        LOW = "low"
+        MEDIUM = "medium"
+        HIGH = "high"
+
+    request_module.ReasoningEffort = ReasoningEffort
+
+
+def _patch_v1_block_table_triton_kernel(module: types.ModuleType | None = None) -> None:
+    """Replace Triton's slot-mapping kernel with a torch fallback."""
+    if module is None:
+        module = import_module("vllm.v1.worker.block_table")
+
+    existing_kernel = getattr(module, "_compute_slot_mapping_kernel", None)
+    if getattr(existing_kernel, "_vllm_kunlun_patched", False):
+        return
+
+    def _compute_slot_mapping_kernel_impl(
+        num_tokens: int,
+        max_num_tokens: int,
+        query_start_loc: torch.Tensor,
+        positions: torch.Tensor,
+        block_table: torch.Tensor,
+        block_table_stride: int,
+        block_size: int,
+        slot_mapping: torch.Tensor,
+        TOTAL_CP_WORLD_SIZE: int,
+        TOTAL_CP_RANK: int,
+        CP_KV_CACHE_INTERLEAVE_SIZE: int,
+        PAD_ID: int,
+        BLOCK_SIZE: int,
+    ) -> None:
+        del block_table_stride, BLOCK_SIZE
+
+        slot_mapping[:max_num_tokens].fill_(PAD_ID)
+        if num_tokens == 0:
+            return
+
+        virtual_block_size = block_size * TOTAL_CP_WORLD_SIZE
+        interleave_span = TOTAL_CP_WORLD_SIZE * CP_KV_CACHE_INTERLEAVE_SIZE
+        num_reqs = query_start_loc.numel() - 1
+
+        for req_idx in range(num_reqs):
+            start_idx = int(query_start_loc[req_idx].item())
+            end_idx = int(query_start_loc[req_idx + 1].item())
+            if end_idx <= start_idx:
+                continue
+
+            pos = positions[start_idx:end_idx]
+            block_indices = torch.div(pos, virtual_block_size, rounding_mode="floor")
+            block_numbers = (
+                block_table[req_idx]
+                .index_select(
+                    0,
+                    block_indices.to(dtype=torch.long),
+                )
+                .to(torch.int64)
+            )
+
+            virtual_block_offsets = pos - block_indices * virtual_block_size
+            is_local = (
+                torch.div(
+                    virtual_block_offsets,
+                    CP_KV_CACHE_INTERLEAVE_SIZE,
+                    rounding_mode="floor",
+                )
+                % TOTAL_CP_WORLD_SIZE
+                == TOTAL_CP_RANK
+            )
+            local_block_offsets = (
+                torch.div(
+                    virtual_block_offsets,
+                    interleave_span,
+                    rounding_mode="floor",
+                )
+                * CP_KV_CACHE_INTERLEAVE_SIZE
+                + virtual_block_offsets % CP_KV_CACHE_INTERLEAVE_SIZE
+            )
+            slot_ids = block_numbers * block_size + local_block_offsets
+            slot_mapping[start_idx:end_idx] = torch.where(
+                is_local,
+                slot_ids,
+                torch.full_like(slot_ids, PAD_ID),
+            )
+
+    class _ComputeSlotMappingKernelWrapper:
+        _vllm_kunlun_patched = True
+
+        def __getitem__(self, grid):
+            del grid
+            return _compute_slot_mapping_kernel_impl
+
+    module._compute_slot_mapping_kernel = _ComputeSlotMappingKernelWrapper()
+
+
+def _ensure_fx_graph_output_node() -> None:
+    """Backfill torch.fx.Graph.output_node for PyTorch 2.5."""
+    graph_cls = torch.fx.Graph
+    if hasattr(graph_cls, "output_node"):
+        return
+
+    def output_node(self: torch.fx.Graph) -> torch.fx.Node:
+        for node in reversed(tuple(self.nodes)):
+            if node.op == "output":
+                return node
+        raise RuntimeError("Graph has no output node")
+
+    output_node._vllm_kunlun_patched = True  # type: ignore[attr-defined]
+    graph_cls.output_node = output_node  # type: ignore[attr-defined]
+
+
+def _get_fx_graph_outputs(graph: torch.fx.Graph) -> Any:
+    """Extract the output value(s) from an FX graph across PyTorch variants."""
+    global _MISSING_OUTPUT_NODE_WARNING_EMITTED
+
+    nodes = tuple(graph.nodes)
+    if not nodes:
+        raise RuntimeError("Graph has no nodes")
+
+    last_node = nodes[-1]
+    if last_node.op == "output":
+        return last_node.args[0]
+
+    mutated_outputs = _get_mutated_node_outputs(last_node)
+    if mutated_outputs is not None:
+        if not _MISSING_OUTPUT_NODE_WARNING_EMITTED:
+            logging.getLogger("vllm_kunlun.compat").warning(
+                "FX graph is missing an explicit output node; "
+                "falling back to mutated output args of %s (%s)",
+                last_node.name,
+                last_node.op,
+            )
+            _MISSING_OUTPUT_NODE_WARNING_EMITTED = True
+        return mutated_outputs
+
+    if not _MISSING_OUTPUT_NODE_WARNING_EMITTED:
+        logging.getLogger("vllm_kunlun.compat").warning(
+            "FX graph is missing an explicit output node; "
+            "falling back to the last node %s (%s)",
+            last_node.name,
+            last_node.op,
+        )
+        _MISSING_OUTPUT_NODE_WARNING_EMITTED = True
+
+    return last_node
+
+
+def _normalize_mutated_outputs(mutated_args: list[Any]) -> Any | None:
+    if not mutated_args:
+        return None
+    if len(mutated_args) == 1:
+        return mutated_args[0]
+    return tuple(mutated_args)
+
+
+def _collect_mutated_arg_candidates(
+    node: torch.fx.Node,
+    indices: Iterable[int],
+    names: Iterable[str] = (),
+) -> Any | None:
+    mutated_args: list[Any] = []
+    seen: set[int] = set()
+
+    for index in indices:
+        if index >= len(node.args):
+            continue
+        value = node.args[index]
+        if value is None or id(value) in seen:
+            continue
+        mutated_args.append(value)
+        seen.add(id(value))
+
+    for name in names:
+        value = node.kwargs.get(name)
+        if value is None or id(value) in seen:
+            continue
+        mutated_args.append(value)
+        seen.add(id(value))
+
+    return _normalize_mutated_outputs(mutated_args)
+
+
+def _describe_fx_arg(arg: Any) -> str:
+    if isinstance(arg, torch.fx.Node):
+        return f"{arg.name}:{arg.op}"
+    return type(arg).__name__
+
+
+def _maybe_log_mutated_output_debug(
+    node: torch.fx.Node,
+    target: Any,
+    schema: Any,
+) -> None:
+    global _MUTATED_OUTPUT_DEBUG_EMITTED
+
+    target_repr = str(target).lower()
+    if (
+        _MUTATED_OUTPUT_DEBUG_EMITTED
+        or "unified_attention_with_output" not in target_repr
+    ):
+        return
+
+    logging.getLogger("vllm_kunlun.compat").warning(
+        "Failed to infer mutated outputs for %s (%s): target_type=%s target=%r "
+        "schema=%s args=%s kwargs=%s",
+        node.name,
+        node.op,
+        type(target).__name__,
+        target,
+        schema,
+        [_describe_fx_arg(arg) for arg in node.args],
+        sorted(node.kwargs),
+    )
+    _MUTATED_OUTPUT_DEBUG_EMITTED = True
+
+
+def _maybe_log_missing_example_value_debug(
+    target: str,
+    outputs: Any,
+) -> None:
+    global _MISSING_EXAMPLE_VALUE_DEBUG_EMITTED
+
+    if _MISSING_EXAMPLE_VALUE_DEBUG_EMITTED:
+        return
+
+    def describe_output(value: Any) -> str:
+        if isinstance(value, torch.fx.Node):
+            meta_keys = sorted(value.meta)
+            return f"{value.name}:{value.op}:meta={meta_keys}"
+        return repr(value)
+
+    logging.getLogger("vllm_kunlun.compat").warning(
+        "Missing example_value while materializing outputs for submodule %s: %s",
+        target,
+        torch.fx.map_arg(outputs, describe_output),
+    )
+    _MISSING_EXAMPLE_VALUE_DEBUG_EMITTED = True
+
+
+def _get_mutated_node_outputs(node: torch.fx.Node) -> Any | None:
+    """Infer outputs from in-place mutated args when a graph returns None."""
+    target = getattr(node, "target", None)
+    schema = getattr(target, "_schema", None)
+    if schema is not None:
+        mutated_args: list[Any] = []
+        for index, arg_schema in enumerate(schema.arguments):
+            alias_info = getattr(arg_schema, "alias_info", None)
+            if alias_info is None or not getattr(alias_info, "is_write", False):
+                continue
+
+            if index < len(node.args):
+                value = node.args[index]
+            else:
+                value = node.kwargs.get(arg_schema.name)
+
+            if value is not None:
+                mutated_args.append(value)
+
+        normalized_outputs = _normalize_mutated_outputs(mutated_args)
+        if normalized_outputs is not None:
+            return normalized_outputs
+
+    target_repr = str(target).lower()
+    for op_name in (
+        "unified_attention_with_output",
+        "unified_mla_attention_with_output",
+    ):
+        if op_name not in target_repr:
+            continue
+        fallback_outputs = _collect_mutated_arg_candidates(
+            node,
+            indices=(3, 6),
+            names=("output", "output_block_scale"),
+        )
+        if fallback_outputs is not None:
+            return fallback_outputs
+
+    _maybe_log_mutated_output_debug(node, target, schema)
+    return None
+
+
+def _ensure_compiler_set_stance() -> None:
+    """Backfill torch.compiler.set_stance for PyTorch 2.5."""
+    if hasattr(torch.compiler, "set_stance"):
+        return
+
+    def set_stance(_stance: str):
+        return nullcontext()
+
+    torch.compiler.set_stance = set_stance  # type: ignore[attr-defined]
+
+
+def _ensure_functorch_config_keys() -> None:
+    """Expose vLLM 0.19.x functorch config keys on PyTorch 2.5."""
+    config_module = import_module("torch._functorch.config")
+    missing_defaults = {
+        "bundled_autograd_cache": False,
+        "autograd_cache_normalize_inputs": False,
+        "enable_remote_autograd_cache": False,
+        "_cache_config_ignore_prefix": [],
+        "_save_config_ignore": [],
+        "_compile_ignored_keys": set(),
+    }
+
+    for key, default in missing_defaults.items():
+        if key in config_module._config:
+            continue
+        config_module._allowed_keys.add(key)
+        value = default.copy() if isinstance(default, (list, dict, set)) else default
+        config_module._config[key] = value
+        config_module._default[key] = (
+            value.copy() if isinstance(value, (list, dict, set)) else value
+        )
+
+
+def _ensure_torch_accelerator_namespace() -> None:
+    """Backfill torch.accelerator with a CUDA-backed proxy on PyTorch 2.5."""
+    if hasattr(torch, "accelerator"):
+        return
+
+    class _CudaAcceleratorProxy:
+        def is_available(self) -> bool:
+            return torch.cuda.is_available()
+
+        def device_count(self) -> int:
+            return torch.cuda.device_count()
+
+        def set_device_index(self, device: Any) -> None:
+            torch.cuda.set_device(device)
+
+        def current_device_index(self) -> int:
+            return torch.cuda.current_device()
+
+        def empty_cache(self) -> None:
+            torch.cuda.empty_cache()
+
+        def synchronize(self, device: Any | None = None) -> None:
+            torch.cuda.synchronize(device)
+
+        def memory_stats(self, device: Any | None = None) -> dict[str, Any]:
+            return torch.cuda.memory_stats(device)
+
+        def memory_reserved(self, device: Any | None = None) -> int:
+            return torch.cuda.memory_reserved(device)
+
+        def max_memory_allocated(self, device: Any | None = None) -> int:
+            return torch.cuda.max_memory_allocated(device)
+
+        def reset_peak_memory_stats(self, device: Any | None = None) -> None:
+            torch.cuda.reset_peak_memory_stats(device)
+
+        @contextmanager
+        def device_index(self, device: Any) -> Any:
+            with torch.cuda.device(device):
+                yield
+
+        def __getattr__(self, name: str) -> Any:
+            return getattr(torch.cuda, name)
+
+    torch.accelerator = _CudaAcceleratorProxy()  # type: ignore[attr-defined]
+
+
+def _patch_traceable_vllm_parameter_subclasses(module: Any | None = None) -> None:
+    """Teach torch 2.5 Dynamo to trace vLLM parameter tensor subclasses."""
+    if module is None:
+        module = sys.modules.get("vllm.model_executor.parameter")
+        if module is None:
+            try:
+                module = import_module("vllm.model_executor.parameter")
+            except Exception:
+                return
+
+    traceable_subclasses = getattr(
+        torch._dynamo.config, "traceable_tensor_subclasses", None
+    )
+    if traceable_subclasses is None:
+        return
+
+    for class_name in (
+        "BasevLLMParameter",
+        "ModelWeightParameter",
+        "_ColumnvLLMParameter",
+        "RowvLLMParameter",
+    ):
+        parameter_cls = getattr(module, class_name, None)
+        if parameter_cls is not None:
+            traceable_subclasses.add(parameter_cls)
+
+
+def _disable_dynamo_torch_function_dispatch() -> None:
+    """Use traceable tensor subclasses instead of torch_function dispatch."""
+    dynamo_torch_module = import_module("torch._dynamo.variables.torch")
+    current = getattr(dynamo_torch_module, "can_dispatch_torch_function", None)
+    if current is None or getattr(current, "_vllm_kunlun_patched", False):
+        return
+
+    def return_false(*args: Any, **kwargs: Any) -> bool:
+        return False
+
+    return_false._vllm_kunlun_patched = True  # type: ignore[attr-defined]
+    dynamo_torch_module.can_dispatch_torch_function = return_false
+
+
+def _patch_piecewise_compile_interpreter_call_module(
+    module: Any | None = None,
+) -> None:
+    """Handle FX graphs without an explicit output node on PyTorch 2.5."""
+    if module is None:
+        module = sys.modules.get("vllm.compilation.backends")
+        if module is None:
+            try:
+                module = import_module("vllm.compilation.backends")
+            except Exception:
+                return
+
+    interpreter_cls = getattr(module, "PiecewiseCompileInterpreter", None)
+    if interpreter_cls is None:
+        return
+
+    current = getattr(interpreter_cls, "call_module", None)
+    if current is None or getattr(current, "_vllm_kunlun_patched", False):
+        return
+
+    def patched_call_module(
+        self,
+        target: torch.fx.node.Target,
+        args: tuple[torch.fx.node.Argument, ...],
+        kwargs: dict[str, Any],
+    ) -> Any:
+        assert isinstance(target, str)
+
+        gm = getattr(self.module, target)
+        outputs = _get_fx_graph_outputs(gm.graph)
+        try:
+            output = module.fx.map_arg(outputs, lambda node: node.meta["example_value"])
+        except KeyError:
+            if isinstance(outputs, torch.fx.Node):
+                fallback_outputs = _get_mutated_node_outputs(outputs)
+                if fallback_outputs is not None and fallback_outputs is not outputs:
+                    outputs = fallback_outputs
+                    output = module.fx.map_arg(
+                        outputs, lambda node: node.meta["example_value"]
+                    )
+                else:
+                    _maybe_log_missing_example_value_debug(target, outputs)
+                    raise
+            else:
+                _maybe_log_missing_example_value_debug(target, outputs)
+                raise
+
+        if target in self.compile_submod_names:
+            index = self.compile_submod_names.index(target)
+            submod = self.fetch_attr(target)
+
+            sym_shape_indices = [
+                i for i, x in enumerate(args) if isinstance(x, torch.SymInt)
+            ]
+
+            from torch._inductor.compile_fx import graph_returns_tuple
+
+            piecewise_backend_module = import_module(
+                "vllm.compilation.piecewise_backend"
+            )
+            piecewise_backend = piecewise_backend_module.PiecewiseBackend(
+                submod,
+                self.vllm_config,
+                index,
+                len(self.compile_submod_names),
+                sym_shape_indices,
+                self.vllm_backend,
+                graph_returns_tuple(submod),
+                submod_name=target,
+            )
+
+            self.module.__dict__[target] = module.wrap_with_cudagraph_if_needed(
+                piecewise_backend,
+                self.vllm_config,
+                self.compilation_config,
+                piecewise_backend.is_first_graph,
+                piecewise_backend.is_last_graph,
+            )
+
+            module.compilation_counter.num_piecewise_capturable_graphs_seen += 1
+
+        return output
+
+    patched_call_module._vllm_kunlun_patched = True  # type: ignore[attr-defined]
+    interpreter_cls.call_module = patched_call_module
+
+
+def apply_qwen3_moe_loader_compat_patch(module: Any | None = None) -> None:
+    """Skip extra Qwen3-MoE expert weights that do not map to local params."""
+    if module is None:
+        module = import_module("vllm.model_executor.models.qwen3_moe")
+    model_cls = module.Qwen3MoeModel
+
+    if getattr(model_cls.load_weights, "_vllm_kunlun_patched", False):
+        return
+
+    logger = logging.getLogger("vllm_kunlun.compat")
+    original_load_weights = model_cls.load_weights
+
+    def patched_load_weights(
+        self, weights: Iterable[tuple[str, torch.Tensor]]
+    ) -> set[str]:
+        params_dict = dict(self.named_parameters())
+        missing_weight_names = {
+            weight_name
+            for param_name, weight_name, *_ in self.get_expert_mapping()
+            if param_name not in params_dict
+        }
+        if not missing_weight_names:
+            return original_load_weights(self, weights)
+
+        filtered_weights: list[tuple[str, torch.Tensor]] = []
+        skipped_count = 0
+        skipped_example: str | None = None
+        for name, loaded_weight in weights:
+            if any(weight_name in name for weight_name in missing_weight_names):
+                skipped_count += 1
+                if skipped_example is None:
+                    skipped_example = name
+                continue
+            filtered_weights.append((name, loaded_weight))
+
+        if skipped_count:
+            logger.warning(
+                "Skipping %d unmatched Qwen3-MoE expert weights. Example: %s",
+                skipped_count,
+                skipped_example,
+            )
+
+        return original_load_weights(self, filtered_weights)
+
+    patched_load_weights._vllm_kunlun_patched = True  # type: ignore[attr-defined]
+    model_cls.load_weights = patched_load_weights
+
+
+def apply_torch251_compat_shims() -> None:
+    """Apply the compatibility shims needed by vLLM 0.19.x on torch 2.5.1."""
+    _ensure_custom_graph_pass_module()
+    _ensure_graph_pickler_module()
+    _ensure_mistral_reasoning_effort_enum()
+    _ensure_fx_graph_output_node()
+    _ensure_compiler_set_stance()
+    _ensure_functorch_config_keys()
+    _ensure_torch_accelerator_namespace()
+    _disable_dynamo_torch_function_dispatch()
+    _patch_traceable_vllm_parameter_subclasses()
+    _patch_piecewise_compile_interpreter_call_module()

--- a/vllm_kunlun/compat.py
+++ b/vllm_kunlun/compat.py
@@ -619,6 +619,128 @@ def apply_qwen3_moe_loader_compat_patch(module: Any | None = None) -> None:
     model_cls.load_weights = patched_load_weights
 
 
+def _current_cuda_device() -> torch.device | None:
+    if not torch.cuda.is_available():
+        return None
+    return torch.device("cuda", torch.cuda.current_device())
+
+
+def _move_mla_runtime_tensor_attrs(
+    instance: Any,
+    device: torch.device,
+) -> None:
+    for attr_name in (
+        "W_UK_T",
+        "W_UV",
+        "W_K",
+        "W_K_scale",
+        "W_V",
+        "W_V_scale",
+        "W_UK_SCALE",
+        "W_UV_SCALE",
+    ):
+        tensor = getattr(instance, attr_name, None)
+        if not isinstance(tensor, torch.Tensor):
+            continue
+        if tensor.device != device:
+            setattr(instance, attr_name, tensor.to(device=device))
+
+
+def _get_mla_runtime_compute_dtype(
+    instance: Any,
+    fallback: torch.dtype,
+) -> torch.dtype:
+    for attr_name in ("W_UK_T", "W_UV", "W_K", "W_V"):
+        tensor = getattr(instance, attr_name, None)
+        if isinstance(tensor, torch.Tensor) and tensor.is_floating_point():
+            return tensor.dtype
+    return fallback
+
+
+def _cast_mla_runtime_tensor(
+    tensor: torch.Tensor,
+    dtype: torch.dtype,
+) -> torch.Tensor:
+    if tensor.is_floating_point() and tensor.dtype != dtype:
+        return tensor.to(dtype=dtype)
+    return tensor
+
+
+def _patch_mla_attention_runtime_weight_device(module: Any | None = None) -> None:
+    if module is None:
+        module = import_module("vllm.model_executor.layers.attention.mla_attention")
+
+    attention_cls = getattr(module, "MLAAttention", None)
+    if attention_cls is None:
+        return
+
+    current_process = getattr(attention_cls, "process_weights_after_loading", None)
+    if current_process is not None and not getattr(
+        current_process,
+        "_vllm_kunlun_patched",
+        False,
+    ):
+
+        def patched_process_weights_after_loading(
+            self: Any,
+            act_dtype: torch.dtype,
+        ) -> Any:
+            result = current_process(self, act_dtype)
+            device = _current_cuda_device()
+            if device is not None:
+                _move_mla_runtime_tensor_attrs(self, device)
+            return result
+
+        patched_process_weights_after_loading._vllm_kunlun_patched = True  # type: ignore[attr-defined]
+        attention_cls.process_weights_after_loading = (
+            patched_process_weights_after_loading
+        )
+
+    current_forward = getattr(attention_cls, "forward_impl", None)
+    if current_forward is not None and not getattr(
+        current_forward,
+        "_vllm_kunlun_patched",
+        False,
+    ):
+
+        def patched_forward_impl(self: Any, q: torch.Tensor, *args: Any, **kwargs: Any):
+            _move_mla_runtime_tensor_attrs(self, q.device)
+            compute_dtype = _get_mla_runtime_compute_dtype(self, q.dtype)
+            runtime_q = _cast_mla_runtime_tensor(q, compute_dtype)
+            runtime_args = tuple(
+                (
+                    _cast_mla_runtime_tensor(arg, compute_dtype)
+                    if index < 2 and isinstance(arg, torch.Tensor)
+                    else arg
+                )
+                for index, arg in enumerate(args)
+            )
+            output = kwargs.get("output")
+            if (
+                isinstance(output, torch.Tensor)
+                and output.is_floating_point()
+                and output.dtype != compute_dtype
+            ):
+                runtime_kwargs = dict(kwargs)
+                runtime_output = torch.empty_like(output, dtype=compute_dtype)
+                runtime_kwargs["output"] = runtime_output
+                current_forward(self, runtime_q, *runtime_args, **runtime_kwargs)
+                output.copy_(runtime_output.to(dtype=output.dtype))
+                return output
+
+            result = current_forward(self, runtime_q, *runtime_args, **kwargs)
+            if (
+                isinstance(result, torch.Tensor)
+                and result.is_floating_point()
+                and result.dtype != q.dtype
+            ):
+                return result.to(dtype=q.dtype)
+            return result
+
+        patched_forward_impl._vllm_kunlun_patched = True  # type: ignore[attr-defined]
+        attention_cls.forward_impl = patched_forward_impl
+
+
 def apply_torch251_compat_shims() -> None:
     """Apply the compatibility shims needed by vLLM 0.19.x on torch 2.5.1."""
     _ensure_custom_graph_pass_module()

--- a/vllm_kunlun/compilation/wrapper.py
+++ b/vllm_kunlun/compilation/wrapper.py
@@ -105,8 +105,14 @@ class TorchCompileWithNoGuardsWrapper:
             return ctx.result
         return callable_fn(*args, **kwargs)
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        compile_prefix: str = "",
+        is_encoder: bool = False,
+    ) -> None:
         self.compiled = False
+        self._compile_prefix = compile_prefix
+        self._is_encoder = is_encoder
 
         vllm_config = get_current_vllm_config()
         self.vllm_config = vllm_config
@@ -117,7 +123,14 @@ class TorchCompileWithNoGuardsWrapper:
         if mode is None:
             raise RuntimeError("Compilation mode cannot be NO_COMPILATION")
 
-        backend = vllm_config.compilation_config.init_backend(vllm_config)
+        try:
+            backend = vllm_config.compilation_config.init_backend(
+                vllm_config,
+                prefix=compile_prefix,
+                is_encoder=is_encoder,
+            )
+        except TypeError:
+            backend = vllm_config.compilation_config.init_backend(vllm_config)
 
         # options is only safe to populate when backend is a plain string
         # (e.g. "inductor"). On PyTorch 2.5, passing a non-empty options dict
@@ -224,11 +237,12 @@ class TorchCompileWithNoGuardsWrapper:
                         self.forward, *args, **kwargs
                     )
         else:
-            ctx = (
-                nullcontext()
-                if self.first_compile or not self.evaluate_guards
-                else torch.compiler.set_stance("fail_on_recompile")
-            )
+            if self.first_compile or not self.evaluate_guards:
+                ctx = nullcontext()
+            elif hasattr(torch.compiler, "set_stance"):
+                ctx = torch.compiler.set_stance("fail_on_recompile")
+            else:
+                ctx = nullcontext()
             self.first_compile = False
             with _compilation_context(), ctx:
                 return self._call_with_optional_nvtx_range(
@@ -305,3 +319,52 @@ class TorchCompileWithNoGuardsWrapper:
             yield
         finally:
             self.__class__.forward.__code__ = original
+
+
+def reset_compile_wrapper(model: torch.nn.Module) -> None:
+    """
+    Reset compiled wrapper state so elastic EP can rebuild with new settings.
+    """
+    if not isinstance(model, TorchCompileWithNoGuardsWrapper) and hasattr(
+        model, "model"
+    ):
+        model = model.model
+    if not isinstance(model, TorchCompileWithNoGuardsWrapper):
+        return
+    if hasattr(model, "do_not_compile") and model.do_not_compile:
+        return
+
+    from vllm.compilation.counter import compilation_counter
+
+    compilation_counter.num_models_seen = 0
+    compilation_counter.num_graphs_seen = 0
+    compilation_counter.num_piecewise_graphs_seen = 0
+    compilation_counter.num_piecewise_capturable_graphs_seen = 0
+    compilation_counter.num_backend_compilations = 0
+    compilation_counter.num_gpu_runner_capture_triggers = 0
+    compilation_counter.num_cudagraph_captured = 0
+    compilation_counter.num_inductor_compiles = 0
+    compilation_counter.num_eager_compiles = 0
+    compilation_counter.num_cache_entries_updated = 0
+    compilation_counter.num_compiled_artifacts_saved = 0
+    compilation_counter.stock_torch_compile_count = 0
+    compilation_counter.num_aot_compiles = 0
+    compilation_counter.num_aot_artifacts_saved = 0
+    compilation_counter.num_aot_artifacts_loaded = 0
+
+    if hasattr(model, "aot_compiled_fn"):
+        model.aot_compiled_fn = None
+    if hasattr(model, "was_aot_compile_fn_loaded_from_disk"):
+        model.was_aot_compile_fn_loaded_from_disk = False
+
+    compilation_config = model.vllm_config.compilation_config
+    compilation_config.cache_dir = ""
+    if hasattr(compilation_config, "local_cache_dir"):
+        compilation_config.local_cache_dir = ""
+
+    model.__class__.forward.__code__ = model.original_code_object()
+    TorchCompileWithNoGuardsWrapper.__init__(
+        model,
+        compile_prefix=getattr(model, "_compile_prefix", ""),
+        is_encoder=getattr(model, "_is_encoder", False),
+    )

--- a/vllm_kunlun/hf_config_compat.py
+++ b/vllm_kunlun/hf_config_compat.py
@@ -1,0 +1,12 @@
+from vllm.transformers_utils.configs.qwen3_5 import (
+    Qwen3_5Config as UpstreamQwen3_5Config,
+)
+from vllm.transformers_utils.configs.qwen3_5_moe import (
+    Qwen3_5MoeConfig as UpstreamQwen3_5MoeConfig,
+)
+
+from vllm_kunlun.transformers_utils.configs.qwen3_5 import Qwen3_5Config
+from vllm_kunlun.transformers_utils.configs.qwen3_5_moe import Qwen3_5MoeConfig
+
+QWEN3_5_CONFIG_TYPES = (Qwen3_5Config, UpstreamQwen3_5Config)
+QWEN3_5_MOE_CONFIG_TYPES = (Qwen3_5MoeConfig, UpstreamQwen3_5MoeConfig)

--- a/vllm_kunlun/models/__init__.py
+++ b/vllm_kunlun/models/__init__.py
@@ -26,9 +26,10 @@ def register_model():
     #     "Qwen3ForCausalLM",
     #     "vllm_kunlun.models.qwen3:Qwen3ForCausalLM")
 
-    # ModelRegistry.register_model(
-    #     "Qwen3MoeForCausalLM",
-    #     "vllm_kunlun.models.qwen3_moe:Qwen3MoeForCausalLM")
+    ModelRegistry.register_model(
+        "Qwen3MoeForCausalLM",
+        "vllm_kunlun.models.qwen3_moe:Qwen3MoeForCausalLM",
+    )
 
     ModelRegistry.register_model(
         "Qwen3NextForCausalLM", "vllm_kunlun.models.qwen3_next:Qwen3NextForCausalLM"

--- a/vllm_kunlun/models/__init__.py
+++ b/vllm_kunlun/models/__init__.py
@@ -4,6 +4,7 @@ from vllm import ModelRegistry
 def register_model():
 
     # TODO Remove all of models registration below
+    from vllm_kunlun.models.deepseek_v2 import DeepseekV3ForCausalLM
 
     # from .demo_model import DemoModel  # noqa: F401
 
@@ -79,11 +80,13 @@ def register_model():
     )
 
     ModelRegistry.register_model(
-        "DeepseekV3ForCausalLM", "vllm_kunlun.models.deepseek_v2:DeepseekV3ForCausalLM"
+        "DeepseekV3ForCausalLM",
+        DeepseekV3ForCausalLM,
     )
 
     ModelRegistry.register_model(
-        "DeepseekV32ForCausalLM", "vllm_kunlun.models.deepseek_v2:DeepseekV3ForCausalLM"
+        "DeepseekV32ForCausalLM",
+        DeepseekV3ForCausalLM,
     )
 
     ModelRegistry.register_model(

--- a/vllm_kunlun/models/deepseek_mtp.py
+++ b/vllm_kunlun/models/deepseek_mtp.py
@@ -21,6 +21,7 @@ from vllm.model_executor.models.utils import maybe_prefix
 from vllm.sequence import IntermediateTensors
 
 from .deepseek_v2 import DeepseekV2DecoderLayer, get_spec_layer_idx_from_weight_name
+from .fused_moe_compat import make_expert_params_mapping
 
 
 class SharedHead(nn.Module):
@@ -188,7 +189,9 @@ class DeepSeekMTP(nn.Module, SupportsPP):
             ("fused_qkv_a_proj", "kv_a_proj_with_mqa", 1),
         ]
 
-        expert_params_mapping = FusedMoE.make_expert_params_mapping(
+        expert_params_mapping = make_expert_params_mapping(
+            FusedMoE,
+            self,
             ckpt_gate_proj_name="gate_proj",
             ckpt_down_proj_name="down_proj",
             ckpt_up_proj_name="up_proj",

--- a/vllm_kunlun/models/deepseek_v2.py
+++ b/vllm_kunlun/models/deepseek_v2.py
@@ -24,6 +24,7 @@
 # limitations under the License.
 """Inference-only DeepseekV2/DeepseekV3 model."""
 
+import inspect
 import typing
 from collections.abc import Callable, Iterable
 from itertools import islice
@@ -45,7 +46,8 @@ from vllm.distributed import (
 )
 from vllm.forward_context import get_forward_context
 from vllm.logger import init_logger
-from vllm.model_executor.layers.fused_moe import FusedMoE
+from vllm.model_executor.layers.activation import SiluAndMul
+from vllm.model_executor.layers.fused_moe import FusedMoE, SharedFusedMoE
 from vllm.model_executor.layers.layernorm import LayerNorm, RMSNorm
 from vllm.model_executor.layers.linear import (
     ColumnParallelLinear,
@@ -53,10 +55,9 @@ from vllm.model_executor.layers.linear import (
     RowParallelLinear,
 )
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
-from vllm.model_executor.layers.mla import MLAModules, MultiHeadLatentAttention
+from vllm.model_executor.layers.mla import MLAModules, MultiHeadLatentAttentionWrapper
 from vllm.model_executor.layers.quantization import QuantizationConfig
 from vllm.model_executor.layers.rotary_embedding import get_rope
-from vllm.model_executor.layers.shared_fused_moe import SharedFusedMoE
 from vllm.model_executor.layers.vocab_parallel_embedding import (
     ParallelLMHead,
     VocabParallelEmbedding,
@@ -82,11 +83,14 @@ from vllm.model_executor.models.utils import (
 from vllm.platforms import current_platform
 from vllm.sequence import IntermediateTensors
 
-from vllm_kunlun.ops.activation import SiluAndMul
+from vllm_kunlun.compat import _patch_mla_attention_runtime_weight_device
+from vllm_kunlun.models.fused_moe_compat import make_expert_params_mapping
 from vllm_kunlun.ops.attention.layer import Attention
 from vllm_kunlun.ops.deep_gemm import int8_mqa_logits, int8_paged_mqa_logits
 from vllm_kunlun.ops.linear import ReplicatedLinear
 from vllm_kunlun.v1.attention.backends.mla.indexer import DeepseekV32IndexerMetadata
+
+_patch_mla_attention_runtime_weight_device()
 
 if current_platform.is_cuda_alike():
     pass
@@ -95,6 +99,50 @@ elif current_platform.is_xpu():
 
 _is_kunlun = True
 logger = init_logger(__name__)
+
+
+def _get_rope_compat(
+    head_size: int,
+    rotary_dim: int,
+    max_position: int,
+    base: float,
+    rope_scaling: Optional[dict[str, Any]],
+    is_neox_style: bool,
+    rope_fn: Callable[..., Any] = get_rope,
+):
+    if "rope_parameters" in inspect.signature(rope_fn).parameters:
+        rope_parameters = dict(rope_scaling or {})
+        rope_parameters.setdefault("rope_theta", base)
+        if rotary_dim != head_size:
+            rope_parameters["partial_rotary_factor"] = rotary_dim / head_size
+        return rope_fn(
+            head_size,
+            max_position=max_position,
+            is_neox_style=is_neox_style,
+            rope_parameters=rope_parameters,
+        )
+
+    return rope_fn(
+        head_size,
+        rotary_dim=rotary_dim,
+        max_position=max_position,
+        base=base,
+        rope_scaling=rope_scaling,
+        is_neox_style=is_neox_style,
+    )
+
+
+def _reshape_indexer_rope_outputs(
+    q_pe: torch.Tensor,
+    k_pe: torch.Tensor,
+    n_head: int,
+    rope_dim: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    return q_pe.reshape(-1, n_head, rope_dim), k_pe.reshape(-1, 1, rope_dim)
+
+
+def _get_indexer_kv_cache(k_cache: Any) -> torch.Tensor:
+    return k_cache.kv_cache
 
 
 class DeepseekV2MLP(nn.Module):
@@ -406,7 +454,7 @@ class DeepseekV2Attention(nn.Module):
         if rope_scaling:
             rope_scaling["rope_type"] = "deepseek_yarn"
 
-        self.rotary_emb = get_rope(
+        self.rotary_emb = _get_rope_compat(
             qk_rope_head_dim,
             rotary_dim=qk_rope_head_dim,
             max_position=max_position_embeddings,
@@ -747,6 +795,9 @@ class Indexer(nn.Module):
         )
 
         q_pe, k_pe = rotary_emb(positions, q_pe, k_pe.unsqueeze(1))
+        q_pe, k_pe = _reshape_indexer_rope_outputs(
+            q_pe, k_pe, self.n_head, self.rope_dim
+        )
         q = torch.cat([q_pe, q_nope], dim=-1)
         k = torch.cat([k_pe.squeeze(1), k_nope], dim=-1)
 
@@ -773,7 +824,7 @@ class Indexer(nn.Module):
         torch.ops.vllm.sparse_attn_indexer_vllm_kunlun(
             hidden_states,
             self.k_cache.prefix,
-            self.k_cache.kv_cache[0],
+            _get_indexer_kv_cache(self.k_cache),
             q_fp8,
             k,
             weights,
@@ -888,7 +939,7 @@ class DeepseekV2MLAAttention(nn.Module):
 
         if rope_scaling:
             rope_scaling["rope_type"] = "deepseek_yarn"
-        self.rotary_emb = get_rope(
+        self.rotary_emb = _get_rope_compat(
             qk_rope_head_dim,
             rotary_dim=qk_rope_head_dim,
             max_position=max_position_embeddings,
@@ -905,6 +956,14 @@ class DeepseekV2MLAAttention(nn.Module):
         self.is_v32 = hasattr(config, "index_topk")
 
         if self.is_v32:
+            self.indexer_rope_emb = _get_rope_compat(
+                qk_rope_head_dim,
+                rotary_dim=qk_rope_head_dim,
+                max_position=max_position_embeddings,
+                base=rope_theta,
+                rope_scaling=rope_scaling,
+                is_neox_style=not getattr(config, "indexer_rope_interleave", False),
+            )
             self.indexer = Indexer(
                 vllm_config,
                 config,
@@ -916,6 +975,7 @@ class DeepseekV2MLAAttention(nn.Module):
                 f"{prefix}.indexer",
             )
         else:
+            self.indexer_rope_emb = None
             self.indexer = None
 
         mla_modules = MLAModules(
@@ -933,11 +993,12 @@ class DeepseekV2MLAAttention(nn.Module):
             q_b_proj=self.q_b_proj if self.q_lora_rank is not None else None,
             q_proj=self.q_proj if self.q_lora_rank is None else None,
             indexer=self.indexer,
+            indexer_rotary_emb=self.indexer_rope_emb,
             is_sparse=self.is_v32,
             topk_indices_buffer=topk_indices_buffer,
         )
 
-        self.mla_attn = MultiHeadLatentAttention(
+        self.mla_attn = MultiHeadLatentAttentionWrapper(
             self.hidden_size,
             self.num_local_heads,
             self.scaling,
@@ -1263,6 +1324,9 @@ class DeepseekV2ForCausalLM(nn.Module, SupportsPP, MixtureOfExperts, SupportsLoR
     def get_input_embeddings(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.model.get_input_embeddings(input_ids)
 
+    def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
+        return self.model.get_input_embeddings(input_ids)
+
     def forward(
         self,
         input_ids: torch.Tensor,
@@ -1293,7 +1357,9 @@ class DeepseekV2ForCausalLM(nn.Module, SupportsPP, MixtureOfExperts, SupportsLoR
 
         # Params for weights, fp8 weight scales, fp8 activation scales
         # (param_name, weight_name, expert_id, shard_id)
-        expert_params_mapping = FusedMoE.make_expert_params_mapping(
+        expert_params_mapping = make_expert_params_mapping(
+            FusedMoE,
+            self,
             ckpt_gate_proj_name="gate_proj",
             ckpt_down_proj_name="down_proj",
             ckpt_up_proj_name="up_proj",

--- a/vllm_kunlun/models/fused_moe_compat.py
+++ b/vllm_kunlun/models/fused_moe_compat.py
@@ -1,0 +1,32 @@
+#
+# Copyright (c) 2026 Baidu, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-kunlun project.
+#
+
+import inspect
+from typing import Any
+
+import torch
+
+
+def make_expert_params_mapping(
+    fused_moe_cls: type[Any],
+    model: torch.nn.Module,
+    **kwargs: Any,
+):
+    method = fused_moe_cls.make_expert_params_mapping
+    if "model" in inspect.signature(method).parameters:
+        return method(model, **kwargs)
+    return method(**kwargs)

--- a/vllm_kunlun/models/mimo_v2_flash.py
+++ b/vllm_kunlun/models/mimo_v2_flash.py
@@ -43,6 +43,7 @@ from vllm.model_executor.models.utils import (
 )
 from vllm.sequence import IntermediateTensors
 
+from vllm_kunlun.models.fused_moe_compat import make_expert_params_mapping
 from vllm_kunlun.ops.activation import SiluAndMul
 from vllm_kunlun.ops.attention.layer import Attention
 from vllm_kunlun.ops.linear import QKVParallelLinear
@@ -485,7 +486,9 @@ class MiMoV2Model(nn.Module):
     def get_expert_mapping(self) -> list[tuple[str, str, int, str]]:
         # Params for weights, fp8 weight scales, fp8 activation scales
         # (param_name, weight_name, expert_id, shard_id)
-        return FusedMoE.make_expert_params_mapping(
+        return make_expert_params_mapping(
+            FusedMoE,
+            self,
             ckpt_gate_proj_name="gate_proj",
             ckpt_down_proj_name="down_proj",
             ckpt_up_proj_name="up_proj",

--- a/vllm_kunlun/models/qwen3_5.py
+++ b/vllm_kunlun/models/qwen3_5.py
@@ -76,6 +76,10 @@ from vllm.model_executor.models.utils import (
 from vllm.multimodal import MULTIMODAL_REGISTRY
 from vllm.sequence import IntermediateTensors
 
+from vllm_kunlun.hf_config_compat import (
+    QWEN3_5_CONFIG_TYPES,
+    QWEN3_5_MOE_CONFIG_TYPES,
+)
 from vllm_kunlun.ops.mamba.mamba_utils import (
     MambaStateCopyFunc,
     MambaStateCopyFuncCalculator,
@@ -105,12 +109,12 @@ logger = init_logger(__name__)
 
 class Qwen3_5ProcessingInfo(Qwen3VLProcessingInfo):
     def get_hf_config(self):
-        return self.ctx.get_hf_config(Qwen3_5Config)
+        return self.ctx.get_hf_config(QWEN3_5_CONFIG_TYPES)
 
 
 class Qwen3_5MoeProcessingInfo(Qwen3VLProcessingInfo):
     def get_hf_config(self):
-        return self.ctx.get_hf_config(Qwen3_5MoeConfig)
+        return self.ctx.get_hf_config(QWEN3_5_MOE_CONFIG_TYPES)
 
 
 class Qwen3_5GatedDeltaNet(Qwen3NextGatedDeltaNet):

--- a/vllm_kunlun/models/qwen3_moe.py
+++ b/vllm_kunlun/models/qwen3_moe.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import logging
+import typing
+from collections.abc import Iterable
+
+import torch
+from vllm.config import VllmConfig
+from vllm.model_executor.models import qwen3_moe as upstream
+
+logger = logging.getLogger(__name__)
+
+
+class Qwen3MoeModel(upstream.Qwen3MoeModel):
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        stacked_params_mapping = [
+            ("qkv_proj", "q_proj", "q"),
+            ("qkv_proj", "k_proj", "k"),
+            ("qkv_proj", "v_proj", "v"),
+            ("gate_up_proj", "gate_proj", 0),
+            ("gate_up_proj", "up_proj", 1),
+        ]
+        ignore_suffixes = (
+            ".bias",
+            "_bias",
+            ".weight_scale",
+            "_weight_scale",
+            ".input_scale",
+            "_input_scale",
+        )
+
+        params_dict = dict(self.named_parameters())
+        loaded_params: set[str] = set()
+        expert_params_mapping = self.get_expert_mapping()
+        skipped_count = 0
+        skipped_example: str | None = None
+        for name, loaded_weight in weights:
+            if self.quant_config is not None and (
+                scale_name := self.quant_config.get_cache_scale(name)
+            ):
+                param = params_dict[scale_name]
+                weight_loader = getattr(
+                    param, "weight_loader", upstream.default_weight_loader
+                )
+                assert (
+                    loaded_weight.numel() == 1
+                ), f"KV scale numel {loaded_weight.numel()} != 1"
+                loaded_weight = loaded_weight.squeeze()
+                weight_loader(param, loaded_weight)
+                loaded_params.add(scale_name)
+                continue
+            if "scale" in name or "zero_point" in name:
+                name = upstream.maybe_remap_kv_scale_name(name, params_dict)
+                if name is None:
+                    continue
+            for param_name, weight_name, shard_id in stacked_params_mapping:
+                if weight_name not in name:
+                    continue
+                if "mlp.experts" in name:
+                    continue
+                name = name.replace(weight_name, param_name)
+
+                if name.endswith(ignore_suffixes) and name not in params_dict:
+                    continue
+                if upstream.is_pp_missing_parameter(name, self):
+                    continue
+                if name.endswith("scale"):
+                    name = upstream.maybe_remap_kv_scale_name(name, params_dict)
+                    if name is None:
+                        continue
+                if name not in params_dict:
+                    continue
+
+                param = params_dict[name]
+                weight_loader = getattr(
+                    param, "weight_loader", upstream.default_weight_loader
+                )
+                if weight_loader == upstream.default_weight_loader:
+                    weight_loader(param, loaded_weight)
+                else:
+                    weight_loader(param, loaded_weight, shard_id)
+                break
+            else:
+                is_expert_weight = False
+                for mapping in expert_params_mapping:
+                    param_name, weight_name, expert_id, shard_id = mapping
+                    if weight_name not in name:
+                        continue
+
+                    is_expert_weight = True
+                    name_mapped = name.replace(weight_name, param_name)
+
+                    if upstream.is_pp_missing_parameter(name_mapped, self):
+                        continue
+                    if (
+                        name_mapped.endswith(ignore_suffixes)
+                        and name_mapped not in params_dict
+                    ):
+                        continue
+                    if name_mapped not in params_dict:
+                        skipped_count += 1
+                        if skipped_example is None:
+                            skipped_example = name
+                        continue
+
+                    param = params_dict[name_mapped]
+                    weight_loader = typing.cast(
+                        typing.Callable[..., bool], param.weight_loader
+                    )
+                    success = weight_loader(
+                        param,
+                        loaded_weight,
+                        name_mapped,
+                        shard_id=shard_id,
+                        expert_id=expert_id,
+                        return_success=True,
+                    )
+                    if success:
+                        name = name_mapped
+                        break
+                else:
+                    if is_expert_weight:
+                        continue
+                    if name.endswith(ignore_suffixes) and name not in params_dict:
+                        continue
+                    if upstream.is_pp_missing_parameter(name, self):
+                        continue
+                    if name not in params_dict:
+                        continue
+                    param = params_dict[name]
+                    weight_loader = getattr(
+                        param, "weight_loader", upstream.default_weight_loader
+                    )
+                    weight_loader(param, loaded_weight)
+            loaded_params.add(name)
+
+        if skipped_count:
+            logger.warning(
+                "Skipping %d unmatched Qwen3-MoE expert weights. Example: %s",
+                skipped_count,
+                skipped_example,
+            )
+
+        return loaded_params
+
+
+class Qwen3MoeForCausalLM(upstream.Qwen3MoeForCausalLM):
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
+        original_model_cls = upstream.Qwen3MoeModel
+        upstream.Qwen3MoeModel = Qwen3MoeModel
+        try:
+            super().__init__(vllm_config=vllm_config, prefix=prefix)
+        finally:
+            upstream.Qwen3MoeModel = original_model_cls

--- a/vllm_kunlun/models/qwen3_next.py
+++ b/vllm_kunlun/models/qwen3_next.py
@@ -10,7 +10,6 @@ import torch
 from einops import rearrange
 from torch import nn
 from transformers.activations import ACT2FN
-from vllm.attention.layer import Attention
 from vllm.compilation.decorators import support_torch_compile
 from vllm.config import (
     CacheConfig,
@@ -88,6 +87,7 @@ from vllm.transformers_utils.configs import Qwen3NextConfig
 from vllm.utils.torch_utils import direct_register_custom_op
 from vllm.v1.attention.backend import AttentionMetadata
 
+from vllm_kunlun.attention_compat import Attention
 from vllm_kunlun.ops._kunlun_ops import KunlunOps as ops
 
 # from vllm_kunlun.ops.attention.layer import Attention

--- a/vllm_kunlun/models/qwen3_omni_moe_thinker.py
+++ b/vllm_kunlun/models/qwen3_omni_moe_thinker.py
@@ -43,7 +43,6 @@ from transformers.models.qwen3_omni_moe.processing_qwen3_omni_moe import (
     Qwen3OmniMoeProcessor,
 )
 from transformers.models.whisper import WhisperFeatureExtractor
-from vllm.attention.layer import check_upstream_fa_availability
 from vllm.compilation.decorators import support_torch_compile
 from vllm.config import VllmConfig
 from vllm.distributed import get_pp_group
@@ -92,6 +91,8 @@ from vllm.multimodal.processing import (
 )
 from vllm.platforms.interface import _Backend
 from vllm.sequence import IntermediateTensors
+
+from ..attention_compat import check_upstream_fa_availability
 
 # yapf: enable
 from .qwen2_5_vl import (

--- a/vllm_kunlun/models/qwen3_vl.py
+++ b/vllm_kunlun/models/qwen3_vl.py
@@ -47,7 +47,6 @@ from transformers.models.qwen3_vl.video_processing_qwen3_vl import (
     smart_resize as video_smart_resize,
 )
 from transformers.video_utils import VideoMetadata
-from vllm.attention.layer import check_upstream_fa_availability
 from vllm.compilation.decorators import support_torch_compile
 from vllm.config import VllmConfig
 from vllm.distributed import get_pp_group
@@ -99,6 +98,8 @@ from vllm.sequence import IntermediateTensors
 from vllm.transformers_utils.config import uses_mrope
 from vllm.utils import is_list_of
 
+from vllm_kunlun.attention_compat import check_upstream_fa_availability
+
 from .qwen2_5_vl import (
     Qwen2_5_VisionAttention,
     Qwen2_5_VisionRotaryEmbedding,
@@ -117,7 +118,6 @@ _MAX_FRAMES_PER_VIDEO = 24576
 
 
 class Qwen3_VisionPatchEmbed(nn.Module):
-
     def __init__(
         self,
         patch_size: int = 14,
@@ -147,7 +147,6 @@ class Qwen3_VisionPatchEmbed(nn.Module):
 
 
 class Qwen3_VisionMLP(nn.Module):
-
     def __init__(
         self,
         in_features: int,
@@ -185,7 +184,6 @@ class Qwen3_VisionMLP(nn.Module):
 
 
 class Qwen3_VisionBlock(nn.Module):
-
     def __init__(
         self,
         dim: int,
@@ -245,7 +243,6 @@ class Qwen3_VisionBlock(nn.Module):
 
 
 class Qwen3_VisionPatchMerger(nn.Module):
-
     def __init__(
         self,
         d_model: int,
@@ -298,7 +295,6 @@ class Qwen3_VisionPatchMerger(nn.Module):
 
 
 class Qwen3_VisionTransformer(nn.Module):
-
     def __init__(
         self,
         vision_config: Qwen3VLVisionConfig,
@@ -448,7 +444,6 @@ class Qwen3_VisionTransformer(nn.Module):
         return rotary_pos_emb
 
     def fast_pos_embed_interpolate(self, grid_thw: list[list[int]]) -> torch.Tensor:
-
         num_grid_per_side = self.num_grid_per_side
         m_size = self.spatial_merge_size
         hidden_dim = self.pos_embed.embedding_dim
@@ -615,7 +610,6 @@ class Qwen3_VisionTransformer(nn.Module):
 
 
 class Qwen3VLProcessingInfo(Qwen2VLProcessingInfo):
-
     def get_hf_config(self):
         return self.ctx.get_hf_config(Qwen3VLConfig)
 
@@ -782,7 +776,6 @@ class Qwen3VLProcessingInfo(Qwen2VLProcessingInfo):
 
 
 class Qwen3VLDummyInputsBuilder(BaseDummyInputsBuilder[Qwen3VLProcessingInfo]):
-
     def get_dummy_text(self, mm_counts: Mapping[str, int]) -> str:
         num_images = mm_counts.get("image", 0)
         num_videos = mm_counts.get("video", 0)
@@ -866,7 +859,6 @@ class Qwen3VLDummyInputsBuilder(BaseDummyInputsBuilder[Qwen3VLProcessingInfo]):
 
 
 class Qwen3VLMultiModalProcessor(BaseMultiModalProcessor[Qwen3VLProcessingInfo]):
-
     def _get_data_parser(self) -> MultiModalDataParser:
         return MultiModalDataParser(video_needs_metadata=True)
 
@@ -1067,7 +1059,6 @@ class Qwen3VLMultiModalProcessor(BaseMultiModalProcessor[Qwen3VLProcessingInfo])
     }
 )
 class Qwen3LLMModel(Qwen3Model):
-
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
         super().__init__(vllm_config=vllm_config, prefix=prefix)
         if not get_pp_group().is_first_rank:
@@ -1125,7 +1116,6 @@ class Qwen3LLMModel(Qwen3Model):
 
 
 class Qwen3LLMForCausalLM(Qwen3ForCausalLM):
-
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
         super(Qwen3ForCausalLM, self).__init__()
         config = vllm_config.model_config.hf_config.text_config
@@ -1400,7 +1390,6 @@ class Qwen3VLForConditionalGeneration(
     def _process_image_input(
         self, image_input: Qwen2_5_VLImageInputs
     ) -> tuple[torch.Tensor, ...]:
-
         grid_thw = image_input["image_grid_thw"]
         assert grid_thw.ndim == 2
         grid_thw_list = grid_thw.tolist()
@@ -1428,7 +1417,6 @@ class Qwen3VLForConditionalGeneration(
     def _process_video_input(
         self, video_input: Qwen2_5_VLVideoInputs
     ) -> tuple[torch.Tensor, ...]:
-
         grid_thw = video_input["video_grid_thw"]
         assert grid_thw.ndim == 2
         grid_thw_list = grid_thw.tolist()
@@ -1480,7 +1468,6 @@ class Qwen3VLForConditionalGeneration(
     def get_multimodal_embeddings(
         self, **kwargs: object
     ) -> Optional[MultiModalEmbeddings]:
-
         mm_input_by_modality = self._parse_and_validate_multimodal_inputs(**kwargs)
         if not mm_input_by_modality:
             return None
@@ -1513,12 +1500,13 @@ class Qwen3VLForConditionalGeneration(
         ]
         multimodal_embeddings_cat = torch.cat(multimodal_embeddings, dim=0)
 
-        multimodal_embeddings_main, multimodal_embeddings_multiscale = (
-            torch.split(  # noqa:E501
-                multimodal_embeddings_cat,
-                [self.visual_dim, self.multiscale_dim],
-                dim=-1,
-            )
+        (
+            multimodal_embeddings_main,
+            multimodal_embeddings_multiscale,
+        ) = torch.split(  # noqa:E501
+            multimodal_embeddings_cat,
+            [self.visual_dim, self.multiscale_dim],
+            dim=-1,
         )
 
         multimodal_embeddings = torch.split(
@@ -1556,10 +1544,11 @@ class Qwen3VLForConditionalGeneration(
         inputs_embeds = self.language_model.get_input_embeddings(input_ids)
         if multimodal_embeddings is not None:
             if self.use_deepstack:
-                deepstack_input_embeds, multimodal_embeddings = (
-                    self._compute_deepstack_embeds(  # noqa:E501
-                        input_ids, inputs_embeds, multimodal_embeddings
-                    )
+                (
+                    deepstack_input_embeds,
+                    multimodal_embeddings,
+                ) = self._compute_deepstack_embeds(  # noqa:E501
+                    input_ids, inputs_embeds, multimodal_embeddings
                 )
             inputs_embeds = merge_multimodal_embeddings(
                 input_ids,
@@ -1743,7 +1732,6 @@ class Qwen3VLForConditionalGeneration(
         return self.language_model.compute_logits(hidden_states)
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
-
         skip_prefixes = []
         if self.visual is None:
             skip_prefixes.extend(["visual."])

--- a/vllm_kunlun/ops/__init__.py
+++ b/vllm_kunlun/ops/__init__.py
@@ -15,17 +15,14 @@
 # This file is a part of the vllm-ascend project.
 #
 
-import vllm_kunlun.ops._custom_ops
-import vllm_kunlun.ops.fused_moe.layer
+"""Kunlun ops package.
 
-# base layers
-import vllm_kunlun.ops.layernorm
-import vllm_kunlun.ops.linear
+Avoid eager side-effect imports here. vLLM 0.19 imports
+``vllm.v1.attention.ops.merge_attn_states`` during CLI argument parsing, and our
+import hook redirects that path into ``vllm_kunlun.ops.attention``. Pulling in
+``vllm_kunlun.ops`` package-wide side effects at that stage forces ``kunlun_ops``
+and ``torch_xmlir`` to load before the service is even configured.
 
-# embedding
-import vllm_kunlun.ops.rotary_embedding
-import vllm_kunlun.ops.vocab_parallel_embedding
-import vllm_kunlun.v1.sample.spec_decode.eagle  # noqa: F401
-
-# TODO @xyDong0223 remove v0.16.0
-# import vllm_kunlun.ops.mla
+The individual submodules still import and register their runtime pieces when
+they are imported explicitly by model/attention code.
+"""

--- a/vllm_kunlun/ops/_custom_ops.py
+++ b/vllm_kunlun/ops/_custom_ops.py
@@ -1627,9 +1627,101 @@ def _fake_concat_and_cache_mla(
 concat_and_cache_mla.register_fake(_fake_concat_and_cache_mla)
 
 
+if not hasattr(torch.ops._C_cache_ops, "concat_and_cache_mla"):
+
+    @custom_op("_C_cache_ops::concat_and_cache_mla", mutates_args=())
+    def concat_and_cache_mla_vllm019(
+        kv_c: torch.Tensor,
+        k_pe: torch.Tensor,
+        kv_cache: torch.Tensor,
+        slot_mapping: torch.Tensor,
+        kv_cache_dtype: str,
+        scale: torch.Tensor,
+    ) -> None:
+        kunlun_ops.concat_and_cache_mla(
+            kv_c=kv_c,
+            k_pe=k_pe,
+            slot_mapping=slot_mapping,
+            kv_cache=kv_cache,
+        )
+
+    @impl("_C_cache_ops::concat_and_cache_mla", "CUDA")
+    def concat_and_cache_mla_vllm019_cuda(
+        kv_c: torch.Tensor,
+        k_pe: torch.Tensor,
+        kv_cache: torch.Tensor,
+        slot_mapping: torch.Tensor,
+        kv_cache_dtype: str,
+        scale: torch.Tensor,
+    ) -> None:
+        kunlun_ops.concat_and_cache_mla(
+            kv_c=kv_c,
+            k_pe=k_pe,
+            slot_mapping=slot_mapping,
+            kv_cache=kv_cache,
+        )
+
+    def _fake_concat_and_cache_mla_vllm019(
+        kv_c: torch.Tensor,
+        k_pe: torch.Tensor,
+        kv_cache: torch.Tensor,
+        slot_mapping: torch.Tensor,
+        kv_cache_dtype: str,
+        scale: torch.Tensor,
+    ) -> None:
+        return None
+
+    concat_and_cache_mla_vllm019.register_fake(_fake_concat_and_cache_mla_vllm019)
+
+
 ######################################################
 # -------------- scaled_int8_quant -------------------
 ######################################################
+def _scaled_int8_quant_torch_fallback(
+    x: torch.Tensor,
+    x_q: torch.Tensor,
+    scale: torch.Tensor,
+) -> None:
+    x_2d = x.reshape(-1, x.shape[-1]).to(torch.float32)
+    scale_2d = scale.reshape(-1, 1)
+    if scale_2d.shape[0] != x_2d.shape[0]:
+        raise RuntimeError(
+            "scaled_int8_quant fallback expected one scale per input row, "
+            f"got scale rows={scale_2d.shape[0]} and input rows={x_2d.shape[0]}"
+        )
+
+    absmax = torch.amax(torch.abs(x_2d), dim=-1, keepdim=True)
+    denom = torch.where(absmax > 0, absmax, torch.ones_like(absmax))
+    quantized = torch.round(x_2d * (127.0 / denom)).clamp_(-127, 127)
+
+    x_q.reshape(-1, x.shape[-1]).copy_(quantized.to(torch.int8))
+    scale_2d.copy_(absmax)
+
+
+def _dynamic_scaled_int8_quant(
+    x: torch.Tensor,
+    x_q: torch.Tensor,
+    scale: torch.Tensor,
+) -> None:
+    x_contiguous = x.contiguous()
+    try:
+        # NOTE: For quant2d ops, scale represents max.
+        ret = kunlun_ops.quant2d(
+            x=x_contiguous,
+            y=x_q,
+            max=scale,
+            force_sdnn=True,
+        )
+    except RuntimeError:
+        _scaled_int8_quant_torch_fallback(x_contiguous, x_q, scale)
+        return
+
+    if ret in (None, 0):
+        return
+
+    _scaled_int8_quant_torch_fallback(x_contiguous, x_q, scale)
+
+
 @custom_op("_C::scaled_int8_quant", mutates_args=())
 def scaled_int8_quant(
     x: torch.Tensor,
@@ -1648,8 +1740,7 @@ def scaled_int8_quant(
         )
         azp = None if symmetric else torch.empty_like(scale, dtype=torch.int32)
         if symmetric:
-            # NOTE: For quant2d ops, scale represents max.
-            kunlun_ops.quant2d(x=x.contiguous(), y=x_q, max=scale, force_sdnn=True)
+            _dynamic_scaled_int8_quant(x, x_q, scale)
         else:
             torch.ops.xspeedgate_ops.dynamic_scaled_int8_quant(
                 x_q, x.contiguous(), scale, azp
@@ -1675,8 +1766,7 @@ def scaled_int8_quant_cuda(
         )
         azp = None if symmetric else torch.empty_like(scale, dtype=torch.int32)
         if symmetric:
-            # NOTE: For quant2d ops, scale represents max.
-            kunlun_ops.quant2d(x=x.contiguous(), y=x_q, max=scale, force_sdnn=True)
+            _dynamic_scaled_int8_quant(x, x_q, scale)
         else:
             torch.ops.xspeedgate_ops.dynamic_scaled_int8_quant(
                 x_q, x.contiguous(), scale, azp

--- a/vllm_kunlun/ops/_kunlun_ops.py
+++ b/vllm_kunlun/ops/_kunlun_ops.py
@@ -21,26 +21,296 @@ from typing import Optional
 
 import cocopod  # noqa
 import torch
+import torch.nn.functional as F
 import xspeedgate_ops  # noqa
 from vllm.logger import init_logger
 from vllm.v1.worker.workspace import current_workspace_manager
 
 logger = init_logger(__name__)
 
+kunlun_ops = None
 try:
-    import kunlun_ops
+    import kunlun_ops as _kunlun_ops
 
+    kunlun_ops = _kunlun_ops
     logger.info("Load custom ops library success!")
-except ImportError as e:
-    logger.warning("Import error msg: %s", e.msg)
+except (ImportError, OSError) as e:
+    logger.warning("Import error msg: %s", e)
 
 
 _per_token_smooth_quant = True
+_logged_native_moe_fallback = False
 
 
 def is_per_token_smooth_quant():
     """is per token smooth quant"""
     return _per_token_smooth_quant
+
+
+def _torch_op_exists(namespace: str, op_name: str) -> bool:
+    try:
+        getattr(getattr(torch.ops, namespace), op_name)
+        return True
+    except AttributeError:
+        return False
+
+
+def _grouped_topk_native(
+    gating_output: torch.Tensor,
+    topk: int,
+    renormalize: bool,
+    num_expert_group: int,
+    topk_group: int,
+    scoring_func: str,
+    e_score_correction_bias: torch.Tensor | None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if scoring_func == "softmax":
+        scores = torch.softmax(gating_output.float(), dim=-1)
+    elif scoring_func == "sigmoid":
+        scores = gating_output.float().sigmoid()
+    else:
+        raise ValueError(f"Unsupported scoring function: {scoring_func}")
+
+    num_tokens = scores.shape[0]
+    if e_score_correction_bias is not None:
+        original_scores = scores
+        scores = scores + e_score_correction_bias.unsqueeze(0)
+        group_scores = (
+            scores.view(num_tokens, num_expert_group, -1).topk(2, dim=-1)[0].sum(dim=-1)
+        )
+    else:
+        group_scores = scores.view(num_tokens, num_expert_group, -1).max(dim=-1).values
+
+    group_idx = torch.topk(group_scores, k=topk_group, dim=-1, sorted=False)[1]
+    group_mask = torch.zeros_like(group_scores)
+    group_mask.scatter_(1, group_idx, 1)
+    score_mask = (
+        group_mask.unsqueeze(-1)
+        .expand(num_tokens, num_expert_group, scores.shape[-1] // num_expert_group)
+        .reshape(num_tokens, -1)
+    )
+    masked_scores = scores.masked_fill(~score_mask.bool(), float("-inf"))
+
+    if e_score_correction_bias is not None:
+        topk_ids = torch.topk(masked_scores, k=topk, dim=-1, sorted=False)[1]
+        topk_weights = original_scores.gather(1, topk_ids)
+    else:
+        topk_weights, topk_ids = torch.topk(masked_scores, k=topk, dim=-1, sorted=False)
+
+    if renormalize:
+        topk_weights = topk_weights / topk_weights.sum(dim=-1, keepdim=True).clamp_min(
+            torch.finfo(topk_weights.dtype).eps
+        )
+
+    return topk_weights.to(torch.float32), topk_ids.to(torch.int32)
+
+
+def _select_experts_native(
+    router_logits: torch.Tensor,
+    moe_top_k: int,
+    renormalize: bool,
+    use_grouped_topk: bool,
+    num_expert_group: int | None,
+    topk_group: int | None,
+    scoring_func: str,
+    e_score_correction_bias: torch.Tensor | None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    router_logits = router_logits.float()
+
+    if use_grouped_topk:
+        if num_expert_group is None or topk_group is None:
+            raise ValueError("Grouped top-k requires expert-group metadata.")
+        return _grouped_topk_native(
+            gating_output=router_logits,
+            topk=moe_top_k,
+            renormalize=renormalize,
+            num_expert_group=num_expert_group,
+            topk_group=topk_group,
+            scoring_func=scoring_func,
+            e_score_correction_bias=e_score_correction_bias,
+        )
+
+    if scoring_func == "softmax":
+        topk_logits, topk_ids = torch.topk(
+            router_logits, k=moe_top_k, dim=-1, sorted=False
+        )
+        if renormalize:
+            topk_weights = torch.softmax(topk_logits, dim=-1)
+        else:
+            log_z = torch.logsumexp(router_logits, dim=-1, keepdim=True)
+            topk_weights = (topk_logits - log_z).exp()
+    elif scoring_func == "sigmoid":
+        scores = router_logits.sigmoid()
+        topk_weights, topk_ids = torch.topk(scores, k=moe_top_k, dim=-1, sorted=False)
+        if renormalize:
+            topk_weights = topk_weights / topk_weights.sum(
+                dim=-1, keepdim=True
+            ).clamp_min(torch.finfo(topk_weights.dtype).eps)
+    else:
+        raise ValueError(f"Unsupported scoring function: {scoring_func}")
+
+    return topk_weights.to(torch.float32), topk_ids.to(torch.int32)
+
+
+def _swiglu_native(x: torch.Tensor) -> torch.Tensor:
+    half = x.shape[-1] // 2
+    return F.silu(x[..., :half]) * x[..., half:]
+
+
+def _iter_local_moe_routes_cpu(
+    topk_ids: torch.Tensor,
+    topk_weights: torch.Tensor,
+    moe_top_k: int,
+    num_local_experts: int,
+    ep_rank: int,
+):
+    flat_topk_ids_cpu = topk_ids.reshape(-1).to(device="cpu", dtype=torch.int64)
+    flat_topk_weights_cpu = topk_weights.reshape(-1).to(
+        device="cpu", dtype=torch.float32
+    )
+
+    expert_id_offset = ep_rank * num_local_experts
+    if (
+        ep_rank != 0
+        and flat_topk_ids_cpu.numel() > 0
+        and int(flat_topk_ids_cpu.max().item()) < num_local_experts
+    ):
+        expert_id_offset = 0
+
+    local_expert_ids_cpu = flat_topk_ids_cpu - expert_id_offset
+    valid_mask = (local_expert_ids_cpu >= 0) & (
+        local_expert_ids_cpu < num_local_experts
+    )
+    if not bool(valid_mask.any()):
+        return
+
+    valid_route_indices_cpu = torch.nonzero(valid_mask, as_tuple=False).flatten()
+    local_expert_ids_cpu = local_expert_ids_cpu.index_select(0, valid_route_indices_cpu)
+    route_weights_cpu = flat_topk_weights_cpu.index_select(0, valid_route_indices_cpu)
+
+    sort_order = torch.argsort(local_expert_ids_cpu, stable=True)
+    sorted_route_indices_cpu = valid_route_indices_cpu.index_select(0, sort_order)
+    sorted_expert_ids_cpu = local_expert_ids_cpu.index_select(0, sort_order)
+    sorted_route_weights_cpu = route_weights_cpu.index_select(0, sort_order)
+    sorted_token_indices_cpu = torch.div(
+        sorted_route_indices_cpu,
+        moe_top_k,
+        rounding_mode="floor",
+    )
+
+    counts = torch.bincount(sorted_expert_ids_cpu, minlength=num_local_experts)
+    start = 0
+    for local_expert_id, count in enumerate(counts.tolist()):
+        if count == 0:
+            continue
+        end = start + count
+        yield (
+            local_expert_id,
+            sorted_token_indices_cpu[start:end],
+            sorted_route_weights_cpu[start:end],
+        )
+        start = end
+
+
+def _run_moe_native(
+    hidden_states: torch.Tensor,
+    w1: torch.Tensor,
+    w2: torch.Tensor,
+    router_logits: torch.Tensor,
+    ep_rank: int,
+    moe_top_k: int,
+    renormalize: bool,
+    use_grouped_topk: bool,
+    num_expert_group: int | None,
+    topk_group: int | None,
+    w1_bias: torch.Tensor | None,
+    w2_bias: torch.Tensor | None,
+    scoring_func: str,
+    e_score_correction_bias: torch.Tensor | None,
+) -> torch.Tensor:
+    topk_weights, topk_ids = _select_experts_native(
+        router_logits=router_logits,
+        moe_top_k=moe_top_k,
+        renormalize=renormalize,
+        use_grouped_topk=use_grouped_topk,
+        num_expert_group=num_expert_group,
+        topk_group=topk_group,
+        scoring_func=scoring_func,
+        e_score_correction_bias=e_score_correction_bias,
+    )
+
+    token_count, hidden_size = hidden_states.shape
+    num_local_experts = w1.shape[0]
+    output = torch.zeros(
+        (token_count, hidden_size),
+        dtype=hidden_states.dtype,
+        device=hidden_states.device,
+    )
+
+    for (
+        local_expert_id,
+        token_indices_cpu,
+        route_weights_cpu,
+    ) in _iter_local_moe_routes_cpu(
+        topk_ids=topk_ids,
+        topk_weights=topk_weights,
+        moe_top_k=moe_top_k,
+        num_local_experts=num_local_experts,
+        ep_rank=ep_rank,
+    ):
+        token_indices = token_indices_cpu.to(
+            device=hidden_states.device, dtype=torch.long
+        )
+        route_weights = route_weights_cpu.to(
+            device=hidden_states.device,
+            dtype=hidden_states.dtype,
+        )
+        expert_hidden_states = hidden_states.index_select(0, token_indices)
+        gate_up = expert_hidden_states @ w1[local_expert_id].transpose(0, 1)
+        if w1_bias is not None:
+            gate_up = gate_up + w1_bias[local_expert_id]
+        activated = _swiglu_native(gate_up)
+        expert_output = activated @ w2[local_expert_id].transpose(0, 1)
+        if w2_bias is not None:
+            expert_output = expert_output + w2_bias[local_expert_id]
+        expert_output = expert_output * route_weights.unsqueeze(-1)
+        output.index_add_(0, token_indices, expert_output)
+
+    return output
+
+
+def _should_use_native_moe_fallback(
+    hidden_states: torch.Tensor,
+    scoring_func: str,
+    use_grouped_topk: bool,
+) -> bool:
+    if hidden_states.device.type == "cpu":
+        return True
+
+    if scoring_func == "softmax" and not use_grouped_topk:
+        required_ops = (
+            _torch_op_exists("_C", "moe_softmax_topk_norm"),
+            _torch_op_exists("xspeedgate_ops", "moe_pre_small"),
+            _torch_op_exists("xspeedgate_ops", "moe_active_expert_balance"),
+            _torch_op_exists("xspeedgate_ops", "fused_moe"),
+        )
+    elif scoring_func == "sigmoid" and use_grouped_topk:
+        required_ops = (_torch_op_exists("_C", "moe_sigmoid_group_topk_norm"),)
+    else:
+        required_ops = ()
+
+    return not all(required_ops)
+
+
+def _log_native_moe_fallback_once() -> None:
+    global _logged_native_moe_fallback
+    if _logged_native_moe_fallback:
+        return
+    _logged_native_moe_fallback = True
+    logger.warning(
+        "Falling back to native PyTorch MoE path because Kunlun MoE custom ops "
+        "are unavailable in the current runtime."
+    )
 
 
 class KunlunOps:
@@ -393,6 +663,29 @@ class KunlunOps:
         e_score_correction_bias: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         """fused_moe"""
+        if _should_use_native_moe_fallback(
+            hidden_states=hidden_states,
+            scoring_func=scoring_func,
+            use_grouped_topk=use_grouped_topk,
+        ):
+            _log_native_moe_fallback_once()
+            return _run_moe_native(
+                hidden_states=hidden_states,
+                w1=w1,
+                w2=w2,
+                router_logits=router_logits,
+                ep_rank=ep_rank,
+                moe_top_k=moe_top_k,
+                renormalize=renormalize,
+                use_grouped_topk=use_grouped_topk,
+                num_expert_group=num_expert_group,
+                topk_group=topk_group,
+                w1_bias=w1_bias,
+                w2_bias=w2_bias,
+                scoring_func=scoring_func,
+                e_score_correction_bias=e_score_correction_bias,
+            )
+
         global_num_experts, up_gate_size, _ = w1.shape
         M, N = hidden_states.shape
         hidden_dim = w2.shape[1]

--- a/vllm_kunlun/ops/attention/flashmla.py
+++ b/vllm_kunlun/ops/attention/flashmla.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 # adapted from: https://github.com/deepseek-ai/FlashMLA/blob/main/flash_mla/flash_mla_interface.py
+import os
 from typing import Optional, Tuple
 
 import kunlun_ops
@@ -58,6 +59,56 @@ def get_mla_metadata(
     return cache_seqlens_cpu, cache_seqlens
 
 
+def _env_flag(name: str) -> bool:
+    return os.environ.get(name, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _torch_mla_decode(
+    q_c: torch.Tensor,
+    q_r: torch.Tensor,
+    k_cache: torch.Tensor,
+    block_table: torch.Tensor,
+    cache_seqlens: torch.Tensor,
+    softmax_scale: float,
+) -> torch.Tensor:
+    batch_size, seq_len_q, num_heads_q, kv_lora_rank = q_c.shape
+    page_block_size = k_cache.shape[2]
+    head_dim = k_cache.shape[3]
+    qk_rope_head_dim = q_r.shape[-1]
+    flat_cache = k_cache[:, 0]
+
+    out = torch.empty(
+        batch_size,
+        seq_len_q,
+        num_heads_q,
+        kv_lora_rank,
+        dtype=q_c.dtype,
+        device=q_c.device,
+    )
+    for batch_idx in range(batch_size):
+        seq_len = int(cache_seqlens[batch_idx].item())
+        if seq_len == 0:
+            out[batch_idx].zero_()
+            continue
+
+        num_blocks = (seq_len + page_block_size - 1) // page_block_size
+        block_ids = block_table[batch_idx, :num_blocks].to(torch.long)
+        seq_cache = flat_cache.index_select(0, block_ids).reshape(-1, head_dim)[
+            :seq_len
+        ]
+        seq_cache = seq_cache.to(device=q_c.device, dtype=q_c.dtype, non_blocking=True)
+        kv_c = seq_cache[:, :kv_lora_rank]
+        k_pe = seq_cache[:, kv_lora_rank : kv_lora_rank + qk_rope_head_dim]
+
+        scores = torch.einsum("qhd,kd->qhk", q_c[batch_idx], kv_c)
+        scores = scores + torch.einsum("qhr,kr->qhk", q_r[batch_idx], k_pe)
+        scores = scores.float() * softmax_scale
+        probs = torch.softmax(scores, dim=-1).to(q_c.dtype)
+        out[batch_idx] = torch.einsum("qhk,kd->qhd", probs, kv_c)
+
+    return out
+
+
 def flash_mla_with_kvcache(
     q: torch.Tensor,
     k_cache: torch.Tensor,
@@ -102,16 +153,28 @@ def flash_mla_with_kvcache(
     page_block_size = k_cache.shape[1]
     k_cache = k_cache.view(-1, 1, page_block_size, head_dim)
 
-    # todo: optimize memcp
-    # q_c = q[..., : kv_lora_rank].contiguous()
-    # q_r = q[..., kv_lora_rank :].contiguous()
+    q_c = q[..., :kv_lora_rank].contiguous()
+    q_r = q[..., kv_lora_rank:].contiguous()
+
+    if _env_flag("VLLM_KUNLUN_MLA_DECODE_FALLBACK"):
+        return (
+            _torch_mla_decode(
+                q_c=q_c,
+                q_r=q_r,
+                k_cache=k_cache,
+                block_table=block_table,
+                cache_seqlens=cache_seqlens,
+                softmax_scale=softmax_scale,
+            ),
+            softmax_lse,
+        )
 
     is_context = False
     vo_head_dim = -1
 
     kunlun_ops.paged_attention(
         out,
-        q,
+        q_c,
         k_cache,
         None,
         block_table,
@@ -123,7 +186,7 @@ def flash_mla_with_kvcache(
         kv_lora_rank,
         qk_rope_head_dim,
         softmax_scale,
-        q_r=q,
+        q_r=q_r,
     )
     return out, softmax_lse
 

--- a/vllm_kunlun/ops/attention/layer.py
+++ b/vllm_kunlun/ops/attention/layer.py
@@ -5,9 +5,6 @@ from typing import List, Optional
 import torch
 import torch.nn.functional as F
 from torch.library import custom_op
-from vllm.attention import Attention as VllmAttention
-from vllm.attention import AttentionType
-from vllm.attention.layer import MultiHeadAttention as VllmMultiHeadAttention
 from vllm.config import CacheConfig
 from vllm.distributed.kv_transfer import (
     get_kv_transfer_group,
@@ -15,8 +12,16 @@ from vllm.distributed.kv_transfer import (
     is_v1_kv_transfer_group,
 )
 from vllm.forward_context import ForwardContext, get_forward_context
+from vllm.model_executor.layers.attention import Attention as VllmAttention
 from vllm.model_executor.layers.quantization.base_config import QuantizationConfig
-from vllm.platforms import _Backend
+from vllm.v1.attention.backend import AttentionType
+
+
+class _Backend:
+    FLASH_ATTN = "FLASH_ATTN"
+    XFORMERS = "XFORMERS"
+    TORCH_SDPA = "TORCH_SDPA"
+    PALLAS_VLLM_V1 = "PALLAS_VLLM_V1"
 
 
 class Attention(VllmAttention):
@@ -117,8 +122,8 @@ class Attention(VllmAttention):
                 return unified_attention(query, key, value, self.layer_name)
 
 
-# 重写自 vllm.attention.layer 中的 MultiHeadAttention 类
-class MultiHeadAttention(VllmMultiHeadAttention):
+# 重写自旧版 vllm.attention.layer 中的 MultiHeadAttention 类
+class MultiHeadAttention(torch.nn.Module):
     def __init__(
         self,
         num_heads: int,
@@ -126,12 +131,12 @@ class MultiHeadAttention(VllmMultiHeadAttention):
         scale: float,
         num_kv_heads: Optional[int] = None,
     ):
-        super().__init__(
-            num_heads=num_heads,
-            head_size=head_size,
-            scale=scale,
-            num_kv_heads=num_kv_heads,
-        )
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_size = head_size
+        self.scale = scale
+        self.num_kv_heads = num_kv_heads if num_kv_heads is not None else num_heads
+        self.num_queries_per_kv = self.num_heads // self.num_kv_heads
         # kunlun只支持flash_attn
         self.attn_backend = _Backend.FLASH_ATTN
 

--- a/vllm_kunlun/ops/attention/merge_attn_states.py
+++ b/vllm_kunlun/ops/attention/merge_attn_states.py
@@ -1,9 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import importlib
 from typing import Optional
 
-import kunlun_ops
 import torch
+
+
+def _get_kunlun_ops():
+    return importlib.import_module("kunlun_ops")
 
 
 def merge_attn_states(
@@ -14,7 +18,6 @@ def merge_attn_states(
     suffix_lse: torch.Tensor,
     output_lse: Optional[torch.Tensor] = None,
 ) -> None:
-
-    return kunlun_ops.attention_merge_stage(
+    return _get_kunlun_ops().attention_merge_stage(
         prefix_output, prefix_lse, suffix_output, suffix_lse, output, output_lse
     )

--- a/vllm_kunlun/ops/fused_moe/layer.py
+++ b/vllm_kunlun/ops/fused_moe/layer.py
@@ -25,6 +25,11 @@ class KunlunUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod):
       routing internally with device-optimized kernels.
     """
 
+    def __init__(self, moe):
+        super().__init__(moe)
+        self._is_monolithic = True
+        self.apply_monolithic = self._apply_monolithic_kunlun
+
     @property
     def is_monolithic(self) -> bool:
         return True
@@ -33,7 +38,7 @@ class KunlunUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod):
         """Skip _setup_kernel() since Kunlun does not need Triton kernels."""
         FusedMoEMethodBase.process_weights_after_loading(self, layer)
 
-    def apply_monolithic(
+    def _apply_monolithic_kunlun(
         self,
         layer,
         x: torch.Tensor,

--- a/vllm_kunlun/patches/patch_torch251.py
+++ b/vllm_kunlun/patches/patch_torch251.py
@@ -1,98 +1,47 @@
-"""
-vLLM Compatibility Patch Script for PyTorch 2.5.1
-==================================================
+"""Patch vLLM 0.19.x so it can run on PyTorch 2.5.1."""
 
-Why are these patches necessary?
---------------------------------
-vLLM (v0.15.x) was developed and tested against newer versions of PyTorch
-(2.7+), which introduced several API changes that are NOT available in
-PyTorch 2.5.1. Running vLLM on PyTorch 2.5.1 without these patches will
-result in AttributeError or TypeError exceptions at runtime.
-
-Specifically, the following incompatibilities exist:
-
-1. `torch._functorch.config.bundled_autograd_cache` — This configuration
-   option was introduced in PyTorch 2.7+. It does not exist in PyTorch
-   2.5.1, so any code referencing it (either as a direct attribute or via
-   `torch._functorch.config.patch(...)`) will raise an AttributeError.
-
-2. `patched_inline_call(self_: Any)` signature — The inline call hook
-   signature changed between PyTorch versions. In PyTorch 2.5.1, it
-   expects `(parent, func, args, kwargs)` rather than `(self_: Any)`.
-
-3. `torch.Size(...)` constructor — In certain compilation contexts under
-   PyTorch 2.5.1, `torch.Size()` does not work correctly during tracing.
-   Using `torch.empty().size` is a compatible workaround.
-
-4. `list[int]` type hint — Python 3.10 supports `list[int]` in type
-   annotations, but certain runtime introspection paths (especially
-   within torch.compile / FX tracing) may fail to resolve built-in
-   generic aliases. Using `typing.List[int]` avoids this.
-
-When should these patches be removed?
---------------------------------------
-These patches are TEMPORARY workarounds for PyTorch 2.5.1 compatibility.
-They should be REMOVED once the environment is upgraded to PyTorch 2.9+,
-where all referenced APIs are stable and available. Keeping these patches
-on PyTorch 2.9+ may cause unexpected behavior.
-
-Usage:
-------
-    python patch_torch251.py           # Apply all patches
-    python patch_torch251.py --dry-run # Preview changes without modifying files
-    python patch_torch251.py --revert  # Restore all files from .bak backups
-"""
+from __future__ import annotations
 
 import os
 import shutil
 import site
 import sys
 
-# ============================================================
-# Base path for the target Python environment
-# ============================================================
-# Determine the site-packages directory dynamically to keep this
-# script portable across different Python installations.
-_site_packages_list = []
+_site_packages = []
 try:
-    _site_packages_list = site.getsitepackages()
+    _site_packages = site.getsitepackages()
 except Exception:
-    _site_packages_list = []
-if _site_packages_list:
-    # Prefer the first returned site-packages directory.
-    SITE_PACKAGES = _site_packages_list[0]
+    _site_packages = []
+
+if _site_packages:
+    SITE_PACKAGES = _site_packages[0]
 else:
-    # Fallback: use the current environment prefix.
     SITE_PACKAGES = sys.prefix
 
-# ============================================================
-# Patch definitions
-# Each patch contains:
-#   - file:      target file path (relative to SITE_PACKAGES)
-#   - desc:      human-readable description
-#   - lines:     original line numbers (for reference only)
-#   - old:       the exact code to find and replace
-#   - new:       the replacement code
-#   - count:     (optional) number of occurrences to replace.
-#                Defaults to 1. Use 0 to replace ALL occurrences.
-#
-# IMPORTANT: When multiple patches target the same file, the
-# import/header patches should come BEFORE the body patches to
-# ensure correct dependency order.
-# ============================================================
 PATCHES = [
-    # ----------------------------------------------------------
-    # Patch 1: decorators.py — Fix inline call signature
-    # ----------------------------------------------------------
+    {
+        "file": "vllm/compilation/passes/inductor_pass.py",
+        "lines": "22",
+        "desc": (
+            "Backfill torch._inductor.custom_graph_pass with a fallback base "
+            "class when PyTorch 2.5.1 does not ship this module."
+        ),
+        "old": "from torch._inductor.custom_graph_pass import CustomGraphPass",
+        "new": """\
+try:
+    from torch._inductor.custom_graph_pass import CustomGraphPass
+except ModuleNotFoundError:
+    class CustomGraphPass:
+        def __call__(self, graph):
+            return None
+
+        def uuid(self):
+            return self.__class__.__name__""",
+    },
     {
         "file": "vllm/compilation/decorators.py",
-        "desc": (
-            "Fix patched_inline_call signature. "
-            "PyTorch 2.5.1 uses (parent, func, args, kwargs) instead of "
-            "(self_: Any). The self_.f_code attribute does not exist in "
-            "2.5.1; use func.get_code() instead."
-        ),
-        "lines": "505-508",
+        "lines": "547-550",
+        "desc": "Adapt patched_inline_call to the PyTorch 2.5.1 callback signature.",
         "old": """\
         def patched_inline_call(self_: Any) -> Any:
             code = self_.f_code
@@ -100,29 +49,14 @@ PATCHES = [
             return inline_call(self_)""",
         "new": """\
         def patched_inline_call(parent, func, args, kwargs):
-            # [PyTorch 2.5.1 compat] Use func.get_code() instead of
-            # self_.f_code, which is not available in this version.
             code = func.get_code()
-
-            # Note: vLLM 0.15.x uses self.compilation_config directly
-            # (not self.vllm_config.compilation_config)
             self.compilation_config.traced_files.add(code.co_filename)
-
-            # Pass all four arguments as expected by PyTorch 2.5.1
             return inline_call(parent, func, args, kwargs)""",
     },
-    # ----------------------------------------------------------
-    # Patch 2: layer.py — Fix torch.Size during tracing
-    # ----------------------------------------------------------
     {
-        "file": "vllm/attention/layer.py",
-        "desc": (
-            "Replace torch.Size() with torch.empty().size. "
-            "In PyTorch 2.5.1, torch.Size() does not work correctly "
-            "during torch.compile tracing. torch.empty().size produces "
-            "a compatible result."
-        ),
-        "lines": "378-380",
+        "file": "vllm/model_executor/layers/attention/attention.py",
+        "lines": "437-440",
+        "desc": "Avoid torch.Size tracing issues on PyTorch 2.5.1.",
         "old": """\
                 output_shape = torch.Size(
                     (num_tokens, self.num_heads * self.head_size_v)
@@ -132,79 +66,50 @@ PATCHES = [
                     (num_tokens, self.num_heads * self.head_size_v)
                 ).size()""",
     },
-    # ----------------------------------------------------------
-    # Patch 3: piecewise_backend.py — Remove bundled_autograd_cache
-    #          context manager (serialize path)
-    # ----------------------------------------------------------
+    {
+        "file": "vllm/model_executor/models/openpangu.py",
+        "lines": "779-783",
+        "desc": "Avoid torch.Size tracing issues in OpenPangu attention output.",
+        "old": """\
+            output_shape=torch.Size(
+                [q.shape[0], q.shape[1] // self.head_dim * self.v_channels]
+            ),""",
+        "new": """\
+            output_shape=torch.empty(
+                [q.shape[0], q.shape[1] // self.head_dim * self.v_channels]
+            ).size(),""",
+        "required": False,
+    },
     {
         "file": "vllm/compilation/piecewise_backend.py",
+        "lines": "221-227",
         "desc": (
-            "Remove bundled_autograd_cache context manager around "
-            "serialization. torch._functorch.config.bundled_autograd_cache "
-            "does not exist in PyTorch 2.5.1."
+            "Remove bundled_autograd_cache patching during serialize because "
+            "that config flag does not exist on PyTorch 2.5.1."
         ),
-        "lines": "180-185",
         "old": """\
             with torch._functorch.config.patch("bundled_autograd_cache", True):
                 entry = fn.serialize()
 
                 f = io.BytesIO()
                 StandaloneCompiledArtifactsPickler(f).dump(entry)
-                result = f.getvalue()""",
+                result = f.getvalue()
+            return result""",
         "new": """\
             entry = fn.serialize()
 
             f = io.BytesIO()
             StandaloneCompiledArtifactsPickler(f).dump(entry)
-            result = f.getvalue()""",
+            result = f.getvalue()
+            return result""",
     },
-    # ----------------------------------------------------------
-    # Patch 4: piecewise_backend.py — Remove bundled_autograd_cache
-    #          context manager (compile path)
-    # ----------------------------------------------------------
-    {
-        "file": "vllm/compilation/piecewise_backend.py",
-        "desc": (
-            "Remove bundled_autograd_cache context manager around "
-            "compilation. Same reason as above — the config option is "
-            "unavailable in PyTorch 2.5.1."
-        ),
-        "lines": "243-254",
-        "old": """\
-                with (
-                    torch._functorch.config.patch("bundled_autograd_cache", True),
-                ):
-                    range_entry.runnable = self.vllm_backend.compiler_manager.compile(
-                        self.graph,
-                        args_list,
-                        self.vllm_backend.inductor_config,
-                        self.compilation_config,
-                        compile_range=range_entry.compile_range,
-                        graph_index=self.piecewise_compile_index,
-                        num_graphs=self.total_piecewise_compiles,
-                    )""",
-        "new": """\
-                range_entry.runnable = self.vllm_backend.compiler_manager.compile(
-                    self.graph,
-                    args_list,
-                    self.vllm_backend.inductor_config,
-                    self.compilation_config,
-                    compile_range=range_entry.compile_range,
-                    graph_index=self.piecewise_compile_index,
-                    num_graphs=self.total_piecewise_compiles,
-                )""",
-    },
-    # ----------------------------------------------------------
-    # Patch 5: compiler_interface.py — Comment out unavailable config
-    # ----------------------------------------------------------
     {
         "file": "vllm/compilation/compiler_interface.py",
+        "lines": "778-780",
         "desc": (
-            "Comment out bundled_autograd_cache assignment. "
-            "This attribute does not exist in torch._functorch.config "
-            "on PyTorch 2.5.1 and will raise AttributeError."
+            "Skip bundled_autograd_cache assignment because the attribute is "
+            "absent on PyTorch 2.5.1."
         ),
-        "lines": "654-656",
         "old": """\
 def set_functorch_config() -> None:
     if not envs.VLLM_USE_MEGA_AOT_ARTIFACT:
@@ -212,387 +117,106 @@ def set_functorch_config() -> None:
         "new": """\
 def set_functorch_config() -> None:
     if not envs.VLLM_USE_MEGA_AOT_ARTIFACT:
-        # [PyTorch 2.5.1 compat] bundled_autograd_cache is not available.
-        # TODO: Restore this line after upgrading to PyTorch 2.9+
-        # torch._functorch.config.bundled_autograd_cache = False
         pass""",
     },
-    # ----------------------------------------------------------
-    # Patch 6: parallel_state.py — Add List to typing imports
-    #          (must be applied BEFORE Patch 7)
-    # ----------------------------------------------------------
     {
         "file": "vllm/distributed/parallel_state.py",
-        "desc": (
-            "Add List to the typing import. Required by Patch 7 which "
-            "changes list[int] to List[int]. Without this import, "
-            "List would be undefined."
-        ),
-        "lines": "36",
-        "old": "from typing import Any, Optional",
-        "new": "from typing import Any, List, Optional",
+        "lines": "32",
+        "desc": "Import List so PyTorch 2.5 tracing does not trip on list[int].",
+        "old": "from typing import TYPE_CHECKING, Any, Protocol",
+        "new": "from typing import TYPE_CHECKING, Any, List, Protocol",
     },
-    # ----------------------------------------------------------
-    # Patch 7: parallel_state.py — Use List[int] instead of list[int]
-    # ----------------------------------------------------------
     {
         "file": "vllm/distributed/parallel_state.py",
-        "desc": (
-            "Replace built-in generic `list[int]` with `List[int]` from "
-            "typing. While Python 3.10 supports `list[int]` in annotations, "
-            "certain runtime introspection paths used by torch.compile / "
-            "FX tracing may fail to resolve it. Using `typing.List[int]` "
-            "is the safe, backward-compatible form."
-        ),
-        "lines": "173, 225",
-        # Replace ALL occurrences in the file
-        "count": 0,
+        "lines": "187,239",
+        "desc": "Replace list[int] annotations with typing.List[int].",
         "old": "    output_shape: list[int],",
         "new": "    output_shape: List[int],",
+        "count": 0,
     },
-    # ----------------------------------------------------------
-    # Patch 8: vllm/transformers_utils/config.py - add qwen3_5
-    # ----------------------------------------------------------
-    {
-        "file": "vllm/transformers_utils/config.py",
-        "desc": ("support qwen3_5 in vllm0.15.1"),
-        "lines": "101",
-        "old": """\
-_CONFIG_REGISTRY: dict[str, type[PretrainedConfig]] = LazyConfigDict(
-    afmoe="AfmoeConfig",
-    bagel="BagelConfig",
-    chatglm="ChatGLMConfig",
-    deepseek_vl_v2="DeepseekVLV2Config",
-    deepseek_v32="DeepseekV3Config",
-    flex_olmo="FlexOlmoConfig",
-    hunyuan_vl="HunYuanVLConfig",
-    isaac="IsaacConfig",
-    kimi_linear="KimiLinearConfig",
-    kimi_vl="KimiVLConfig",
-    kimi_k25="KimiK25Config",
-    RefinedWeb="RWConfig",  # For tiiuae/falcon-40b(-instruct)
-    RefinedWebModel="RWConfig",  # For tiiuae/falcon-7b(-instruct)
-    jais="JAISConfig",
-    mlp_speculator="MLPSpeculatorConfig",
-    medusa="MedusaConfig",
-    midashenglm="MiDashengLMConfig",
-    eagle="EAGLEConfig",
-    speculators="SpeculatorsConfig",
-    nemotron="NemotronConfig",
-    olmo3="Olmo3Config",
-    ovis="OvisConfig",
-    ultravox="UltravoxConfig",
-    step3_vl="Step3VLConfig",
-    step3_text="Step3TextConfig",
-    step3p5="Step3p5Config",
-    qwen3_asr="Qwen3ASRConfig",
-    qwen3_next="Qwen3NextConfig",
-    lfm2_moe="Lfm2MoeConfig",
-    tarsier2="Tarsier2Config",
-)""",
-        "new": """\
-_CONFIG_REGISTRY: dict[str, type[PretrainedConfig]] = LazyConfigDict(
-    afmoe="AfmoeConfig",
-    bagel="BagelConfig",
-    chatglm="ChatGLMConfig",
-    deepseek_vl_v2="DeepseekVLV2Config",
-    deepseek_v32="DeepseekV3Config",
-    flex_olmo="FlexOlmoConfig",
-    hunyuan_vl="HunYuanVLConfig",
-    isaac="IsaacConfig",
-    kimi_linear="KimiLinearConfig",
-    kimi_vl="KimiVLConfig",
-    kimi_k25="KimiK25Config",
-    RefinedWeb="RWConfig",  # For tiiuae/falcon-40b(-instruct)
-    RefinedWebModel="RWConfig",  # For tiiuae/falcon-7b(-instruct)
-    jais="JAISConfig",
-    mlp_speculator="MLPSpeculatorConfig",
-    medusa="MedusaConfig",
-    midashenglm="MiDashengLMConfig",
-    eagle="EAGLEConfig",
-    speculators="SpeculatorsConfig",
-    nemotron="NemotronConfig",
-    olmo3="Olmo3Config",
-    ovis="OvisConfig",
-    ultravox="UltravoxConfig",
-    step3_vl="Step3VLConfig",
-    step3_text="Step3TextConfig",
-    step3p5="Step3p5Config",
-    qwen3_asr="Qwen3ASRConfig",
-    qwen3_next="Qwen3NextConfig",
-    qwen3_5="Qwen3_5Config",
-    qwen3_5_moe="Qwen3_5MoeConfig",
-    lfm2_moe="Lfm2MoeConfig",
-    tarsier2="Tarsier2Config",
-)""",
-    },
-    # ----------------------------------------------------------
-    # Patch 9: vllm/transformers_utils/configs/__init__.py
-    #                       add qwen3_5
-    # ----------------------------------------------------------
-    {
-        "file": "vllm/transformers_utils/configs/__init__.py",
-        "desc": ("support qwen3_5 in vllm0.15.1"),
-        "lines": "55",
-        "old": """\
-_CLASS_TO_MODULE: dict[str, str] = {
-    "AfmoeConfig": "vllm.transformers_utils.configs.afmoe",
-    "BagelConfig": "vllm.transformers_utils.configs.bagel",
-    "ChatGLMConfig": "vllm.transformers_utils.configs.chatglm",
-    "DeepseekVLV2Config": "vllm.transformers_utils.configs.deepseek_vl2",
-    "DotsOCRConfig": "vllm.transformers_utils.configs.dotsocr",
-    "EAGLEConfig": "vllm.transformers_utils.configs.eagle",
-    "FlexOlmoConfig": "vllm.transformers_utils.configs.flex_olmo",
-    "HunYuanVLConfig": "vllm.transformers_utils.configs.hunyuan_vl",
-    "HunYuanVLTextConfig": "vllm.transformers_utils.configs.hunyuan_vl",
-    "HunYuanVLVisionConfig": "vllm.transformers_utils.configs.hunyuan_vl",
-    "IsaacConfig": "vllm.transformers_utils.configs.isaac",
-    # RWConfig is for the original tiiuae/falcon-40b(-instruct) and
-    # tiiuae/falcon-7b(-instruct) models. Newer Falcon models will use the
-    # `FalconConfig` class from the official HuggingFace transformers library.
-    "RWConfig": "vllm.transformers_utils.configs.falcon",
-    "JAISConfig": "vllm.transformers_utils.configs.jais",
-    "Lfm2MoeConfig": "vllm.transformers_utils.configs.lfm2_moe",
-    "MedusaConfig": "vllm.transformers_utils.configs.medusa",
-    "MiDashengLMConfig": "vllm.transformers_utils.configs.midashenglm",
-    "MLPSpeculatorConfig": "vllm.transformers_utils.configs.mlp_speculator",
-    "MoonViTConfig": "vllm.transformers_utils.configs.moonvit",
-    "KimiLinearConfig": "vllm.transformers_utils.configs.kimi_linear",
-    "KimiVLConfig": "vllm.transformers_utils.configs.kimi_vl",
-    "KimiK25Config": "vllm.transformers_utils.configs.kimi_k25",
-    "NemotronConfig": "vllm.transformers_utils.configs.nemotron",
-    "NemotronHConfig": "vllm.transformers_utils.configs.nemotron_h",
-    "Olmo3Config": "vllm.transformers_utils.configs.olmo3",
-    "OvisConfig": "vllm.transformers_utils.configs.ovis",
-    "PixelShuffleSiglip2VisionConfig": "vllm.transformers_utils.configs.isaac",
-    "RadioConfig": "vllm.transformers_utils.configs.radio",
-    "SpeculatorsConfig": "vllm.transformers_utils.configs.speculators.base",
-    "UltravoxConfig": "vllm.transformers_utils.configs.ultravox",
-    "Step3VLConfig": "vllm.transformers_utils.configs.step3_vl",
-    "Step3VisionEncoderConfig": "vllm.transformers_utils.configs.step3_vl",
-    "Step3TextConfig": "vllm.transformers_utils.configs.step3_vl",
-    "Step3p5Config": "vllm.transformers_utils.configs.step3p5",
-    "Qwen3ASRConfig": "vllm.transformers_utils.configs.qwen3_asr",
-    "Qwen3NextConfig": "vllm.transformers_utils.configs.qwen3_next",
-    "Tarsier2Config": "vllm.transformers_utils.configs.tarsier2",
-    # Special case: DeepseekV3Config is from HuggingFace Transformers
-    "DeepseekV3Config": "transformers",
-}""",
-        "new": """\
-_CLASS_TO_MODULE: dict[str, str] = {
-    "AfmoeConfig": "vllm.transformers_utils.configs.afmoe",
-    "BagelConfig": "vllm.transformers_utils.configs.bagel",
-    "ChatGLMConfig": "vllm.transformers_utils.configs.chatglm",
-    "DeepseekVLV2Config": "vllm.transformers_utils.configs.deepseek_vl2",
-    "DotsOCRConfig": "vllm.transformers_utils.configs.dotsocr",
-    "EAGLEConfig": "vllm.transformers_utils.configs.eagle",
-    "FlexOlmoConfig": "vllm.transformers_utils.configs.flex_olmo",
-    "HunYuanVLConfig": "vllm.transformers_utils.configs.hunyuan_vl",
-    "HunYuanVLTextConfig": "vllm.transformers_utils.configs.hunyuan_vl",
-    "HunYuanVLVisionConfig": "vllm.transformers_utils.configs.hunyuan_vl",
-    "IsaacConfig": "vllm.transformers_utils.configs.isaac",
-    # RWConfig is for the original tiiuae/falcon-40b(-instruct) and
-    # tiiuae/falcon-7b(-instruct) models. Newer Falcon models will use the
-    # `FalconConfig` class from the official HuggingFace transformers library.
-    "RWConfig": "vllm.transformers_utils.configs.falcon",
-    "JAISConfig": "vllm.transformers_utils.configs.jais",
-    "Lfm2MoeConfig": "vllm.transformers_utils.configs.lfm2_moe",
-    "MedusaConfig": "vllm.transformers_utils.configs.medusa",
-    "MiDashengLMConfig": "vllm.transformers_utils.configs.midashenglm",
-    "MLPSpeculatorConfig": "vllm.transformers_utils.configs.mlp_speculator",
-    "MoonViTConfig": "vllm.transformers_utils.configs.moonvit",
-    "KimiLinearConfig": "vllm.transformers_utils.configs.kimi_linear",
-    "KimiVLConfig": "vllm.transformers_utils.configs.kimi_vl",
-    "KimiK25Config": "vllm.transformers_utils.configs.kimi_k25",
-    "NemotronConfig": "vllm.transformers_utils.configs.nemotron",
-    "NemotronHConfig": "vllm.transformers_utils.configs.nemotron_h",
-    "Olmo3Config": "vllm.transformers_utils.configs.olmo3",
-    "OvisConfig": "vllm.transformers_utils.configs.ovis",
-    "PixelShuffleSiglip2VisionConfig": "vllm.transformers_utils.configs.isaac",
-    "RadioConfig": "vllm.transformers_utils.configs.radio",
-    "SpeculatorsConfig": "vllm.transformers_utils.configs.speculators.base",
-    "UltravoxConfig": "vllm.transformers_utils.configs.ultravox",
-    "Step3VLConfig": "vllm.transformers_utils.configs.step3_vl",
-    "Step3VisionEncoderConfig": "vllm.transformers_utils.configs.step3_vl",
-    "Step3TextConfig": "vllm.transformers_utils.configs.step3_vl",
-    "Step3p5Config": "vllm.transformers_utils.configs.step3p5",
-    "Qwen3ASRConfig": "vllm.transformers_utils.configs.qwen3_asr",
-    "Qwen3NextConfig": "vllm.transformers_utils.configs.qwen3_next",
-    "Qwen3_5Config": "vllm_kunlun.transformers_utils.configs.qwen3_5",
-    "Qwen3_5TextConfig": "vllm_kunlun.transformers_utils.configs.qwen3_5",
-    "Qwen3_5MoeConfig": "vllm_kunlun.transformers_utils.configs.qwen3_5_moe",
-    "Qwen3_5MoeTextConfig": "vllm_kunlun.transformers_utils.configs.qwen3_5_moe",
-    "Tarsier2Config": "vllm.transformers_utils.configs.tarsier2",
-    # Special case: DeepseekV3Config is from HuggingFace Transformers
-    "DeepseekV3Config": "transformers",
-}""",
-    },
-    {
-        "file": "vllm/transformers_utils/configs/__init__.py",
-        "desc": ("support qwen3_5 in vllm0.15.1"),
-        "lines": "97",
-        "old": """\
-__all__ = [
-    "AfmoeConfig",
-    "BagelConfig",
-    "ChatGLMConfig",
-    "DeepseekVLV2Config",
-    "DeepseekV3Config",
-    "DotsOCRConfig",
-    "EAGLEConfig",
-    "FlexOlmoConfig",
-    "HunYuanVLConfig",
-    "HunYuanVLTextConfig",
-    "HunYuanVLVisionConfig",
-    "IsaacConfig",
-    "RWConfig",
-    "JAISConfig",
-    "Lfm2MoeConfig",
-    "MedusaConfig",
-    "MiDashengLMConfig",
-    "MLPSpeculatorConfig",
-    "MoonViTConfig",
-    "KimiLinearConfig",
-    "KimiVLConfig",
-    "KimiK25Config",
-    "NemotronConfig",
-    "NemotronHConfig",
-    "Olmo3Config",
-    "OvisConfig",
-    "PixelShuffleSiglip2VisionConfig",
-    "RadioConfig",
-    "SpeculatorsConfig",
-    "UltravoxConfig",
-    "Step3VLConfig",
-    "Step3VisionEncoderConfig",
-    "Step3TextConfig",
-    "Step3p5Config",
-    "Qwen3ASRConfig",
-    "Qwen3NextConfig",
-    "Tarsier2Config",
-]""",
-        "new": """\
-__all__ = [
-    "AfmoeConfig",
-    "BagelConfig",
-    "ChatGLMConfig",
-    "DeepseekVLV2Config",
-    "DeepseekV3Config",
-    "DotsOCRConfig",
-    "EAGLEConfig",
-    "FlexOlmoConfig",
-    "HunYuanVLConfig",
-    "HunYuanVLTextConfig",
-    "HunYuanVLVisionConfig",
-    "IsaacConfig",
-    "RWConfig",
-    "JAISConfig",
-    "Lfm2MoeConfig",
-    "MedusaConfig",
-    "MiDashengLMConfig",
-    "MLPSpeculatorConfig",
-    "MoonViTConfig",
-    "KimiLinearConfig",
-    "KimiVLConfig",
-    "KimiK25Config",
-    "NemotronConfig",
-    "NemotronHConfig",
-    "Olmo3Config",
-    "OvisConfig",
-    "PixelShuffleSiglip2VisionConfig",
-    "RadioConfig",
-    "SpeculatorsConfig",
-    "UltravoxConfig",
-    "Step3VLConfig",
-    "Step3VisionEncoderConfig",
-    "Step3TextConfig",
-    "Step3p5Config",
-    "Qwen3ASRConfig",
-    "Qwen3NextConfig",
-    "Qwen3_5Config",
-    "Qwen3_5TextConfig",
-    "Qwen3_5MoeConfig",
-    "Qwen3_5MoeTextConfig",
-    "Tarsier2Config",
-]""",
-    },
-    # ----------------------------------------------------------
-    # Patch 10: utils.py — Add backend="torch_native" to
-    #           apply_token_bitmask_inplace call
-    # ----------------------------------------------------------
     {
         "file": "vllm/v1/structured_output/utils.py",
+        "lines": "121",
         "desc": (
-            "Add backend='torch_native' parameter to "
-            "xgr.apply_token_bitmask_inplace call. Without this parameter, "
-            "the default backend may not be compatible with the Kunlun "
-            "platform on PyTorch 2.5.1."
+            "Force xgrammar torch-native backend to avoid backend selection "
+            "mismatches on Kunlun."
         ),
-        "lines": "119",
-        "old": (
-            "xgr.apply_token_bitmask_inplace(logits, grammar_bitmask, "
-            "indices=index_tensor)"
-        ),
+        "old": "        xgr.apply_token_bitmask_inplace(logits, grammar_bitmask, indices=index_tensor)",
         "new": (
-            "xgr.apply_token_bitmask_inplace(logits, grammar_bitmask, "
-            'indices=index_tensor, backend="torch_native")'
+            "        xgr.apply_token_bitmask_inplace("
+            'logits, grammar_bitmask, indices=index_tensor, backend="torch_native")'
         ),
+        "required": False,
+    },
+    {
+        "file": "vllm/compilation/wrapper.py",
+        "lines": "199-203",
+        "desc": "Fall back to nullcontext() when torch.compiler.set_stance is unavailable.",
+        "old": """\
+            ctx = (
+                nullcontext()
+                if self.first_compile or not self.evaluate_guards
+                else torch.compiler.set_stance("fail_on_recompile")
+            )""",
+        "new": """\
+            if self.first_compile or not self.evaluate_guards:
+                ctx = nullcontext()
+            elif hasattr(torch.compiler, "set_stance"):
+                ctx = torch.compiler.set_stance("fail_on_recompile")
+            else:
+                ctx = nullcontext()""",
+        "required": False,
     },
 ]
 
 
-# ============================================================
-# Core logic
-# ============================================================
-
-
 def get_full_path(relative_path: str) -> str:
-    """Construct the full file path from SITE_PACKAGES."""
     return os.path.join(SITE_PACKAGES, relative_path)
 
 
-def apply_patch(patch: dict, dry_run: bool = False) -> str:
-    """
-    Apply a single patch.
-    Returns: 'success', 'skipped', or 'failed'
-    """
-    file_path = get_full_path(patch["file"])
-    desc = patch["desc"]
-    # How many occurrences to replace: default 1, use 0 for all
-    count = patch.get("count", 1)
+def _backup_path(file_path: str) -> str:
+    return f"{file_path}.bak"
+
+
+def apply_patch(patch: dict[str, object], dry_run: bool = False) -> str:
+    file_path = get_full_path(str(patch["file"]))
+    required = bool(patch.get("required", True))
+    count = int(patch.get("count", 1))
 
     print(
         f"\n{'[DRY RUN] ' if dry_run else ''}"
         f"Patch: {patch['file']} (lines {patch['lines']})"
     )
-    print(f"  Description: {desc}")
+    print(f"  Description: {patch['desc']}")
 
-    # 1. Read the file
     try:
-        with open(file_path, "r", encoding="utf-8") as f:
-            content = f.read()
+        with open(file_path, "r", encoding="utf-8") as handle:
+            content = handle.read()
     except FileNotFoundError:
-        print(f"  FAIL: File not found: {file_path}")
-        return "failed"
+        if required:
+            print(f"  FAIL: File not found: {file_path}")
+            return "failed"
+        print(f"  SKIP: Optional file not found: {file_path}")
+        return "skipped"
 
-    # 2. Check if already patched (idempotent)
-    if patch["new"] in content and patch["old"] not in content:
+    old = str(patch["old"])
+    new = str(patch["new"])
+
+    if new in content and old not in content:
         print("  SKIP: Already patched.")
         return "skipped"
 
-    # 3. Verify the original code exists
-    if patch["old"] not in content:
-        print(
-            "  FAIL: Original code not found. The file may have been "
-            "modified or the vLLM version may differ."
-        )
-        return "failed"
+    if old not in content:
+        if required:
+            print("  FAIL: Original code not found.")
+            return "failed"
+        print("  SKIP: Optional patch target not found.")
+        return "skipped"
 
-    # Count how many occurrences will be replaced
-    num_occurrences = content.count(patch["old"])
-    replacements = num_occurrences if count == 0 else min(count, num_occurrences)
+    occurrences = content.count(old)
+    replacements = occurrences if count == 0 else min(count, occurrences)
     print(
-        f"  Found {num_occurrences} occurrence(s), "
+        f"  Found {occurrences} occurrence(s), "
         f"will replace {'all' if count == 0 else replacements}."
     )
 
@@ -600,52 +224,46 @@ def apply_patch(patch: dict, dry_run: bool = False) -> str:
         print("  OK: Would apply patch.")
         return "success"
 
-    # 4. Backup (only once per file, never overwrite existing .bak)
-    backup_path = file_path + ".bak"
+    backup_path = _backup_path(file_path)
     if not os.path.exists(backup_path):
         shutil.copy2(file_path, backup_path)
         print(f"  Backup created: {backup_path}")
     else:
-        print(f"  Backup already exists, not overwriting: {backup_path}")
+        print(f"  Backup already exists: {backup_path}")
 
-    # 5. Replace and write back
     if count == 0:
-        # Replace ALL occurrences
-        new_content = content.replace(patch["old"], patch["new"])
+        new_content = content.replace(old, new)
     else:
-        new_content = content.replace(patch["old"], patch["new"], count)
+        new_content = content.replace(old, new, count)
 
-    with open(file_path, "w", encoding="utf-8") as f:
-        f.write(new_content)
+    with open(file_path, "w", encoding="utf-8") as handle:
+        handle.write(new_content)
 
     print(f"  SUCCESS: Patch applied ({replacements} replacement(s)).")
     return "success"
 
 
-def revert_all():
-    """Restore all patched files from their .bak backups."""
+def revert_all() -> None:
     print("=" * 64)
     print("  Reverting all patches from .bak backups")
     print("=" * 64)
 
-    seen = set()
+    seen: set[str] = set()
     for patch in PATCHES:
-        file_path = get_full_path(patch["file"])
+        file_path = get_full_path(str(patch["file"]))
         if file_path in seen:
             continue
         seen.add(file_path)
 
-        backup_path = file_path + ".bak"
+        backup_path = _backup_path(file_path)
         if os.path.exists(backup_path):
             shutil.copy2(backup_path, file_path)
             print(f"  Restored: {file_path}")
         else:
             print(f"  No backup found for: {file_path}")
 
-    print("\nRevert complete.")
 
-
-def main():
+def main() -> None:
     dry_run = "--dry-run" in sys.argv
     revert = "--revert" in sys.argv
 
@@ -654,35 +272,28 @@ def main():
         return
 
     print("=" * 64)
-    print("  vLLM Compatibility Patch for PyTorch 2.5.1")
+    print("  vLLM 0.19.x Compatibility Patch for PyTorch 2.5.1")
+    print(f"  Site-packages: {SITE_PACKAGES}")
     print(f"  Total patches: {len(PATCHES)}")
     if dry_run:
-        print("  Mode: DRY RUN (no files will be modified)")
-    print("")
-    print("  NOTE: These patches are TEMPORARY. Remove them after")
-    print("        upgrading to PyTorch 2.9+.")
+        print("  Mode: DRY RUN")
     print("=" * 64)
 
     results = {"success": 0, "skipped": 0, "failed": 0}
-
     for patch in PATCHES:
         result = apply_patch(patch, dry_run=dry_run)
         results[result] += 1
 
     print("\n" + "=" * 64)
     print(
-        f"  Results: "
-        f"{results['success']} applied  |  "
-        f"{results['skipped']} skipped  |  "
-        f"{results['failed']} failed  |  "
-        f"{len(PATCHES)} total"
+        f"  Results: {results['success']} applied | "
+        f"{results['skipped']} skipped | {results['failed']} failed"
     )
     if not dry_run and results["success"] > 0:
-        print("  Original files backed up as .bak")
-        print("  To revert: python patch_torch251.py --revert")
+        print("  Original files are backed up as .bak")
+        print("  Revert with: python patch_torch251.py --revert")
     print("=" * 64)
 
-    # Exit with non-zero code if any patch failed
     if results["failed"] > 0:
         sys.exit(1)
 

--- a/vllm_kunlun/platforms/kunlun.py
+++ b/vllm_kunlun/platforms/kunlun.py
@@ -1,5 +1,6 @@
 """kunlun"""
 
+import importlib
 from typing import TYPE_CHECKING, Optional
 
 import psutil
@@ -17,6 +18,21 @@ else:
     VllmConfig = None
 
 logger = init_logger(__name__)
+
+
+def _resolve_backend_or_fallback(primary_backend: str, fallback_backend: str) -> str:
+    try:
+        importlib.import_module(primary_backend.rsplit(".", 1)[0])
+        return primary_backend
+    except Exception as exc:
+        logger.warning(
+            "Failed to import Kunlun attention backend %s; falling back to %s. "
+            "Original error: %s",
+            primary_backend,
+            fallback_backend,
+            exc,
+        )
+        return fallback_backend
 
 
 class KunlunPlatform(Platform):
@@ -145,6 +161,11 @@ class KunlunPlatform(Platform):
         return DeviceCapability(major=major, minor=minor)
 
     @classmethod
+    def num_compute_units(cls, device_id: int = 0) -> int:
+        """Return the hardware compute-unit count exposed through torch.cuda."""
+        return torch.cuda.get_device_properties(device_id).multi_processor_count
+
+    @classmethod
     def check_and_update_config(cls, vllm_config: "VllmConfig") -> None:
         """
         TODO Update here for v0.15.1
@@ -221,7 +242,8 @@ class KunlunPlatform(Platform):
         from vllm.config import CUDAGraphMode
 
         if (
-            envs.VLLM_ALL2ALL_BACKEND == "deepep_high_throughput"
+            getattr(parallel_config, "all2all_backend", None)
+            == "deepep_high_throughput"
             and parallel_config.data_parallel_size > 1
             and vllm_config.compilation_config.cudagraph_mode != CUDAGraphMode.NONE
         ):
@@ -249,6 +271,7 @@ class KunlunPlatform(Platform):
         cls,
         selected_backend: "AttentionBackendEnum",
         attn_selector_config: "AttentionSelectorConfig",
+        num_heads: int | None = None,
     ) -> str:
         """
             Returns the class of attention backend based on the selected backend and other parameters.
@@ -265,6 +288,7 @@ class KunlunPlatform(Platform):
         Returns:
             str: Class name of the attention backend.
         """
+        del selected_backend, num_heads
         if attn_selector_config.use_mla:
             if attn_selector_config.use_sparse:
                 logger.info_once("Using Sparse MLA backend on V1 engine.")
@@ -274,8 +298,10 @@ class KunlunPlatform(Platform):
                 )
             return "vllm_kunlun.v1.attention.backends.mla.flashmla.FlashMLABackend"
         elif not attn_selector_config.use_mla:
-            return (
-                "vllm_kunlun.v1.attention.backends.kunlun_attn.KunlunAttentionBackend"
+            return _resolve_backend_or_fallback(
+                "vllm_kunlun.v1.attention.backends.kunlun_attn."
+                "KunlunAttentionBackend",
+                "vllm.v1.attention.backends.triton_attn.TritonAttentionBackend",
             )
         else:
             return (
@@ -382,9 +408,17 @@ class KunlunPlatform(Platform):
         cls, parser: FlexibleArgumentParser | None = None
     ) -> None:
         from vllm_kunlun.quantization.awq import KunlunAWQConfig  # noqa
-        from vllm_kunlun.quantization.compressed_tensors import (  # noqa
-            KunlunCompressedTensorsConfig,
-        )
         from vllm_kunlun.quantization.gptq import KunlunGPTQConfig  # noqa
         from vllm_kunlun.quantization.kernels import _POSSIBLE_INT8_KERNELS  # noqa
         from vllm_kunlun.quantization.kernels import _POSSIBLE_KERNELS  # noqa
+
+        try:
+            from vllm_kunlun.quantization.compressed_tensors import (  # noqa: F401
+                KunlunCompressedTensorsConfig,
+            )
+        except Exception as exc:
+            logger.warning(
+                "Skipping compressed-tensors quantization registration during "
+                "platform pre-registration: %s",
+                exc,
+            )

--- a/vllm_kunlun/platforms/kunlun.py
+++ b/vllm_kunlun/platforms/kunlun.py
@@ -1,6 +1,7 @@
 """kunlun"""
 
 import importlib
+import os
 from typing import TYPE_CHECKING, Optional
 
 import psutil
@@ -33,6 +34,165 @@ def _resolve_backend_or_fallback(primary_backend: str, fallback_backend: str) ->
             exc,
         )
         return fallback_backend
+
+
+def _get_vllm_attention_backend() -> Optional[str]:
+    return getattr(envs, "VLLM_ATTENTION_BACKEND", None) or os.environ.get(
+        "VLLM_ATTENTION_BACKEND"
+    )
+
+
+def _check_flashmla_supported(flashmla_module=None) -> tuple[bool, Optional[str]]:
+    if flashmla_module is None:
+        try:
+            flashmla_module = __import__(
+                "vllm.attention.ops.flashmla",
+                fromlist=["is_flashmla_supported"],
+            )
+        except ModuleNotFoundError:
+            flashmla_module = importlib.import_module("vllm.v1.attention.ops.flashmla")
+    support_fn = getattr(flashmla_module, "is_flashmla_supported", None)
+    if support_fn is None:
+        support_fn = getattr(flashmla_module, "is_flashmla_dense_supported", None)
+    if support_fn is None:
+        return False, "FlashMLA support check is unavailable."
+    return support_fn()
+
+
+def _patch_quantization_config_loader() -> None:
+    import sys
+
+    import vllm.model_executor.layers.quantization as quant_module
+
+    method_specs = {
+        "awq": ("vllm.model_executor.layers.quantization.awq", "AWQConfig"),
+        "fp8": ("vllm.model_executor.layers.quantization.fp8", "Fp8Config"),
+        "fbgemm_fp8": (
+            "vllm.model_executor.layers.quantization.fbgemm_fp8",
+            "FBGEMMFp8Config",
+        ),
+        "modelopt": (
+            "vllm.model_executor.layers.quantization.modelopt",
+            "ModelOptFp8Config",
+        ),
+        "modelopt_fp4": (
+            "vllm.model_executor.layers.quantization.modelopt",
+            "ModelOptNvFp4Config",
+        ),
+        "modelopt_mxfp8": (
+            "vllm.model_executor.layers.quantization.modelopt",
+            "ModelOptMxFp8Config",
+        ),
+        "modelopt_mixed": (
+            "vllm.model_executor.layers.quantization.modelopt",
+            "ModelOptMixedPrecisionConfig",
+        ),
+        "bitblas": (
+            "vllm.model_executor.layers.quantization.bitblas",
+            "BitBLASConfig",
+        ),
+        "gguf": ("vllm.model_executor.layers.quantization.gguf", "GGUFConfig"),
+        "gptq_marlin_24": (
+            "vllm.model_executor.layers.quantization.gptq_marlin_24",
+            "GPTQMarlin24Config",
+        ),
+        "gptq_marlin": (
+            "vllm.model_executor.layers.quantization.gptq_marlin",
+            "GPTQMarlinConfig",
+        ),
+        "gptq_bitblas": (
+            "vllm.model_executor.layers.quantization.gptq_bitblas",
+            "GPTQBitBLASConfig",
+        ),
+        "awq_marlin": (
+            "vllm.model_executor.layers.quantization.awq_marlin",
+            "AWQMarlinConfig",
+        ),
+        "gptq": ("vllm.model_executor.layers.quantization.gptq", "GPTQConfig"),
+        "compressed-tensors": (
+            "vllm.model_executor.layers.quantization.compressed_tensors.compressed_tensors",
+            "CompressedTensorsConfig",
+        ),
+        "bitsandbytes": (
+            "vllm.model_executor.layers.quantization.bitsandbytes",
+            "BitsAndBytesConfig",
+        ),
+        "ptpc_fp8": (
+            "vllm.model_executor.layers.quantization.ptpc_fp8",
+            "PTPCFp8Config",
+        ),
+        "experts_int8": (
+            "vllm.model_executor.layers.quantization.experts_int8",
+            "ExpertsInt8Config",
+        ),
+        "ipex": (
+            "vllm.model_executor.layers.quantization.ipex_quant",
+            "IPEXConfig",
+        ),
+        "quark": (
+            "vllm.model_executor.layers.quantization.quark.quark",
+            "QuarkConfig",
+        ),
+        "moe_wna16": (
+            "vllm.model_executor.layers.quantization.moe_wna16",
+            "MoeWNA16Config",
+        ),
+        "torchao": (
+            "vllm.model_executor.layers.quantization.torchao",
+            "TorchAOConfig",
+        ),
+        "auto-round": (
+            "vllm.model_executor.layers.quantization.inc",
+            "INCConfig",
+        ),
+        "inc": ("vllm.model_executor.layers.quantization.inc", "INCConfig"),
+        "mxfp4": ("vllm.model_executor.layers.quantization.mxfp4", "Mxfp4Config"),
+        "petit_nvfp4": (
+            "vllm.model_executor.layers.quantization.petit",
+            "PetitNvFp4Config",
+        ),
+        "cpu_awq": (
+            "vllm.model_executor.layers.quantization.cpu_wna16",
+            "CPUAWQConfig",
+        ),
+    }
+
+    available_methods = []
+    for method in quant_module.QUANTIZATION_METHODS:
+        module_name, _ = method_specs.get(method, ("", ""))
+        if not module_name or importlib.util.find_spec(module_name) is not None:
+            available_methods.append(method)
+
+    quant_module.QUANTIZATION_METHODS[:] = available_methods
+    quant_module.DEPRECATED_QUANTIZATION_METHODS[:] = [
+        method
+        for method in quant_module.DEPRECATED_QUANTIZATION_METHODS
+        if method in available_methods
+    ]
+
+    def _get_quantization_config(quantization: str):
+        if (
+            quantization not in quant_module.QUANTIZATION_METHODS
+            and quantization not in method_specs
+        ):
+            raise ValueError(f"Invalid quantization method: {quantization}")
+
+        custom_configs = getattr(
+            quant_module,
+            "_CUSTOMIZED_METHOD_TO_QUANT_CONFIG",
+            {},
+        )
+        if quantization in custom_configs:
+            return custom_configs[quantization]
+
+        module_name, class_name = method_specs[quantization]
+        module = importlib.import_module(module_name)
+        return getattr(module, class_name)
+
+    quant_module.get_quantization_config = _get_quantization_config
+    weight_utils = sys.modules.get("vllm.model_executor.model_loader.weight_utils")
+    if weight_utils is not None:
+        weight_utils.get_quantization_config = _get_quantization_config
 
 
 class KunlunPlatform(Platform):
@@ -220,17 +380,11 @@ class KunlunPlatform(Platform):
             # we default to FlashMLA backend, so we need to force the blocksize
             # here
             use_sparse = hasattr(vllm_config.model_config.hf_config, "index_topk")
-            use_flashmla = (
-                envs.VLLM_ATTENTION_BACKEND is None
-                or envs.VLLM_ATTENTION_BACKEND == "FLASHMLA"
-            )
-            from vllm.attention.ops.flashmla import is_flashmla_supported
+            attention_backend = _get_vllm_attention_backend()
+            use_flashmla = attention_backend is None or attention_backend == "FLASHMLA"
+            flashmla_supported, _ = _check_flashmla_supported()
 
-            if (
-                use_flashmla
-                and is_flashmla_supported()[0]
-                and cache_config.block_size != 64
-            ):
+            if use_flashmla and flashmla_supported and cache_config.block_size != 64:
                 cache_config.block_size = 64
                 logger.info("Forcing kv cache block size to 64 for FlashMLA backend.")
             if use_sparse and cache_config.block_size != 64:
@@ -290,6 +444,10 @@ class KunlunPlatform(Platform):
         """
         del selected_backend, num_heads
         if attn_selector_config.use_mla:
+            attention_backend = _get_vllm_attention_backend()
+            if attention_backend == "FLASHMLA":
+                logger.info_once("Using dense FlashMLA backend on V1 engine.")
+                return "vllm_kunlun.v1.attention.backends.mla.flashmla.FlashMLABackend"
             if attn_selector_config.use_sparse:
                 logger.info_once("Using Sparse MLA backend on V1 engine.")
                 return (
@@ -422,3 +580,4 @@ class KunlunPlatform(Platform):
                 "platform pre-registration: %s",
                 exc,
             )
+        _patch_quantization_config_loader()

--- a/vllm_kunlun/platforms/version.py
+++ b/vllm_kunlun/platforms/version.py
@@ -1,8 +1,8 @@
 """vllm_kunlun version.py"""
 
-vllm_version = "0.15.1"
+vllm_version = "0.19.0"
 
-xvllm_version_tuple = (0, 15, 1)
+xvllm_version_tuple = (0, 19, 0)
 
 
 def get_xvllm_version():

--- a/vllm_kunlun/quantization/compressed_tensors/compressed_tensors.py
+++ b/vllm_kunlun/quantization/compressed_tensors/compressed_tensors.py
@@ -51,7 +51,10 @@ class KunlunCompressedTensorsConfig(CompressedTensorsConfig):
         layer: torch.nn.Module,
         prefix: str,
     ) -> Optional["QuantizeMethodBase"]:
-        from vllm.attention.layer import Attention  # Avoid circular import
+        try:
+            from vllm.attention.layer import Attention  # Avoid circular import
+        except ModuleNotFoundError:
+            from vllm.model_executor.layers.attention import Attention
 
         if isinstance(layer, LinearBase):
             # collect schemes

--- a/vllm_kunlun/quantization/kernels/__init__.py
+++ b/vllm_kunlun/quantization/kernels/__init__.py
@@ -1,4 +1,4 @@
-from vllm.model_executor.layers.quantization.kernels.scaled_mm import (
+from vllm.model_executor.kernels.linear import (
     _POSSIBLE_INT8_KERNELS,
 )
 from vllm.platforms import PlatformEnum

--- a/vllm_kunlun/quantization/kernels/exllama.py
+++ b/vllm_kunlun/quantization/kernels/exllama.py
@@ -19,13 +19,59 @@
 from typing import Optional
 
 import torch
-from vllm.model_executor.layers.quantization.kernels.mixed_precision import (
-    _POSSIBLE_KERNELS,
+from vllm.model_executor.kernels.linear import _POSSIBLE_KERNELS
+from vllm.model_executor.kernels.linear.mixed_precision import MPLinearLayerConfig
+from vllm.model_executor.kernels.linear.mixed_precision.exllama import (
     ExllamaLinearKernel,
 )
+from vllm.platforms import PlatformEnum, current_platform
 
 
 class KunlunExllamaLinearKernel(ExllamaLinearKernel):
+    @classmethod
+    def can_implement(cls, c: MPLinearLayerConfig) -> tuple[bool, str | None]:
+        if not current_platform.is_out_of_tree():
+            return super().can_implement(c)
+
+        if c.has_g_idx and c.partition_weight_shape[0] != c.full_weight_shape[0]:
+            return (
+                False,
+                "Act reordering currently not supported by Exllama, "
+                "when the input features are partitioned across devices",
+            )
+
+        if c.partition_weight_shape[1] % (32 // c.weight_type.size_bits) != 0:
+            return (
+                False,
+                "Output features must be a multiple of the pack factor "
+                "(32 / num_bits) so that we can correctly pack the zero points",
+            )
+
+        if c.act_type != torch.float16:
+            return False, "Exllama only supports float16 activations"
+
+        if c.weight_type not in cls.SUPPORTED_QUANT_TYPES:
+            return (
+                False,
+                f"Quant type ({c.weight_type}) not supported by Exllama, "
+                f"supported types are: {cls.SUPPORTED_QUANT_TYPES}",
+            )
+
+        if c.group_size <= 0:
+            return (
+                False,
+                f"Group size ({c.group_size}) must be positive, "
+                "Exllama does not support channelwise quantization",
+            )
+
+        if c.full_weight_shape[0] % c.group_size != 0:
+            return (
+                False,
+                f"Group size ({c.group_size}) does not evenly divide the number "
+                f"of input features ({c.full_weight_shape[0]})",
+            )
+
+        return True, None
 
     def apply_weights(
         self,
@@ -51,6 +97,11 @@ class KunlunExllamaLinearKernel(ExllamaLinearKernel):
         return output.reshape(out_shape)
 
 
-# remove ExllamaLinearKernel and add KunlunExllamaLinearKernel
-_POSSIBLE_KERNELS.remove(ExllamaLinearKernel)
-_POSSIBLE_KERNELS.append(KunlunExllamaLinearKernel)
+_POSSIBLE_KERNELS.setdefault(PlatformEnum.OOT, [])
+_POSSIBLE_KERNELS[PlatformEnum.OOT] = [
+    kernel
+    for kernel in _POSSIBLE_KERNELS[PlatformEnum.OOT]
+    if kernel is not ExllamaLinearKernel
+]
+if KunlunExllamaLinearKernel not in _POSSIBLE_KERNELS[PlatformEnum.OOT]:
+    _POSSIBLE_KERNELS[PlatformEnum.OOT].append(KunlunExllamaLinearKernel)

--- a/vllm_kunlun/quantization/kernels/scale_mm.py
+++ b/vllm_kunlun/quantization/kernels/scale_mm.py
@@ -19,7 +19,7 @@
 from typing import Optional
 
 import torch
-from vllm.model_executor.layers.quantization.kernels.scaled_mm import (
+from vllm.model_executor.kernels.linear.scaled_mm import (
     CutlassInt8ScaledMMLinearKernel,
     Int8ScaledMMLinearLayerConfig,
 )
@@ -27,7 +27,6 @@ from vllm.platforms import current_platform
 
 
 class KunlunScaledMMLinearKernel(CutlassInt8ScaledMMLinearKernel):
-
     @classmethod
     def is_supported(
         cls, compute_capability: int | None = None

--- a/vllm_kunlun/quantization/kernels/scale_mm.py
+++ b/vllm_kunlun/quantization/kernels/scale_mm.py
@@ -26,6 +26,44 @@ from vllm.model_executor.kernels.linear.scaled_mm import (
 from vllm.platforms import current_platform
 
 
+def _torch_scaled_int8_mm_fallback(
+    x_q: torch.Tensor,
+    w_q: torch.Tensor,
+    x_max: torch.Tensor,
+    w_max: torch.Tensor,
+    out_dtype: torch.dtype,
+    bias: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    orig_shape = x_q.shape[:-1]
+    device = x_q.device
+    x_2d = x_q.reshape(-1, x_q.shape[-1]).to(torch.float32)
+
+    x_scale = x_max.reshape(-1, 1).to(device=device, dtype=torch.float32) / 127.0
+    if x_scale.shape[0] == 1 and x_2d.shape[0] != 1:
+        x_scale = x_scale.expand(x_2d.shape[0], 1)
+    if x_scale.shape[0] != x_2d.shape[0]:
+        raise RuntimeError(
+            "scaled int8 fallback expected one activation scale per row, "
+            f"got scale rows={x_scale.shape[0]} and input rows={x_2d.shape[0]}"
+        )
+
+    w_scale = w_max.reshape(-1).to(device=device, dtype=torch.float32) / 127.0
+    if w_scale.numel() == 1 and w_q.shape[1] != 1:
+        w_scale = w_scale.expand(w_q.shape[1])
+    if w_scale.numel() != w_q.shape[1]:
+        raise RuntimeError(
+            "scaled int8 fallback expected one weight scale per output column, "
+            f"got scales={w_scale.numel()} and output columns={w_q.shape[1]}"
+        )
+
+    x_dequant = x_2d * x_scale
+    w_dequant = w_q.to(device=device, dtype=torch.float32) * w_scale.reshape(1, -1)
+    out = torch.matmul(x_dequant, w_dequant)
+    if bias is not None:
+        out = out + bias.to(device=device, dtype=torch.float32)
+    return out.to(out_dtype).reshape(*orig_shape, w_q.shape[1])
+
+
 class KunlunScaledMMLinearKernel(CutlassInt8ScaledMMLinearKernel):
     @classmethod
     def is_supported(
@@ -79,14 +117,28 @@ class KunlunScaledMMLinearKernel(CutlassInt8ScaledMMLinearKernel):
                 bias=bias.to(torch.float32).contiguous() if bias is not None else None,
             )
         else:  # symmetric
-            return torch.ops._C.matmul(
-                x=x_q,
-                w=w_q.transpose(0, 1),
-                out_dtype=x.dtype,
-                x_pc_max=x_s * 127.0 if static else x_s,
-                w_pc_max=w_s,
-                bias=bias.to(torch.float32).contiguous() if bias is not None else None,
+            x_max = x_s * 127.0 if static else x_s
+            bias_fp32 = (
+                bias.to(torch.float32).contiguous() if bias is not None else None
             )
+            try:
+                return torch.ops._C.matmul(
+                    x=x_q,
+                    w=w_q.transpose(0, 1),
+                    out_dtype=x.dtype,
+                    x_pc_max=x_max,
+                    w_pc_max=w_s,
+                    bias=bias_fp32,
+                )
+            except (RuntimeError, ValueError):
+                return _torch_scaled_int8_mm_fallback(
+                    x_q=x_q,
+                    w_q=w_q,
+                    x_max=x_max,
+                    w_max=w_s,
+                    out_dtype=x.dtype,
+                    bias=bias_fp32,
+                )
 
             # backup option: lower performance
             # return torch.ops._C.cutlass_scaled_mm(

--- a/vllm_kunlun/v1/attention/backends/mla/common.py
+++ b/vllm_kunlun/v1/attention/backends/mla/common.py
@@ -197,30 +197,30 @@ import torch
 import vllm.envs as envs
 from tqdm import tqdm
 from vllm import _custom_ops as ops
-from vllm.attention.backends.abstract import (
-    AttentionBackend,
-    AttentionLayer,
-    AttentionMetadata,
-    MLAAttentionImpl,
-)
-from vllm.attention.backends.utils import get_mla_dims
 from vllm.attention.ops.common import cp_lse_ag_out_rs
 from vllm.attention.ops.merge_attn_states import merge_attn_states
-from vllm.attention.utils.fa_utils import get_flash_attn_version
 from vllm.config import VllmConfig, get_current_vllm_config
 from vllm.distributed.parallel_state import get_dcp_group, is_global_first_rank
 from vllm.logger import init_logger
+from vllm.model_executor.layers.attention.mla_attention import get_mla_dims
 from vllm.model_executor.layers.linear import (
     ColumnParallelLinear,
     LinearBase,
     UnquantizedLinearMethod,
 )
 from vllm.platforms import current_platform
-from vllm.utils import cdiv, round_down
 from vllm.utils.flashinfer import has_nvidia_artifactory
-from vllm.v1.attention.backends.utils import (
+from vllm.utils.math_utils import cdiv, round_down
+from vllm.v1.attention.backend import (
+    AttentionBackend,
+    AttentionLayer,
+    AttentionMetadata,
     AttentionMetadataBuilder,
     CommonAttentionMetadata,
+    MLAAttentionImpl,
+)
+from vllm.v1.attention.backends.fa_utils import get_flash_attn_version
+from vllm.v1.attention.backends.utils import (
     get_per_layer_parameters,
     infer_global_hyperparameters,
     split_decodes_and_prefills,
@@ -229,6 +229,8 @@ from vllm.v1.kv_cache_interface import AttentionSpec
 
 import vllm_kunlun.platforms.envs as vllm_kunlun_envs
 
+flash_attn_varlen_func = None
+is_vllm_fa = False
 try:
     from vllm.vllm_flash_attn import flash_attn_varlen_func
 
@@ -236,8 +238,10 @@ try:
 except ImportError:
     # For rocm use upstream flash attention
     if current_platform.is_rocm():
-        from flash_attn import flash_attn_varlen_func
-    is_vllm_fa = False
+        try:
+            from flash_attn import flash_attn_varlen_func
+        except ImportError:
+            pass
 
 try:
     from flashinfer import BatchPrefillWithRaggedKVCacheWrapper
@@ -429,13 +433,17 @@ M = TypeVar("M", bound=MLACommonMetadata)
 A = TypeVar("A")
 
 
+def _env_flag(name: str, default: bool = False) -> bool:
+    return bool(getattr(envs, name, default))
+
+
 def use_flashinfer_prefill() -> bool:
     # For blackwell default to flashinfer prefill if it's available since
     # it is faster than FA2.
     return (
-        not envs.VLLM_DISABLE_FLASHINFER_PREFILL
+        not _env_flag("VLLM_DISABLE_FLASHINFER_PREFILL")
         and flashinfer_available
-        and not envs.VLLM_USE_CUDNN_PREFILL
+        and not _env_flag("VLLM_USE_CUDNN_PREFILL")
         and current_platform.is_device_capability(100)
     )
 
@@ -443,7 +451,7 @@ def use_flashinfer_prefill() -> bool:
 def use_cudnn_prefill() -> bool:
     return (
         flashinfer_available
-        and envs.VLLM_USE_CUDNN_PREFILL
+        and _env_flag("VLLM_USE_CUDNN_PREFILL")
         and current_platform.is_device_capability(100)
         and has_nvidia_artifactory()
     )
@@ -1221,10 +1229,13 @@ class MLACommonImpl(MLACommonBaseImpl[M], Generic[M]):
             # RoCM and the latter has an additional parameter to control
             # FA2 vs FA3
             self.flash_attn_varlen_func = flash_attn_varlen_func
-            self.vllm_flash_attn_version = get_flash_attn_version()
+            self.vllm_flash_attn_version = None
+            if self.flash_attn_varlen_func is not None:
+                self.vllm_flash_attn_version = get_flash_attn_version()
             if self.vllm_flash_attn_version is not None:
                 self.flash_attn_varlen_func = functools.partial(
-                    flash_attn_varlen_func, fa_version=self.vllm_flash_attn_version
+                    self.flash_attn_varlen_func,
+                    fa_version=self.vllm_flash_attn_version,
                 )
 
             # For MLA the v head dim is smaller than qk head dim so we pad out
@@ -1237,12 +1248,70 @@ class MLACommonImpl(MLACommonBaseImpl[M], Generic[M]):
             )
 
         self.dcp_world_size: Optional[int] = None
+        self._ensure_dcp_world_size()
 
         self.chunked_prefill_workspace_size = (
             MLACommonMetadataBuilder.determine_chunked_prefill_workspace_size(
                 get_current_vllm_config()
             )
         )
+
+    def _torch_prefill_attention(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        context_seq_lod_xpu: Optional[torch.Tensor],
+        context_seq_lod_cpu: Optional[torch.Tensor],
+        return_softmax_lse: bool,
+        causal: bool,
+        softmax_scale: Optional[float],
+    ):
+        scale = softmax_scale if softmax_scale is not None else q.shape[-1] ** -0.5
+        maybe_padded_v = v
+        if self._pad_v:
+            maybe_padded_v = torch.nn.functional.pad(
+                v, [0, q.shape[-1] - v.shape[-1]], value=0
+            )
+
+        out = q.new_empty((*q.shape[:-1], maybe_padded_v.shape[-1]))
+        softmax_lse = torch.empty(
+            q.size(1), q.size(0), dtype=torch.float32, device=q.device
+        )
+        softmax_lse.fill_(float("-inf"))
+
+        if context_seq_lod_cpu is not None:
+            seq_lens = context_seq_lod_cpu.tolist()
+        elif context_seq_lod_xpu is not None:
+            seq_lens = context_seq_lod_xpu.detach().cpu().tolist()
+        else:
+            seq_lens = [0, q.shape[0]]
+
+        for start, end in zip(seq_lens[:-1], seq_lens[1:]):
+            if end <= start:
+                continue
+
+            q_i = q[start:end].to(torch.float32)
+            k_i = k[start:end].to(torch.float32)
+            v_i = maybe_padded_v[start:end].to(torch.float32)
+
+            scores = torch.einsum("qhd,khd->hqk", q_i, k_i) * scale
+            if causal:
+                q_len = end - start
+                causal_mask = torch.triu(
+                    torch.ones(q_len, q_len, dtype=torch.bool, device=q.device),
+                    diagonal=1,
+                )
+                scores = scores.masked_fill(causal_mask.unsqueeze(0), float("-inf"))
+
+            probs = torch.softmax(scores, dim=-1)
+            out[start:end].copy_(torch.einsum("hqk,khd->qhd", probs, v_i).to(out.dtype))
+            if return_softmax_lse:
+                softmax_lse[:, start:end] = torch.logsumexp(scores, dim=-1)
+
+        if return_softmax_lse:
+            return out, softmax_lse
+        return out
 
     def _flash_attn_varlen_diff_headdims(
         self,
@@ -1283,26 +1352,38 @@ class MLACommonImpl(MLACommonBaseImpl[M], Generic[M]):
             tp_q_head_num, q.size(0), dtype=torch.float32, device=q.device
         )
         softmax_lse.fill_(float("-inf"))
-        kunlun_ops.attention(
-            q=q,
-            k_cache=k,
-            v_cache=maybe_padded_v,
-            out=attn_out,
-            is_causal=causal,
-            is_prefill=True,
-            prefill_len=0,
-            k_perchannel_scale=None,
-            v_perchannel_scale=None,
-            smooth=None,
-            context_seq_lod_cpu=context_seq_lod_cpu,
-            context_seq_lod_xpu=context_seq_lod_xpu,
-            slot_mapping_cpu=None,
-            slot_mapping_xpu=None,
-            v_trans=False,
-            v_trans_threshold=0,
-            alpha=ds_alpha,
-            softmax_lse=softmax_lse,
-        )
+        try:
+            kunlun_ops.attention(
+                q=q,
+                k_cache=k,
+                v_cache=maybe_padded_v,
+                out=attn_out,
+                is_causal=causal,
+                is_prefill=True,
+                prefill_len=0,
+                k_perchannel_scale=None,
+                v_perchannel_scale=None,
+                smooth=None,
+                context_seq_lod_cpu=context_seq_lod_cpu,
+                context_seq_lod_xpu=context_seq_lod_xpu,
+                slot_mapping_cpu=None,
+                slot_mapping_xpu=None,
+                v_trans=False,
+                v_trans_threshold=0,
+                alpha=ds_alpha,
+                softmax_lse=softmax_lse,
+            )
+        except (RuntimeError, ValueError):
+            return self._torch_prefill_attention(
+                q=q,
+                k=k,
+                v=v,
+                context_seq_lod_xpu=context_seq_lod_xpu,
+                context_seq_lod_cpu=context_seq_lod_cpu,
+                return_softmax_lse=return_softmax_lse,
+                causal=causal,
+                softmax_scale=softmax_scale,
+            )
 
         # Unpack the output if there is multiple results
         if isinstance(attn_out, tuple):
@@ -1851,6 +1932,46 @@ class MLACommonImpl(MLACommonBaseImpl[M], Generic[M]):
         layer: AttentionLayer,
     ) -> tuple[torch.Tensor, Optional[torch.Tensor]]:
         raise NotImplementedError
+
+    def _ensure_dcp_world_size(self) -> None:
+        if self.dcp_world_size is not None:
+            return
+        try:
+            self.dcp_world_size = get_dcp_group().world_size
+        except AssertionError:
+            self.dcp_world_size = 1
+
+    def forward_mha(
+        self,
+        q: torch.Tensor,
+        kv_c_normed: torch.Tensor,
+        k_pe: torch.Tensor,
+        kv_c_and_k_pe_cache: torch.Tensor,
+        attn_metadata: M,
+        k_scale: torch.Tensor,
+        output: torch.Tensor,
+    ) -> None:
+        self._ensure_dcp_world_size()
+        output.copy_(
+            self._forward_prefill(
+                q,
+                kv_c_normed,
+                k_pe,
+                kv_c_and_k_pe_cache,
+                attn_metadata,
+                k_scale,
+            )
+        )
+
+    def forward_mqa(
+        self,
+        q: Union[torch.Tensor, tuple[torch.Tensor, torch.Tensor]],
+        kv_c_and_k_pe_cache: torch.Tensor,
+        attn_metadata: M,
+        layer: AttentionLayer,
+    ) -> tuple[torch.Tensor, Optional[torch.Tensor]]:
+        self._ensure_dcp_world_size()
+        return self._forward_decode(q, kv_c_and_k_pe_cache, attn_metadata, layer)
 
     def forward(
         self,

--- a/vllm_kunlun/v1/attention/backends/mla/flashmla.py
+++ b/vllm_kunlun/v1/attention/backends/mla/flashmla.py
@@ -5,10 +5,13 @@ from dataclasses import dataclass
 from typing import ClassVar, Optional, Union
 
 import torch
-from vllm.attention.backends.abstract import AttentionLayer, AttentionType
 from vllm.config import VllmConfig
 from vllm.logger import init_logger
-from vllm.v1.attention.backends.utils import AttentionCGSupport
+from vllm.v1.attention.backend import (
+    AttentionCGSupport,
+    AttentionLayer,
+    AttentionType,
+)
 from vllm.v1.kv_cache_interface import AttentionSpec
 
 from vllm_kunlun.ops.attention.flashmla import (

--- a/vllm_kunlun/v1/attention/backends/mla/flashmla_sparse.py
+++ b/vllm_kunlun/v1/attention/backends/mla/flashmla_sparse.py
@@ -6,22 +6,22 @@ from typing import TYPE_CHECKING, ClassVar, Optional
 
 import numpy as np
 import torch
-from vllm.attention.backends.abstract import (
-    AttentionBackend,
-    AttentionLayer,
-    AttentionMetadata,
-)
-from vllm.attention.backends.utils import get_mla_dims
 from vllm.config import VllmConfig
 from vllm.logger import init_logger
+from vllm.model_executor.layers.attention.mla_attention import get_mla_dims
 from vllm.platforms import current_platform
 from vllm.triton_utils import tl, triton
-from vllm.utils import cdiv
-from vllm.v1.attention.backends.mla.common import MLACommonBaseImpl
-from vllm.v1.attention.backends.utils import (
+from vllm.utils.math_utils import cdiv
+from vllm.v1.attention.backend import (
+    AttentionBackend,
     AttentionCGSupport,
+    AttentionLayer,
+    AttentionMetadata,
     AttentionMetadataBuilder,
     CommonAttentionMetadata,
+    SparseMLAAttentionImpl,
+)
+from vllm.v1.attention.backends.utils import (
     reshape_attn_output_for_spec_decode,
     reshape_query_for_spec_decode,
     split_decodes_and_prefills,
@@ -591,7 +591,7 @@ class FlashMLASparseMetadataBuilder(AttentionMetadataBuilder[FlashMLASparseMetad
         return metadata
 
 
-class FlashMLASparseImpl(MLACommonBaseImpl[FlashMLASparseMetadata]):
+class FlashMLASparseImpl(SparseMLAAttentionImpl[FlashMLASparseMetadata]):
 
     def __init__(
         self,
@@ -610,19 +610,19 @@ class FlashMLASparseImpl(MLACommonBaseImpl[FlashMLASparseMetadata]):
         indexer: Optional["Indexer"] = None,
         **mla_args,
     ) -> None:
-        super().__init__(
-            num_heads,
-            head_size,
-            scale,
-            num_kv_heads,
-            alibi_slopes,
-            sliding_window,
-            kv_cache_dtype,
-            logits_soft_cap,
-            attn_type,
-            kv_sharing_target_layer_name,
-            **mla_args,
-        )
+        if kv_sharing_target_layer_name is not None:
+            raise NotImplementedError("KV sharing is not supported for sparse MLA")
+        self.num_heads = num_heads
+        self.head_size = head_size
+        self.scale = float(scale)
+        self.num_kv_heads = num_kv_heads
+        self.kv_cache_dtype = kv_cache_dtype
+        self.kv_lora_rank = mla_args["kv_lora_rank"]
+        self.qk_nope_head_dim = mla_args["qk_nope_head_dim"]
+        self.qk_rope_head_dim = mla_args["qk_rope_head_dim"]
+        self.qk_head_dim = mla_args["qk_head_dim"]
+        self.v_head_dim = mla_args["v_head_dim"]
+        self.q_pad_num_heads = mla_args.get("q_pad_num_heads")
         self.softmax_scale = scale
         assert indexer is not None
         self.topk_indices_buffer = indexer.topk_indices_buffer
@@ -745,6 +745,30 @@ class FlashMLASparseImpl(MLACommonBaseImpl[FlashMLASparseMetadata]):
         )
 
         return _attn_out
+
+    def forward_mqa(
+        self,
+        q: torch.Tensor | tuple[torch.Tensor, torch.Tensor],
+        kv_c_and_k_pe_cache: torch.Tensor,
+        attn_metadata: FlashMLASparseMetadata,
+        layer: AttentionLayer,
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
+        if isinstance(q, tuple):
+            q = torch.cat(q, dim=-1)
+
+        num_actual_toks = q.shape[0]
+        topk_indices = self.topk_indices_buffer[:num_actual_toks]
+
+        if self.kv_cache_dtype == "fp8_ds_mla":
+            raise NotImplementedError("Only support --kv-cache-dtype bfloat16")
+
+        attn_out = self._forward_bf16_kv(
+            q,
+            kv_c_and_k_pe_cache,
+            topk_indices,
+            attn_metadata,
+        )
+        return attn_out, None
 
     def forward(
         self,

--- a/vllm_kunlun/v1/attention/backends/mla/indexer.py
+++ b/vllm_kunlun/v1/attention/backends/mla/indexer.py
@@ -8,7 +8,6 @@ from vllm.logger import init_logger
 from vllm.v1.attention.backends.mla.indexer import (
     DeepseekV32IndexerMetadataBuilder,
     kv_spans_from_batches,
-    split_prefill_chunks,
 )
 from vllm.v1.attention.backends.utils import (
     CommonAttentionMetadata,
@@ -16,6 +15,32 @@ from vllm.v1.attention.backends.utils import (
 )
 
 logger = init_logger(__name__)
+
+
+def split_prefill_chunks(
+    seq_lens_cpu: torch.Tensor,
+    max_prefill_buffer_size: int,
+    num_decodes: int,
+) -> list[tuple[int, int]]:
+    chunks: list[tuple[int, int]] = []
+    start = num_decodes
+    cur = start
+    total_seq_lens = 0
+
+    for req_idx in range(num_decodes, len(seq_lens_cpu)):
+        seq_len = int(seq_lens_cpu[req_idx].item())
+        if cur > start and total_seq_lens + seq_len > max_prefill_buffer_size:
+            chunks.append((start, cur))
+            start = cur
+            total_seq_lens = 0
+
+        cur = req_idx + 1
+        total_seq_lens += seq_len
+
+    if cur > start:
+        chunks.append((start, cur))
+
+    return chunks
 
 
 @dataclass

--- a/vllm_kunlun/v1/sample/ops/topk_topp_sampler.py
+++ b/vllm_kunlun/v1/sample/ops/topk_topp_sampler.py
@@ -1,15 +1,19 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import importlib
 import os
 from typing import Optional
 
-import kunlun_ops
 import torch
 import torch.nn as nn
 from vllm.logger import init_logger
 
 logger = init_logger(__name__)
+
+
+def _get_kunlun_ops():
+    return importlib.import_module("kunlun_ops")
 
 
 class TopKTopPSampler(nn.Module):
@@ -23,8 +27,15 @@ class TopKTopPSampler(nn.Module):
     def __init__(self, logprobs_mode):
         super().__init__()
         self.logprobs_mode = logprobs_mode
-        logger.info_once("Using FlashInfer for top-p & top-k sampling.")
-        self.forward = self.forward_kunlun
+        self._disable_kunlun_sampling = logprobs_mode in (
+            "processed_logits",
+            "processed_logprobs",
+        )
+        if self._disable_kunlun_sampling:
+            self.forward = self.forward_native
+        else:
+            logger.info_once("Using Kunlun top-p & top-k sampling when available.")
+            self.forward = self.forward_kunlun
         self.apply_top_k_top_p = apply_top_k_top_p
 
     def forward_native(
@@ -56,6 +67,8 @@ class TopKTopPSampler(nn.Module):
         p: Optional[torch.Tensor],
     ) -> tuple[torch.Tensor, torch.Tensor | None]:
         """More optimized implementation for top-k and top-p sampling."""
+        if self._disable_kunlun_sampling:
+            return self.forward_native(logits, generators, k, p)
         if (k is None and p is None) or generators:
             if generators:
                 logger.debug_once(
@@ -64,10 +77,19 @@ class TopKTopPSampler(nn.Module):
                     "PyTorch-native implementation."
                 )
             return self.forward_native(logits, generators, k, p)
-        # flashinfer sampling functions expect contiguous logits.
-        # In flex_attn/triton_attn fp32 inference, logits can be non-contiguous
-        # because of slicing operation in logits_processor.
-        return flashinfer_sample(logits.contiguous(), k, p, generators), None
+        try:
+            # Kunlun sampling functions expect contiguous logits. In
+            # flex_attn/triton_attn fp32 inference, logits can be
+            # non-contiguous because of slicing operation in logits_processor.
+            return flashinfer_sample(logits.contiguous(), k, p, generators), None
+        except Exception as exc:
+            self._disable_kunlun_sampling = True
+            logger.warning_once(
+                "Kunlun sampling ops unavailable; falling back to "
+                "PyTorch-native top-k/top-p sampling. Original error: %s",
+                exc,
+            )
+            return self.forward_native(logits, generators, k, p)
 
 
 def apply_top_k_top_p(
@@ -196,6 +218,7 @@ def flashinfer_sample(
     """
     assert not (k is None and p is None)
     probs = logits.softmax(dim=-1, dtype=torch.float32)
+    kunlun_ops = _get_kunlun_ops()
     if k is None:
         # Top-p only.
         next_token_ids = kunlun_ops.top_p_sampling_from_probs(

--- a/vllm_kunlun/v1/worker/utils.py
+++ b/vllm_kunlun/v1/worker/utils.py
@@ -1,23 +1,191 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import math
 from collections import defaultdict
-from dataclasses import dataclass
-from typing import TYPE_CHECKING, Optional
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from itertools import product as iprod
+from typing import TYPE_CHECKING, Any, Optional
 
 import torch
-from vllm.attention.backends.abstract import AttentionBackend
-from vllm.config import ModelConfig, SchedulerConfig, VllmConfig
+from vllm.config import CacheConfig, ModelConfig, SchedulerConfig, VllmConfig
+from vllm.logger import init_logger
 from vllm.model_executor.models.interfaces import MultiModalEmbeddings
 from vllm.model_executor.models.utils import extract_layer_index
-from vllm.multimodal.cache import processor_only_cache_from_config
 from vllm.multimodal.registry import MultiModalRegistry
 from vllm.platforms import current_platform
-from vllm.v1.attention.backends.utils import AttentionMetadataBuilder
+from vllm.triton_utils import tl, triton
+from vllm.utils.math_utils import largest_power_of_2_divisor
+from vllm.utils.mem_utils import MemorySnapshot, format_gib
+from vllm.v1.attention.backend import (
+    AttentionBackend,
+    AttentionMetadataBuilder,
+    MultipleOf,
+)
 from vllm.v1.core.encoder_cache_manager import compute_mm_encoder_budget
-from vllm.v1.kv_cache_interface import KVCacheGroupSpec, KVCacheSpec
+from vllm.v1.kv_cache_interface import (
+    AttentionSpec,
+    EncoderOnlyAttentionSpec,
+    FullAttentionSpec,
+    KVCacheConfig,
+    KVCacheGroupSpec,
+    KVCacheSpec,
+    MambaSpec,
+    UniformTypeKVCacheSpecs,
+)
 
 if TYPE_CHECKING:
-    from vllm.attention.layer import Attention
+    from vllm.model_executor.layers.attention import Attention
+
+logger = init_logger(__name__)
+
+
+@triton.jit
+def _zero_kv_blocks_kernel(
+    seg_addrs_ptr,
+    block_ids_ptr,
+    n_blocks,
+    N_SEGS: tl.constexpr,
+    PAGE_SIZE_EL: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    """Zero KV cache blocks across all segments in a single launch."""
+    pid = tl.program_id(0)
+    chunks = PAGE_SIZE_EL // BLOCK_SIZE
+    work_per_block = N_SEGS * chunks
+    block_index = pid // work_per_block
+    if block_index >= n_blocks:
+        return
+    remainder = pid % work_per_block
+    seg_index = remainder // chunks
+    chunk_index = remainder % chunks
+    block_id = tl.load(block_ids_ptr + block_index)
+    seg_addr = tl.load(seg_addrs_ptr + seg_index)
+    ptr = tl.cast(seg_addr, tl.pointer_type(tl.int32))
+    offset = (
+        block_id.to(tl.int64) * PAGE_SIZE_EL + chunk_index.to(tl.int64) * BLOCK_SIZE
+    )
+    cols = tl.arange(0, BLOCK_SIZE).to(tl.int64)
+    tl.store(ptr + offset + cols, tl.zeros([BLOCK_SIZE], dtype=tl.int32))
+
+
+class KVBlockZeroer:
+    """Manage efficient zeroing of KV cache blocks via a Triton kernel."""
+
+    def __init__(self, device: torch.device, pin_memory: bool):
+        self.device = device
+        self.pin_memory = pin_memory
+        self._meta: tuple[torch.Tensor, int, int, int] | None = None
+        self._id_cap: int = 0
+        self._ids_pinned: torch.Tensor | None = None
+        self._ids_gpu: torch.Tensor | None = None
+
+    def init_meta(
+        self,
+        attn_groups_iter: Iterable["AttentionGroup"],
+        kernel_block_sizes: list[int],
+        cache_dtype: str,
+        runner_only_attn_layers: set[str],
+        static_forward_context: dict[str, Any],
+    ) -> None:
+        seen_ptrs: set[int] = set()
+        seg_addrs: list[int] = []
+        page_size_el: int | None = None
+
+        for group in attn_groups_iter:
+            spec = group.kv_cache_spec
+            if type(spec) is not FullAttentionSpec:
+                continue
+            if group.kv_cache_group_id >= len(kernel_block_sizes):
+                continue
+            kernel_bs = kernel_block_sizes[group.kv_cache_group_id]
+            ratio = spec.block_size // kernel_bs
+            block_dim = group.backend.get_kv_cache_block_dim(
+                kernel_bs,
+                spec.num_kv_heads,
+                spec.head_size,
+                cache_dtype_str=cache_dtype,
+            )
+
+            for layer_name in group.layer_names:
+                if layer_name in runner_only_attn_layers:
+                    continue
+                kv = static_forward_context[layer_name].kv_cache
+                if not isinstance(kv, torch.Tensor):
+                    continue
+                data_ptr = kv.data_ptr()
+                if data_ptr in seen_ptrs:
+                    continue
+                seen_ptrs.add(data_ptr)
+
+                element_size = kv.element_size()
+                cur_bytes = kv.stride(block_dim) * element_size
+                assert cur_bytes % 4 == 0
+                kernel_block_el = cur_bytes // 4
+                cur_page_el = kernel_block_el * ratio
+                if page_size_el is None:
+                    page_size_el = cur_page_el
+                else:
+                    assert (
+                        page_size_el == cur_page_el
+                    ), f"Non-uniform page sizes: {page_size_el} vs {cur_page_el}"
+
+                block_stride_bytes = cur_bytes
+                outer_dims = [
+                    dim
+                    for dim in range(block_dim)
+                    if kv.stride(dim) * element_size > block_stride_bytes
+                ]
+                outer_strides = [kv.stride(dim) * element_size for dim in outer_dims]
+                for outer in iprod(*(range(kv.shape[dim]) for dim in outer_dims)):
+                    off_bytes = sum(
+                        index * stride for index, stride in zip(outer, outer_strides)
+                    )
+                    seg_addrs.append(data_ptr + off_bytes)
+
+        if not seg_addrs or page_size_el is None:
+            self._meta = None
+            return
+
+        blk_size = min(largest_power_of_2_divisor(page_size_el), 1024)
+        self._id_cap = 8192
+        self._ids_pinned = torch.empty(
+            self._id_cap, dtype=torch.int64, pin_memory=self.pin_memory
+        )
+        self._ids_gpu = torch.empty(self._id_cap, dtype=torch.int64, device=self.device)
+        self._meta = (
+            torch.tensor(seg_addrs, dtype=torch.uint64, device=self.device),
+            page_size_el,
+            blk_size,
+            len(seg_addrs),
+        )
+
+    def zero_block_ids(self, block_ids: list[int]) -> None:
+        if not block_ids or self._meta is None:
+            return
+        seg_addrs, page_size_el, blk_size, n_segs = self._meta
+        n_blocks = len(block_ids)
+        if n_blocks > self._id_cap:
+            self._id_cap = n_blocks * 2
+            self._ids_pinned = torch.empty(
+                self._id_cap, dtype=torch.int64, pin_memory=self.pin_memory
+            )
+            self._ids_gpu = torch.empty(
+                self._id_cap, dtype=torch.int64, device=self.device
+            )
+        assert self._ids_pinned is not None and self._ids_gpu is not None
+        self._ids_pinned[:n_blocks].numpy()[:] = block_ids
+        idx = self._ids_gpu[:n_blocks]
+        idx.copy_(self._ids_pinned[:n_blocks], non_blocking=True)
+        grid = (n_blocks * n_segs * (page_size_el // blk_size),)
+        _zero_kv_blocks_kernel[grid](
+            seg_addrs,
+            idx,
+            n_blocks,
+            N_SEGS=n_segs,
+            PAGE_SIZE_EL=page_size_el,
+            BLOCK_SIZE=blk_size,
+        )
 
 
 class MultiModalBudget:
@@ -34,13 +202,15 @@ class MultiModalBudget:
         self.model_config = model_config
         self.scheduler_config = scheduler_config
         self.mm_registry = mm_registry
-        self.cache = cache = processor_only_cache_from_config(model_config, mm_registry)
+        # vLLM 0.19 moved MM processor cache creation onto the registry and
+        # requires a full VllmConfig. This utility only receives ModelConfig /
+        # SchedulerConfig, so keep the legacy helper import-safe here.
+        self.cache = cache = None
 
         self.max_model_len = model_config.max_model_len
         self.max_num_reqs = scheduler_config.max_num_seqs
 
         self.mm_limits = mm_registry.get_mm_limits_per_prompt(model_config, cache=cache)
-
         max_tokens_by_modality = (
             mm_registry.get_max_tokens_per_item_by_nonzero_modality(
                 model_config, cache=cache
@@ -55,15 +225,13 @@ class MultiModalBudget:
         self.encoder_compute_budget = encoder_compute_budget
         self.encoder_cache_size = encoder_cache_size
 
-        max_items_per_prompt_by_modality = dict[str, int]()
-        max_items_per_batch_by_modality = dict[str, int]()
+        max_items_per_prompt_by_modality = {}
+        max_items_per_batch_by_modality = {}
 
         for modality, max_tokens in max_tokens_by_modality.items():
-            (
-                max_items_per_prompt,
-                max_items_per_batch,
-            ) = self.get_max_items(modality, max_tokens)
-
+            max_items_per_prompt, max_items_per_batch = self.get_max_items(
+                modality, max_tokens
+            )
             max_items_per_prompt_by_modality[modality] = max_items_per_prompt
             max_items_per_batch_by_modality[modality] = max_items_per_batch
 
@@ -72,9 +240,7 @@ class MultiModalBudget:
         self.max_items_per_batch_by_modality = max_items_per_batch_by_modality
 
     def get_modality_with_max_tokens(self) -> str:
-        max_tokens_by_modality = self.max_tokens_by_modality
-        modality, _ = max(max_tokens_by_modality.items(), key=lambda x: x[1])
-
+        modality, _ = max(self.max_tokens_by_modality.items(), key=lambda item: item[1])
         return modality
 
     def get_encoder_budget(self) -> int:
@@ -88,20 +254,12 @@ class MultiModalBudget:
         if max_tokens_per_item == 0:
             return 0, 0
 
-        # Check how many items of this modality can be supported by
-        # the encoder budget.
         encoder_budget = self.get_encoder_budget()
-
-        # TODO: handle encoder-decoder models once we support them.
         if encoder_budget == 0:
             return 0, 0
 
         max_encoder_items_per_batch = encoder_budget // max_tokens_per_item
-
-        # Check how many items of this modality can be supported by
-        # the decoder budget.
         mm_limit = self.mm_limits[modality]
-
         max_items_per_prompt = max(
             1,
             min(mm_limit, self.max_model_len // max_tokens_per_item),
@@ -109,7 +267,6 @@ class MultiModalBudget:
 
         scheduler_config = self.scheduler_config
         max_num_reqs = self.max_num_reqs
-
         if not scheduler_config.enable_chunked_prefill:
             max_num_reqs = min(
                 max_num_reqs,
@@ -117,43 +274,117 @@ class MultiModalBudget:
             )
 
         max_decoder_items_per_batch = max_num_reqs * max_items_per_prompt
-
         max_items_per_batch = max(
             1,
             min(max_encoder_items_per_batch, max_decoder_items_per_batch),
         )
-
         return max_items_per_prompt, max_items_per_batch
 
 
 @dataclass
 class AttentionGroup:
     backend: type[AttentionBackend]
-    # When ubatching is enabled we will have a metadata builder for each ubatch
-    # so that if they use internal persistant buffers for cudagraphs, and they
-    # won't have to worry about conflicting with the other ubatches.
-    metadata_builders: list[AttentionMetadataBuilder]
     layer_names: list[str]
     kv_cache_spec: KVCacheSpec
+    kv_cache_group_id: int
+    metadata_builders: list[AttentionMetadataBuilder] = field(
+        default_factory=lambda: []
+    )
 
-    @staticmethod
-    def create_with_metadata_builders(
-        backend: type[AttentionBackend],
-        layer_names: list[str],
-        kv_cache_spec: KVCacheSpec,
+    def create_metadata_builders(
+        self,
         vllm_config: VllmConfig,
         device: torch.device,
+        kernel_block_size: int | None = None,
         num_metadata_builders: int = 1,
-    ) -> "AttentionGroup":
-        metadata_builders = [
-            backend.get_builder_cls()(kv_cache_spec, layer_names, vllm_config, device)
+    ) -> None:
+        kv_cache_spec_builder = (
+            self.kv_cache_spec.copy_with_new_block_size(kernel_block_size)
+            if kernel_block_size is not None
+            else self.kv_cache_spec
+        )
+        self.metadata_builders = [
+            self.backend.get_builder_cls()(
+                kv_cache_spec_builder,
+                self.layer_names,
+                vllm_config,
+                device,
+            )
             for _ in range(num_metadata_builders)
         ]
-        return AttentionGroup(backend, metadata_builders, layer_names, kv_cache_spec)
 
     def get_metadata_builder(self, ubatch_id: int = 0) -> AttentionMetadataBuilder:
         assert len(self.metadata_builders) > ubatch_id
         return self.metadata_builders[ubatch_id]
+
+
+def select_common_block_size(
+    kv_manager_block_size: int,
+    backends: list[type[AttentionBackend]],
+) -> int:
+    """Select a block size supported by all attention backends."""
+
+    def block_size_is_supported(
+        backends: list[type[AttentionBackend]], block_size: int
+    ) -> bool:
+        for backend in backends:
+            is_supported = False
+            for supported_size in backend.get_supported_kernel_block_sizes():
+                if isinstance(supported_size, int):
+                    if block_size == supported_size:
+                        is_supported = True
+                elif isinstance(supported_size, MultipleOf):
+                    if block_size % supported_size.base == 0:
+                        is_supported = True
+                else:
+                    raise ValueError(f"Unknown supported size: {supported_size}")
+            if not is_supported:
+                return False
+        return True
+
+    if block_size_is_supported(backends, kv_manager_block_size):
+        return kv_manager_block_size
+
+    all_int_supported_sizes = set(
+        supported_size
+        for backend in backends
+        for supported_size in backend.get_supported_kernel_block_sizes()
+        if isinstance(supported_size, int)
+    )
+
+    for supported_size in sorted(all_int_supported_sizes, reverse=True):
+        if kv_manager_block_size % supported_size != 0:
+            continue
+        if block_size_is_supported(backends, supported_size):
+            return supported_size
+    raise ValueError(f"No common block size for {kv_manager_block_size}.")
+
+
+def prepare_kernel_block_sizes(
+    kv_cache_config: KVCacheConfig, attn_groups: list[list[AttentionGroup]]
+) -> list[int]:
+    """Generate kernel block sizes matching each KV cache group."""
+    kernel_block_sizes = []
+    for kv_cache_gid, kv_cache_group in enumerate(kv_cache_config.kv_cache_groups):
+        kv_cache_spec = kv_cache_group.kv_cache_spec
+        if isinstance(kv_cache_spec, UniformTypeKVCacheSpecs):
+            kv_cache_spec = next(iter(kv_cache_spec.kv_cache_specs.values()))
+        if isinstance(kv_cache_spec, EncoderOnlyAttentionSpec):
+            continue
+        if isinstance(kv_cache_spec, AttentionSpec):
+            kv_manager_block_size = kv_cache_group.kv_cache_spec.block_size
+            group_backends = [group.backend for group in attn_groups[kv_cache_gid]]
+            selected_kernel_size = select_common_block_size(
+                kv_manager_block_size, group_backends
+            )
+            kernel_block_sizes.append(selected_kernel_size)
+        elif isinstance(kv_cache_spec, MambaSpec):
+            kernel_block_sizes.append(kv_cache_spec.block_size)
+        else:
+            raise NotImplementedError(
+                f"unknown kv cache spec {kv_cache_group.kv_cache_spec}"
+            )
+    return kernel_block_sizes
 
 
 def sanity_check_mm_encoder_outputs(
@@ -161,29 +392,57 @@ def sanity_check_mm_encoder_outputs(
     expected_num_items: int,
 ) -> None:
     """
-    Perform sanity checks for the result of
-    [`vllm.model_executor.models.SupportsMultiModal.get_multimodal_embeddings`][].
+    Perform sanity checks for the result of multimodal embedding generation.
     """
     assert isinstance(mm_embeddings, (list, tuple, torch.Tensor)), (
         "Expected multimodal embeddings to be a list/tuple of 2D tensors, "
-        f"or a single 3D tensor, but got {type(mm_embeddings)} "
-        "instead. This is most likely due to incorrect implementation "
-        "of the model's `get_multimodal_embeddings` method."
+        f"or a single 3D tensor, but got {type(mm_embeddings)} instead. "
+        "This is most likely due to incorrect implementation of the model's "
+        "`embed_multimodal` method."
     )
 
     assert len(mm_embeddings) == expected_num_items, (
-        "Expected number of multimodal embeddings to match number of "
-        f"input items: {expected_num_items}, but got {len(mm_embeddings)=} "
-        "instead. This is most likely due to incorrect implementation "
-        "of the model's `get_multimodal_embeddings` method."
+        "Expected number of multimodal embeddings to match number of input "
+        f"items: {expected_num_items}, but got {len(mm_embeddings)=} instead. "
+        "This is most likely due to incorrect implementation of the model's "
+        "`embed_multimodal` method."
     )
 
-    assert all(e.ndim == 2 for e in mm_embeddings), (
-        "Expected multimodal embeddings to be a sequence of 2D tensors, "
-        f"but got tensors with shapes {[e.shape for e in mm_embeddings]} "
-        "instead. This is most likely due to incorrect implementation "
-        "of the model's `get_multimodal_embeddings` method."
+    assert all(embed.ndim == 2 for embed in mm_embeddings), (
+        "Expected multimodal embeddings to be a sequence of 2D tensors, but "
+        f"got tensors with shapes {[embed.shape for embed in mm_embeddings]} "
+        "instead. This is most likely due to incorrect implementation of the "
+        "model's `embed_multimodal` method."
     )
+
+
+def request_memory(init_snapshot: MemorySnapshot, cache_config: CacheConfig) -> int:
+    """Validate that startup free memory satisfies the requested utilization."""
+    requested_memory = math.ceil(
+        init_snapshot.total_memory * cache_config.gpu_memory_utilization
+    )
+
+    if init_snapshot.free_memory < requested_memory:
+        if hasattr(current_platform, "is_kunlun") and current_platform.is_kunlun():
+            logger.warning(
+                "Kunlun reported free memory %s GiB below requested %s GiB; "
+                "clamping requested memory to the observed free memory and "
+                "continuing initialization.",
+                format_gib(init_snapshot.free_memory),
+                format_gib(requested_memory),
+            )
+            return int(init_snapshot.free_memory)
+        raise ValueError(
+            f"Free memory on device {init_snapshot.device_} "
+            f"({format_gib(init_snapshot.free_memory)}/"
+            f"{format_gib(init_snapshot.total_memory)} GiB) on startup "
+            f"is less than desired GPU memory utilization "
+            f"({cache_config.gpu_memory_utilization}, "
+            f"{format_gib(requested_memory)} GiB). Decrease GPU memory "
+            f"utilization or reduce GPU memory used by other processes."
+        )
+
+    return requested_memory
 
 
 def scatter_mm_placeholders(
@@ -191,17 +450,7 @@ def scatter_mm_placeholders(
     is_embed: Optional[torch.Tensor],
 ) -> torch.Tensor:
     """
-    Scatter the multimodal embeddings into a contiguous tensor that represents
-    the placeholder tokens.
-
-    [`vllm.multimodal.processing.PromptUpdateDetails.is_embed`][].
-
-    Args:
-        embeds: The multimodal embeddings.
-            Shape: `(num_embeds, embed_dim)`
-        is_embed: A boolean mask indicating which positions in the placeholder
-            tokens need to be filled with multimodal embeddings.
-            Shape: `(num_placeholders, num_embeds)`
+    Scatter multimodal embeddings into a contiguous placeholder tensor.
     """
     if is_embed is None:
         return embeds
@@ -218,35 +467,19 @@ def gather_mm_placeholders(
     placeholders: torch.Tensor,
     is_embed: Optional[torch.Tensor],
 ) -> torch.Tensor:
-    """
-    Reconstructs the embeddings from the placeholder tokens.
-
-    This is the operation of [`scatter_mm_placeholders`]
-    [vllm.v1.worker.utils.scatter_mm_placeholders].
-    """
+    """Reconstruct embeddings from placeholder tokens."""
     if is_embed is None:
         return placeholders
-
     return placeholders[is_embed]
 
 
 def add_kv_sharing_layers_to_kv_cache_groups(
     shared_kv_cache_layers: dict[str, str],
     kv_cache_groups: list[KVCacheGroupSpec],
-    runner_only_attn_layers: Optional[set[str]] = None,
+    runner_only_attn_layers: set[str] | None = None,
 ) -> None:
     """
-    Sets up KV cache sharing by reusing the allocated KV caches in `kv_caches`
-    for layers that do not allocate its own KV cache, based on the mapping in
-    `shared_kv_cache_layers`. Adds these layers to the corresponding KV cache
-    group, which is needed to ensure that attention metadata is assigned later.
-
-    Args:
-        shared_kv_cache_layers: Layer pairings for cross-layer KV sharing.
-            If an Attention layer `layer_name` is in the keys of this dict, it
-            means this layer will perform attention using the keys and values
-            from the KV cache of `shared_kv_cache_layers[layer_name]`.
-        kv_cache_groups: The KV cache groups of the model.
+    Reuse allocated KV caches for layers participating in KV sharing.
     """
     layer_to_kv_cache_group: dict[str, KVCacheGroupSpec] = {}
     for kv_cache_group in kv_cache_groups:
@@ -268,25 +501,10 @@ def bind_kv_cache(
     num_attn_module: Optional[int] = 1,
 ) -> None:
     """
-    Bind the allocated KV cache to both ModelRunner and forward context so
-    that the KV cache can be used in the forward pass.
-
-    This function:
-      1) Fills the ModelRunner's kv cache list (`runner_kv_caches`) with
-         kv_caches.
-      2) Associates each attention layer in the `forward_context` with its
-         corresponding KV cache in kv_caches.
-
-    Args:
-        kv_caches: The allocated kv_caches with layer names as keys.
-        forward_context: The global forward context containing all Attention
-            layers with layer names as keys.
-        runner_kv_caches: The kv_cache declared by ModelRunner.
+    Bind allocated KV cache tensors to the runner and forward context.
     """
-    # Bind kv_caches to ModelRunner
     assert len(runner_kv_caches) == 0
 
-    # Convert kv_caches dict to a list of tensors in the order of layer_index.
     index2name = defaultdict(list)
     for layer_name in kv_caches:
         index2name[extract_layer_index(layer_name, num_attn_module)].append(layer_name)
@@ -294,53 +512,42 @@ def bind_kv_cache(
     for layer_index in sorted(index2name.keys()):
         layer_names = index2name[layer_index]
         if len(layer_names) > 1:
-            # One typical case is encoder-decoder model, e.g., bart.
-            # The cross attention and self attention in the same decoder layer
-            # has different layer_name but the same layer_index.
-
-            # TODO - analyze where runner_kv_caches is used and the right
-            # way to ensure it properly reflects multiple attention layers
-            # in the same decoder block.
             if (
                 current_platform.is_kunlun()
-                or current_platform.is_cuda()
+                or current_platform.is_cuda_alike()
                 or current_platform.is_xpu()
+                or current_platform.is_cpu()
             ):
-                # We know that the GPU runner is not impacted by this
-                # case. Some test code depends on runner_kv_caches, but
-                # not in a way that's impacted by ignoring this.
                 pass
             else:
                 raise NotImplementedError
-        layer_name = layer_names[0]
-        runner_kv_caches.append(kv_caches[layer_name])
+        for layer_name in layer_names:
+            runner_kv_caches.append(kv_caches[layer_name])
 
-    # Bind kv_caches to forward context
     for layer_name, kv_cache in kv_caches.items():
-        # NOTE: Use list because of v0 PP virtual engine.
-        forward_context[layer_name].kv_cache = [kv_cache]
+        forward_context[layer_name].kv_cache = kv_cache
 
 
 def is_residual_scattered_for_sp(
     vllm_config: VllmConfig, num_input_tokens: int
 ) -> bool:
-    """Check if the residual tensor is scattered for sequence parallelism.
-
-    The residual tensor is scattered across tensor parallel ranks when sequence
-    parallelism and tensor parallelism is enabled, and the number of
-    input tokens is one of the compilation sizes.
-    """
-    if not vllm_config.compilation_config.pass_config.enable_sequence_parallelism:
+    """Check whether the residual tensor is sequence-parallel scattered."""
+    if not vllm_config.compilation_config.pass_config.enable_sp:
         return False
 
     tp = vllm_config.parallel_config.tensor_parallel_size
-
     if tp == 1:
         return False
 
-    # When sequence parallelism is enabled, we always pad num_input_tokens
-    # to be a multiple of tensor_parallel_size (tp) earlier.
     assert num_input_tokens % tp == 0
 
-    # Currently, SP is only enabled for static size fx graphs.
-    return num_input_tokens in vllm_config.compilation_config.compile_sizes
+    if (
+        not vllm_config.compilation_config.splitting_ops
+        or vllm_config.compilation_config.use_inductor_graph_partition
+    ):
+        return True
+
+    compile_sizes = vllm_config.compilation_config.compile_sizes
+    if compile_sizes is None:
+        return False
+    return num_input_tokens in compile_sizes

--- a/vllm_kunlun/v1/worker/utils.py
+++ b/vllm_kunlun/v1/worker/utils.py
@@ -83,7 +83,7 @@ class KVBlockZeroer:
     def init_meta(
         self,
         attn_groups_iter: Iterable["AttentionGroup"],
-        kernel_block_sizes: list[int],
+        kernel_block_sizes: list[int | None],
         cache_dtype: str,
         runner_only_attn_layers: set[str],
         static_forward_context: dict[str, Any],
@@ -99,6 +99,8 @@ class KVBlockZeroer:
             if group.kv_cache_group_id >= len(kernel_block_sizes):
                 continue
             kernel_bs = kernel_block_sizes[group.kv_cache_group_id]
+            if kernel_bs is None:
+                continue
             ratio = spec.block_size // kernel_bs
             block_dim = group.backend.get_kv_cache_block_dim(
                 kernel_bs,
@@ -362,14 +364,15 @@ def select_common_block_size(
 
 def prepare_kernel_block_sizes(
     kv_cache_config: KVCacheConfig, attn_groups: list[list[AttentionGroup]]
-) -> list[int]:
+) -> list[int | None]:
     """Generate kernel block sizes matching each KV cache group."""
-    kernel_block_sizes = []
+    kernel_block_sizes: list[int | None] = []
     for kv_cache_gid, kv_cache_group in enumerate(kv_cache_config.kv_cache_groups):
         kv_cache_spec = kv_cache_group.kv_cache_spec
         if isinstance(kv_cache_spec, UniformTypeKVCacheSpecs):
             kv_cache_spec = next(iter(kv_cache_spec.kv_cache_specs.values()))
         if isinstance(kv_cache_spec, EncoderOnlyAttentionSpec):
+            kernel_block_sizes.append(None)
             continue
         if isinstance(kv_cache_spec, AttentionSpec):
             kv_manager_block_size = kv_cache_group.kv_cache_spec.block_size


### PR DESCRIPTION
## Summary

- Support serving `DeepSeek-V3.2-W8A8-INT8-Dynamic` on the vLLM 0.19 Kunlun path.
- Add compatibility/fallback paths for dense FlashMLA, MLA prefill/decode, and compressed-tensors W8A8 dynamic INT8 matmul/quantization.
- Add regression coverage for the adapted MLA and quantization paths.

This PR is based on the v0.19 upgrade branch from #315; the new commit adds the DeepSeek V3.2 W8A8 INT8 Dynamic serving adaptation.

Full sanitized logs: https://gist.github.com/Lidang-Jiang/14df1d68a4f9cd17f18a63950cd007ad

<details><summary>Before</summary>

Baseline commit: `864d569`

Service startup failed before the adaptation:

```text
(APIServer pid=165706)   Value error, This model does not support `--runner generate`. [type=value_error, input_value=ArgsKwargs((), {'model': ...nderer_num_workers': 1}), input_type=ArgsKwargs]
```

Client verification:

```text
mode=before
code=864d569
service_log=/workspace/deepseek_v32_before_864d569.log
curl /v1/models:
curl: (7) Failed to connect to 127.0.0.1 port 8566: Connection refused

curl /v1/chat/completions:
curl: (7) Failed to connect to 127.0.0.1 port 8566: Connection refused
```

</details>

<details><summary>After</summary>

Service startup:

```text
(Worker_TP0 pid=166770) INFO 04-24 20:47:36 [default_loader.py:384] Loading weights took 106.27 seconds
(Worker_TP0 pid=166770) INFO 04-24 20:47:37 [gpu_model_runner.py:4820] Model loading took 81.07 GiB memory and 107.374742 seconds
(EngineCore pid=166479) INFO 04-24 20:48:46 [kv_cache_utils.py:1319] GPU KV cache size: 44,352 tokens
(EngineCore pid=166479) INFO 04-24 20:48:46 [kv_cache_utils.py:1324] Maximum concurrency for 32,768 tokens per request: 1.35x
(APIServer pid=166227) INFO:     Application startup complete.
```

Client verification:

```text
mode=after
commit=3dffb27
service_log=/workspace/deepseek_v32_w8a8_p8566.log
curl /health:
200
curl /v1/models:
{"object":"list","data":[{"id":"DeepSeek-V3.2-W8A8-INT8-Dynamic","object":"model","owned_by":"vllm","root":"/models/DeepSeek-V3.2-W8A8-INT8-Dynamic","max_model_len":32768}]}

curl /v1/chat/completions:
HTTP 200, assistant content: 我是DeepSeek，由深度求索公司创造的AI助手！
```

Unit tests:

```text
============================= test session starts ==============================
platform linux -- Python 3.10.15, pytest-8.3.3, pluggy-1.5.0
rootdir: /workspace/vLLM-Kunlun
configfile: pyproject.toml
plugins: typeguard-4.4.1, repeat-0.9.3, anyio-4.6.2.post1, timeout-2.3.1, metadata-3.1.1, html-3.2.0, cov-7.0.0
collected 59 items

tests/ut/test.py ....................................................... [ 93%]
....                                                                     [100%]

============================== 59 passed in 6.91s ==============================
```

</details>

## Test plan

- [x] `/workspace/python310_torch25_cuda/bin/python -m pytest tests/ut/test.py`
- [x] Start service with `DeepSeek-V3.2-W8A8-INT8-Dynamic`
- [x] `curl http://127.0.0.1:8566/health`
- [x] `curl http://127.0.0.1:8566/v1/models`
- [x] `curl http://127.0.0.1:8566/v1/chat/completions`
