### PR TITLE
[Doc] Fix XProfiler benchmark documentation typos

### DIFF
--- a/docs/source/developer_guide/performance/performance_benchmark/benchmark_kernel.md
+++ b/docs/source/developer_guide/performance/performance_benchmark/benchmark_kernel.md
@@ -44,9 +44,9 @@ More parameters can be found in the command-line parameters section later.
 
 The time mode is used to track user programs for a period of time. This method is suitable for tasks that need to run for a long time.
 
-Using the -t or --time command-line parameter, XPorfiler will run for the specified time and then exit, in seconds. In this mode, the application needs to be started separately. An example is as follows:
+Using the -t or --time command-line parameter, XProfiler will run for the specified time and then exit, in seconds. In this mode, the application needs to be started separately. An example is as follows:
 
-(1) Starting XPorfiler
+(1) Starting XProfiler
 
 ```bash
 /xxxx/xxxx/xprofiler -r 500 --xpu=0 -t600 # Time mode collects events within a specified time period, measured in seconds (s).
@@ -63,7 +63,7 @@ export XPU_TRACING_OUTPUT_NAME=<xprofiler execution directory>/xprofiler.sock
 python xxx.py
 ```
 
-#### deamon mode
+#### daemon mode
 
 The daemon mode is used to track the event timeline of a specified code segment, eliminating interference from redundant information. The startup command is the same as in fork mode.
 
@@ -81,9 +81,9 @@ xtorch_ops.kunlun_profiler_start()
 xtorch_ops.kunlun_profiler_end()
 ```
 
-(2) Launch X profiler in a terminal
+(2) Launch XProfiler in a terminal
 
-```python
+```bash
 # Specify the output file as the trace_output file in the current path.
 /xxxx/xxxx/xprofiler-Linux_x86_64-2.0.2.0/bin/xprofiler -r 500 --xpu=0 -e ./trace_output -d
 ```
@@ -96,7 +96,7 @@ xprofiler.sock
 
 (3) Launch your own program on another terminal.
 
-```python
+```bash
 export XPU_ENABLE_PROFILER_TRACING=1
 # Here, the path to the .sock file from step 2 is used for assignment.
 export XPU_TRACING_OUTPUT_NAME=<xprofiler execution directory>/xprofiler.sock


### PR DESCRIPTION
## PR Description

Fix small XProfiler benchmark documentation issues:
- Correct `XPorfiler`/`X profiler` typos to `XProfiler`.
- Correct the `deamon mode` heading to `daemon mode`.
- Mark shell command snippets with `bash` fences instead of `python` fences.

This is documentation-only and does not change the documented CLI option spelling.

---

## Checklist (Required)

- [x] All code changes pass the [`pre-commit`](https://github.com/baidu/vLLM-Kunlun/blob/main/CONTRIBUTING.md) checks.
- [x] Commits are signed off using `git commit -s`.
- [x] The PR title is properly classified.

---

<details>
<summary>Before</summary>

```text
$ check XProfiler benchmark doc on origin/main
misspelled XPorfiler: 2
misspelled deamon heading: 1
spaced X profiler label: 1
xprofiler command block fenced as python: 1
environment shell block fenced as python: 1
result: FAIL
```

</details>

<details>
<summary>After</summary>

```text
$ check XProfiler benchmark doc after patch
misspelled XPorfiler: 0
misspelled deamon heading: 0
spaced X profiler label: 0
xprofiler command block fenced as python: 0
environment shell block fenced as python: 0
result: PASS
$ git diff --check
$ PYTHONWARNINGS=ignore pre-commit run trailing-whitespace --files docs/source/developer_guide/performance/performance_benchmark/benchmark_kernel.md
trim trailing whitespace.................................................Passed
$ PYTHONWARNINGS=ignore pre-commit run end-of-file-fixer --files docs/source/developer_guide/performance/performance_benchmark/benchmark_kernel.md
fix end of files.........................................................Passed
$ PYTHONWARNINGS=ignore pre-commit run pymarkdown --files docs/source/developer_guide/performance/performance_benchmark/benchmark_kernel.md
PyMarkdown...............................................................Passed
```

</details>

## Test plan

- [x] `git diff --check`
- [x] `PYTHONWARNINGS=ignore pre-commit run trailing-whitespace --files docs/source/developer_guide/performance/performance_benchmark/benchmark_kernel.md`
- [x] `PYTHONWARNINGS=ignore pre-commit run end-of-file-fixer --files docs/source/developer_guide/performance/performance_benchmark/benchmark_kernel.md`
- [x] `PYTHONWARNINGS=ignore pre-commit run pymarkdown --files docs/source/developer_guide/performance/performance_benchmark/benchmark_kernel.md`
