### PR TITLE
[Doc] Replace placeholder Docker image tags

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,4 +75,4 @@ Before submitting a pull request, please make sure that:
 By contributing to
 [vLLM Kunlun](https://github.com/baidu/vLLM-Kunlun),
 you agree that your contributions will be licensed under the
-[Apache License 2.0](https://github.com/baidu/vLLM-Kunlun/blob/main/LICENSE.txt).
+[Apache License 2.0](https://github.com/baidu/vLLM-Kunlun/blob/main/LICENSE).

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ By utilizing the vLLM Kunlun plugin, popular open-source models, including Trans
 ---
 ## Supported Models
 
-<h3>Generaltive Models</h3>
+<h3>Generative Models</h3>
 <table>
   <thead>
     <tr>

--- a/docs/source/quick_start.md
+++ b/docs/source/quick_start.md
@@ -20,7 +20,9 @@ if [ $XPU_NUM -gt 0 ]; then
     done
     DOCKER_DEVICE_CONFIG="${DOCKER_DEVICE_CONFIG} --device=/dev/xpuctrl:/dev/xpuctrl"
 fi
-export build_image="xxxxx"
+export build_image="wjie520/vllm_kunlun:uv_base"
+# For Baidu intranet, use:
+# export build_image="iregistry.baidu-int.com/hac_test/aiak-inference-llm:vLLM-Kunlun-Base"
 docker run -itd ${DOCKER_DEVICE_CONFIG} \
     --net=host \
     --cap-add=SYS_PTRACE --security-opt seccomp=unconfined \
@@ -50,7 +52,7 @@ The default working directory is `/workspace`. With the fully provisioned enviro
 
 ```
 #Set environment
-chmod +x /workspace/vllm-kunlun/setup_env.sh && source /workspace/vllm-kunlun/setup_env.sh
+chmod +x /workspace/vLLM-Kunlun/setup_env.sh && source /workspace/vLLM-Kunlun/setup_env.sh
 ```
 
 ## Usage
@@ -138,7 +140,7 @@ if __name__ == "__main__":
 
 vLLM can also be deployed as a server that implements the OpenAI API protocol. Run
 the following command to start the vLLM server with the
-[Qwen3-VL-30B-A3B-Instruct]model:
+Qwen3-VL-30B-A3B-Instruct model:
 
 <!-- tests/e2e/doctest/001-quickstart-test.sh should be considered updating as well -->
 

--- a/docs/source/tutorials/multi_xpu_DeepSeek-V3.2-Exp-w8a8.md
+++ b/docs/source/tutorials/multi_xpu_DeepSeek-V3.2-Exp-w8a8.md
@@ -20,7 +20,9 @@ if [ $XPU_NUM -gt 0 ]; then
     DOCKER_DEVICE_CONFIG="${DOCKER_DEVICE_CONFIG} --device=/dev/xpuctrl:/dev/xpuctrl"
 fi
 
-export build_image="xxx"
+export build_image="wjie520/vllm_kunlun:uv_base"
+# For Baidu intranet, use:
+# export build_image="iregistry.baidu-int.com/hac_test/aiak-inference-llm:vLLM-Kunlun-Base"
 
 docker run -itd ${DOCKER_DEVICE_CONFIG} \
     --net=host \

--- a/docs/source/tutorials/multi_xpu_GLM-5-W8A8-INT8.md
+++ b/docs/source/tutorials/multi_xpu_GLM-5-W8A8-INT8.md
@@ -20,7 +20,9 @@ if [ $XPU_NUM -gt 0 ]; then
     DOCKER_DEVICE_CONFIG="${DOCKER_DEVICE_CONFIG} --device=/dev/xpuctrl:/dev/xpuctrl"
 fi
 
-export build_image="xxx"
+export build_image="wjie520/vllm_kunlun:uv_base"
+# For Baidu intranet, use:
+# export build_image="iregistry.baidu-int.com/hac_test/aiak-inference-llm:vLLM-Kunlun-Base"
 
 docker run -itd ${DOCKER_DEVICE_CONFIG} \
     --net=host \

--- a/docs/source/tutorials/multi_xpu_Qwen2.5-VL-32B.md
+++ b/docs/source/tutorials/multi_xpu_Qwen2.5-VL-32B.md
@@ -16,7 +16,9 @@ if [ $XPU_NUM -gt 0 ]; then
     DOCKER_DEVICE_CONFIG="${DOCKER_DEVICE_CONFIG} --device=/dev/xpuctrl:/dev/xpuctrl"
 fi
 
-export build_image="xxxxxxxxxxxxxxxxx"
+export build_image="wjie520/vllm_kunlun:uv_base"
+# For Baidu intranet, use:
+# export build_image="iregistry.baidu-int.com/hac_test/aiak-inference-llm:vLLM-Kunlun-Base"
 
 docker run -itd ${DOCKER_DEVICE_CONFIG} \
     --net=host \

--- a/docs/source/tutorials/single_xpu_InternVL2_5-26B.md
+++ b/docs/source/tutorials/single_xpu_InternVL2_5-26B.md
@@ -16,7 +16,9 @@ if [ $XPU_NUM -gt 0 ]; then
     DOCKER_DEVICE_CONFIG="${DOCKER_DEVICE_CONFIG} --device=/dev/xpuctrl:/dev/xpuctrl"
 fi
 
-export build_image="xxxxxxxxxxxxxxxxx"
+export build_image="wjie520/vllm_kunlun:uv_base"
+# For Baidu intranet, use:
+# export build_image="iregistry.baidu-int.com/hac_test/aiak-inference-llm:vLLM-Kunlun-Base"
 
 docker run -itd ${DOCKER_DEVICE_CONFIG} \
     --net=host \

--- a/docs/source/tutorials/single_xpu_Qwen3-8B.md
+++ b/docs/source/tutorials/single_xpu_Qwen3-8B.md
@@ -16,7 +16,9 @@ if [ $XPU_NUM -gt 0 ]; then
     DOCKER_DEVICE_CONFIG="${DOCKER_DEVICE_CONFIG} --device=/dev/xpuctrl:/dev/xpuctrl"
 fi
 
-export build_image="xxxxxxxxxxxxxxxxx"
+export build_image="wjie520/vllm_kunlun:uv_base"
+# For Baidu intranet, use:
+# export build_image="iregistry.baidu-int.com/hac_test/aiak-inference-llm:vLLM-Kunlun-Base"
 
 docker run -itd ${DOCKER_DEVICE_CONFIG} \
     --net=host \

--- a/docs/source/tutorials/single_xpu_Qwen3-VL-32B.md
+++ b/docs/source/tutorials/single_xpu_Qwen3-VL-32B.md
@@ -16,7 +16,9 @@ if [ $XPU_NUM -gt 0 ]; then
     DOCKER_DEVICE_CONFIG="${DOCKER_DEVICE_CONFIG} --device=/dev/xpuctrl:/dev/xpuctrl"
 fi
 
-export build_image="xxxxxxxxxxxxxxxxx"
+export build_image="wjie520/vllm_kunlun:uv_base"
+# For Baidu intranet, use:
+# export build_image="iregistry.baidu-int.com/hac_test/aiak-inference-llm:vLLM-Kunlun-Base"
 
 docker run -itd ${DOCKER_DEVICE_CONFIG} \
     --net=host \


### PR DESCRIPTION
## Summary
- Replace placeholder Docker image tags in the quickstart and tutorial container startup examples with the public `wjie520/vllm_kunlun:uv_base` image.
- Add the Baidu intranet image alternative next to those examples, matching the installation guide.
- Fix nearby documentation nits: quickstart setup path, Qwen3-VL model wording, README spelling, and the CONTRIBUTING license link.

N/A (documentation cleanup; no linked issue).

---

## Checklist (Required)

- [x] All code changes pass the `pre-commit` checks.
- [x] Commits are signed off using `git commit -s`.
- [x] The PR title is properly classified.

<details>
<summary>Before</summary>

```console
$ git grep -n -E 'export build_image="x+"|LICENSE\.txt|Generaltive|\]model|/workspace/vllm-kunlun' origin/main -- README.md CONTRIBUTING.md docs/source
origin/main:CONTRIBUTING.md:78:[Apache License 2.0](https://github.com/baidu/vLLM-Kunlun/blob/main/LICENSE.txt).
origin/main:README.md:35:<h3>Generaltive Models</h3>
origin/main:docs/source/quick_start.md:23:export build_image="xxxxx"
origin/main:docs/source/quick_start.md:53:chmod +x /workspace/vllm-kunlun/setup_env.sh && source /workspace/vllm-kunlun/setup_env.sh
origin/main:docs/source/quick_start.md:141:[Qwen3-VL-30B-A3B-Instruct]model:
origin/main:docs/source/tutorials/multi_xpu_DeepSeek-V3.2-Exp-w8a8.md:23:export build_image="xxx"
origin/main:docs/source/tutorials/multi_xpu_GLM-5-W8A8-INT8.md:23:export build_image="xxx"
origin/main:docs/source/tutorials/multi_xpu_Qwen2.5-VL-32B.md:19:export build_image="xxxxxxxxxxxxxxxxx"
origin/main:docs/source/tutorials/single_xpu_InternVL2_5-26B.md:19:export build_image="xxxxxxxxxxxxxxxxx"
origin/main:docs/source/tutorials/single_xpu_Qwen3-8B.md:19:export build_image="xxxxxxxxxxxxxxxxx"
origin/main:docs/source/tutorials/single_xpu_Qwen3-VL-32B.md:19:export build_image="xxxxxxxxxxxxxxxxx"
```

</details>

<details>
<summary>After</summary>

```console
$ rg -n 'export build_image="x+"|LICENSE\.txt|Generaltive|\]model|/workspace/vllm-kunlun' README.md CONTRIBUTING.md docs/source || true

$ pre-commit run --files README.md CONTRIBUTING.md docs/source/quick_start.md docs/source/tutorials/multi_xpu_DeepSeek-V3.2-Exp-w8a8.md docs/source/tutorials/multi_xpu_GLM-5-W8A8-INT8.md docs/source/tutorials/multi_xpu_Qwen2.5-VL-32B.md docs/source/tutorials/single_xpu_InternVL2_5-26B.md docs/source/tutorials/single_xpu_Qwen3-8B.md docs/source/tutorials/single_xpu_Qwen3-VL-32B.md
/workspace/python310_torch25_cuda/lib/python3.10/site-packages/xpytorch_import_hook.py:6: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
  import pkg_resources
fix end of files.........................................................Passed
trim trailing whitespace.................................................Passed
check yaml...........................................(no files to check)Skipped
check toml...........................................(no files to check)Skipped
check for added large files..............................................Passed
ruff check...........................................(no files to check)Skipped
isort................................................(no files to check)Skipped
black................................................(no files to check)Skipped
PyMarkdown...............................................................Passed
Lint GitHub Actions workflow files...................(no files to check)Skipped
Check for spaces in all filenames........................................Passed
Suggestion...............................................................Passed
- hook id: suggestion
- duration: 0s

To bypass pre-commit hooks, add --no-verify to git commit.


$ make -C docs clean html
make: Entering directory '/workspace/vLLM-Kunlun/docs'
/workspace/python310_torch25_cuda/lib/python3.10/site-packages/xpytorch_import_hook.py:6: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
  import pkg_resources
Removing everything under '_build'...
/workspace/python310_torch25_cuda/lib/python3.10/site-packages/xpytorch_import_hook.py:6: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
  import pkg_resources
Running Sphinx v8.1.3
loading translations [en]... done
making output directory... done
[autosummary] generating autosummary for: community/contributors.md, community/governance.md, community/user_stories/index.md, community/versioning_policy.md, developer_guide/contribution/contributing.md, developer_guide/contribution/index.md, developer_guide/evaluation/accuracy/accuracy_kernel.md, developer_guide/evaluation/accuracy/accuracy_server.md, developer_guide/evaluation/accuracy/index.md, developer_guide/evaluation/accuracy_report/GLM-4.5-Air.md, ..., user_guide/configuration/env_vars.md, user_guide/configuration/index.md, user_guide/feature_guide/graph_mode.md, user_guide/feature_guide/index.md, user_guide/feature_guide/lora.md, user_guide/feature_guide/quantization.md, user_guide/release_notes.md, user_guide/support_matrix/index.md, user_guide/support_matrix/supported_features.md, user_guide/support_matrix/supported_models.md
myst v4.0.1: MdParserConfig(commonmark_only=False, gfm_only=False, enable_extensions={'colon_fence', 'substitution'}, disable_syntax=[], all_links_external=False, links_external_new_tab=False, url_schemes=('http', 'https', 'mailto', 'ftp'), ref_domains=None, fence_as_directive=set(), number_code_blocks=[], title_to_header=False, heading_anchors=5, heading_slug_func=None, html_meta={}, footnote_sort=True, footnote_transition=True, words_per_minute=200, substitutions={vllm_version: ..., vllm_kunlun_version: ..., pip_vllm_kunlun_version: ..., pip_vllm_version: ..., ci_vllm_version: ...}, linkify_fuzzy_links=True, dmath_allow_labels=True, dmath_allow_space=True, dmath_allow_digits=True, dmath_double_inline=False, update_mathjax=True, mathjax_classes='tex2jax_process|mathjax_process|math|output_area', enable_checkboxes=False, suppress_warnings=[], highlight_code_blocks=True)
building [mo]: targets for 0 po files that are out of date
writing output... 
building [html]: targets for 45 source files that are out of date
updating environment: [new config] 45 added, 0 changed, 0 removed
reading sources... [  2%] community/contributors
reading sources... [  4%] community/governance
reading sources... [  7%] community/user_stories/index
reading sources... [  9%] community/versioning_policy
reading sources... [ 11%] developer_guide/contribution/contributing
reading sources... [ 13%] developer_guide/contribution/index
reading sources... [ 16%] developer_guide/evaluation/accuracy/accuracy_kernel
reading sources... [ 18%] developer_guide/evaluation/accuracy/accuracy_server
reading sources... [ 20%] developer_guide/evaluation/accuracy/index
reading sources... [ 22%] developer_guide/evaluation/accuracy_report/GLM-4.5
reading sources... [ 24%] developer_guide/evaluation/accuracy_report/GLM-4.5-Air
reading sources... [ 27%] developer_guide/evaluation/accuracy_report/InternVL3_5-30B-A3B
reading sources... [ 29%] developer_guide/evaluation/accuracy_report/Qwen2.5-VL-7B-Instruct
reading sources... [ 31%] developer_guide/evaluation/accuracy_report/index
reading sources... [ 33%] developer_guide/evaluation/index
reading sources... [ 36%] developer_guide/feature_guide/Kunlun_Graph
reading sources... [ 38%] developer_guide/feature_guide/index
reading sources... [ 40%] developer_guide/performance/index
reading sources... [ 42%] developer_guide/performance/performance_benchmark/benchmark_kernel
reading sources... [ 44%] developer_guide/performance/performance_benchmark/benchmark_server
reading sources... [ 47%] developer_guide/performance/performance_benchmark/index
reading sources... [ 49%] developer_guide/performance/performance_benchmark/profiling
reading sources... [ 51%] faqs
reading sources... [ 53%] index
reading sources... [ 56%] installation
reading sources... [ 58%] quick_start
reading sources... [ 60%] tutorials/index
reading sources... [ 62%] tutorials/multi_xpu_DeepSeek-V3.2-Exp-w8a8
reading sources... [ 64%] tutorials/multi_xpu_GLM-4.5
reading sources... [ 67%] tutorials/multi_xpu_GLM-5-W8A8-INT8
reading sources... [ 69%] tutorials/multi_xpu_Qwen2.5-VL-32B
reading sources... [ 71%] tutorials/multi_xpu_Qwen3-Coder-480B-A35B(W8A8)
reading sources... [ 73%] tutorials/single_xpu_InternVL2_5-26B
reading sources... [ 76%] tutorials/single_xpu_Qwen3-8B
reading sources... [ 78%] tutorials/single_xpu_Qwen3-VL-32B
reading sources... [ 80%] user_guide/configuration/env_vars
reading sources... [ 82%] user_guide/configuration/index
reading sources... [ 84%] user_guide/feature_guide/graph_mode
reading sources... [ 87%] user_guide/feature_guide/index
reading sources... [ 89%] user_guide/feature_guide/lora
reading sources... [ 91%] user_guide/feature_guide/quantization
reading sources... [ 93%] user_guide/release_notes
reading sources... [ 96%] user_guide/support_matrix/index
reading sources... [ 98%] user_guide/support_matrix/supported_features
reading sources... [100%] user_guide/support_matrix/supported_models

looking for now-outdated files... none found
pickling environment... done
checking consistency... done
preparing documents... done
copying assets... 
copying static files... 
Writing evaluated template result to /workspace/vLLM-Kunlun/docs/_build/html/_static/language_data.js
Writing evaluated template result to /workspace/vLLM-Kunlun/docs/_build/html/_static/documentation_options.js
Writing evaluated template result to /workspace/vLLM-Kunlun/docs/_build/html/_static/basic.css
Writing evaluated template result to /workspace/vLLM-Kunlun/docs/_build/html/_static/copybutton.js
copying static files: done
copying extra files... 
copying extra files: done
copying assets: done
writing output... [  2%] community/contributors
writing output... [  4%] community/governance
writing output... [  7%] community/user_stories/index
writing output... [  9%] community/versioning_policy
writing output... [ 11%] developer_guide/contribution/contributing
writing output... [ 13%] developer_guide/contribution/index
writing output... [ 16%] developer_guide/evaluation/accuracy/accuracy_kernel
writing output... [ 18%] developer_guide/evaluation/accuracy/accuracy_server
writing output... [ 20%] developer_guide/evaluation/accuracy/index
writing output... [ 22%] developer_guide/evaluation/accuracy_report/GLM-4.5
writing output... [ 24%] developer_guide/evaluation/accuracy_report/GLM-4.5-Air
writing output... [ 27%] developer_guide/evaluation/accuracy_report/InternVL3_5-30B-A3B
writing output... [ 29%] developer_guide/evaluation/accuracy_report/Qwen2.5-VL-7B-Instruct
writing output... [ 31%] developer_guide/evaluation/accuracy_report/index
writing output... [ 33%] developer_guide/evaluation/index
writing output... [ 36%] developer_guide/feature_guide/Kunlun_Graph
writing output... [ 38%] developer_guide/feature_guide/index
writing output... [ 40%] developer_guide/performance/index
writing output... [ 42%] developer_guide/performance/performance_benchmark/benchmark_kernel
writing output... [ 44%] developer_guide/performance/performance_benchmark/benchmark_server
writing output... [ 47%] developer_guide/performance/performance_benchmark/index
writing output... [ 49%] developer_guide/performance/performance_benchmark/profiling
writing output... [ 51%] faqs
writing output... [ 53%] index
writing output... [ 56%] installation
writing output... [ 58%] quick_start
writing output... [ 60%] tutorials/index
writing output... [ 62%] tutorials/multi_xpu_DeepSeek-V3.2-Exp-w8a8
writing output... [ 64%] tutorials/multi_xpu_GLM-4.5
writing output... [ 67%] tutorials/multi_xpu_GLM-5-W8A8-INT8
writing output... [ 69%] tutorials/multi_xpu_Qwen2.5-VL-32B
writing output... [ 71%] tutorials/multi_xpu_Qwen3-Coder-480B-A35B(W8A8)
writing output... [ 73%] tutorials/single_xpu_InternVL2_5-26B
writing output... [ 76%] tutorials/single_xpu_Qwen3-8B
writing output... [ 78%] tutorials/single_xpu_Qwen3-VL-32B
writing output... [ 80%] user_guide/configuration/env_vars
writing output... [ 82%] user_guide/configuration/index
writing output... [ 84%] user_guide/feature_guide/graph_mode
writing output... [ 87%] user_guide/feature_guide/index
writing output... [ 89%] user_guide/feature_guide/lora
writing output... [ 91%] user_guide/feature_guide/quantization
writing output... [ 93%] user_guide/release_notes
writing output... [ 96%] user_guide/support_matrix/index
writing output... [ 98%] user_guide/support_matrix/supported_features
writing output... [100%] user_guide/support_matrix/supported_models

generating indices... genindex done
writing additional pages... search done
copying images... [100%] logos/vllm-kunlun-logo-text-light.png

dumping search index in English (code: en)... done
dumping object inventory... done
build succeeded.

The HTML pages are in _build/html.
make: Leaving directory '/workspace/vLLM-Kunlun/docs'

$ git diff --check
```

</details>

## Test plan

- [x] `rg -n 'export build_image="x+"|LICENSE\.txt|Generaltive|\]model|/workspace/vllm-kunlun' README.md CONTRIBUTING.md docs/source || true`
- [x] `pre-commit run --files README.md CONTRIBUTING.md docs/source/quick_start.md docs/source/tutorials/multi_xpu_DeepSeek-V3.2-Exp-w8a8.md docs/source/tutorials/multi_xpu_GLM-5-W8A8-INT8.md docs/source/tutorials/multi_xpu_Qwen2.5-VL-32B.md docs/source/tutorials/single_xpu_InternVL2_5-26B.md docs/source/tutorials/single_xpu_Qwen3-8B.md docs/source/tutorials/single_xpu_Qwen3-VL-32B.md`
- [x] `make -C docs clean html`
- [x] `git diff --check`
