### PR TITLE
[Doc] Add model source guidance

### DIFF
--- a/docs/source/user_guide/support_matrix/index.md
+++ b/docs/source/user_guide/support_matrix/index.md
@@ -6,5 +6,6 @@ This section provides a detailed matrix supported by vLLM-Kunlun.
 :caption: Support Matrix
 :maxdepth: 1
 supported_models
+model_sources
 supported_features
 :::

--- a/docs/source/user_guide/support_matrix/model_sources.md
+++ b/docs/source/user_guide/support_matrix/model_sources.md
@@ -1,0 +1,75 @@
+<!--
+#
+# Copyright (c) 2026 Baidu, Inc. All Rights Reserved.
+#
+# This file is a part of the vllm-kunlun project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+-->
+
+# Model Source Guidance
+
+This page gives practical guidance for finding and organizing model weights for
+vLLM-Kunlun. It does not imply that vLLM-Kunlun publishes or mirrors weights on
+any specific model hub.
+
+## Supported Model Names and Weight Sources
+
+The supported model matrix describes model families and runtime capabilities. A
+model family name, such as Qwen3 or Qwen3-VL, is not always the same as the
+exact `--model` value used at runtime. The `--model` value should point to the
+actual weight source you have access to.
+
+Common choices include:
+
+- A Hugging Face repository ID, such as `org/model-name`, when the weights are
+  available from Hugging Face and your environment can access that hub.
+- A ModelScope repository ID or a local directory downloaded from ModelScope,
+  when ModelScope is the preferred source in your environment.
+- A private object storage link, such as BOS, if your deployment downloads
+  weights from private storage before starting vLLM-Kunlun.
+- An AI Studio or approved internal source, if your organization provides the
+  model through an internal platform.
+- A local filesystem path, such as `/data/models/qwen3`, after the weights have
+  already been downloaded or mounted on the host.
+
+## Using Local Paths
+
+For reproducible deployments, downloading or mounting the model first and then
+passing a local path to `--model` is often the most explicit option:
+
+```bash
+vllm serve /data/models/qwen3
+```
+
+The local directory should contain the model configuration, tokenizer files, and
+weight files expected by the upstream model format. Keep the directory layout
+compatible with the source from which the model was obtained.
+
+## Mapping Sources to `--model`
+
+Use this checklist when preparing a model:
+
+1. Find the exact model variant that matches the supported model family.
+2. Confirm that you are allowed to access and use the weights from the selected
+   source.
+3. Download, mount, or otherwise make the weights available to the runtime
+   environment.
+4. Pass either the accessible repository ID or the prepared local path as
+   `--model`.
+5. Keep a record of the source, revision, and local path used for deployment so
+   the setup can be reproduced later.
+
+If a model family is listed as supported but no public link is shown in the
+matrix, use the model provider's official distribution channel, your
+organization's approved source, or a local path prepared from those sources.

--- a/docs/source/user_guide/support_matrix/supported_models.md
+++ b/docs/source/user_guide/support_matrix/supported_models.md
@@ -1,5 +1,9 @@
 # Supported Models
 
+For guidance on finding Hugging Face, ModelScope, private object storage,
+approved internal sources, or local filesystem paths for these model families,
+see {doc}`model_sources`.
+
 ## Generative Models
 
 | Model         | Support | W8A8 | LoRA | Tensor Parallel | Expert Parallel | Data Parallel | Piecewise Kunlun Graph |


### PR DESCRIPTION
## Summary
- Add a support-matrix page that explains how to map supported model families to accessible weight sources.
- Link the supported model matrix to the new guidance page.
- Cover Hugging Face, ModelScope, private object storage, approved internal sources, and local filesystem paths without implying that vLLM-Kunlun publishes or mirrors weights.

Related to #343.

<details>
<summary>Before</summary>

```text
$ git ls-tree --name-only origin/main -- docs/source/user_guide/support_matrix/index.md docs/source/user_guide/support_matrix/supported_models.md docs/source/user_guide/support_matrix/model_sources.md
docs/source/user_guide/support_matrix/index.md
docs/source/user_guide/support_matrix/supported_models.md

$ git ls-tree --name-only origin/main -- docs/source/user_guide/support_matrix/model_sources.md || true

$ git show origin/main:docs/source/user_guide/support_matrix/index.md | sed -n "1,14p"
# Features and Models

This section provides a detailed matrix supported by vLLM-Kunlun.

:::{toctree}
:caption: Support Matrix
:maxdepth: 1
supported_models
supported_features
:::

$ git show origin/main:docs/source/user_guide/support_matrix/supported_models.md | sed -n "1,12p"
# Supported Models

## Generative Models

| Model         | Support | W8A8 | LoRA | Tensor Parallel | Expert Parallel | Data Parallel | Piecewise Kunlun Graph |
| :------------ | :------ | :--- | :--- | :-------------- | :-------------- | :------------ | :--------------------- |
| Qwen3         | ✅       | ✅    | ✅    | ✅               |                 | ✅             | ✅                      |
| Qwen3-Moe     | ✅       | ✅    | ✅    | ✅               | ✅               | ✅             | ✅                      |
| Qwen3-Next    | ✅       | ✅    | ✅    | ✅               | ✅               | ✅             | ✅                      |
| Deepseek v3.2 | ✅       | ✅    |      | ✅               |                 | ✅             | ✅                      |

## Multimodal Language Models
```

</details>

<details>
<summary>After</summary>

```text
$ git show --stat --oneline HEAD -- docs/source/user_guide/support_matrix/index.md docs/source/user_guide/support_matrix/supported_models.md docs/source/user_guide/support_matrix/model_sources.md
959fcd7 [Doc] Add model source guidance
 docs/source/user_guide/support_matrix/index.md     |  1 +
 .../user_guide/support_matrix/model_sources.md     | 75 ++++++++++++++++++++++
 .../user_guide/support_matrix/supported_models.md  |  4 ++
 3 files changed, 80 insertions(+)

$ sed -n "1,90p" docs/source/user_guide/support_matrix/model_sources.md
<!--
#
# Copyright (c) 2026 Baidu, Inc. All Rights Reserved.
#
# This file is a part of the vllm-kunlun project.
#
# Licensed under the Apache License, Version 2.0 (the "License");
# you may not use this file except in compliance with the License.
# You may obtain a copy of the License at
#
#     http://www.apache.org/licenses/LICENSE-2.0
#
# Unless required by applicable law or agreed to in writing, software
# distributed under the License is distributed on an "AS IS" BASIS,
# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
# See the License for the specific language governing permissions and
# limitations under the License.
-->

# Model Source Guidance

This page gives practical guidance for finding and organizing model weights for
vLLM-Kunlun. It does not imply that vLLM-Kunlun publishes or mirrors weights on
any specific model hub.

## Supported Model Names and Weight Sources

The supported model matrix describes model families and runtime capabilities. A
model family name, such as Qwen3 or Qwen3-VL, is not always the same as the
exact `--model` value used at runtime. The `--model` value should point to the
actual weight source you have access to.

Common choices include:

- A Hugging Face repository ID, such as `org/model-name`, when the weights are
  available from Hugging Face and your environment can access that hub.
- A ModelScope repository ID or a local directory downloaded from ModelScope,
  when ModelScope is the preferred source in your environment.
- A private object storage link, such as BOS, if your deployment downloads
  weights from private storage before starting vLLM-Kunlun.
- An AI Studio or approved internal source, if your organization provides the
  model through an internal platform.
- A local filesystem path, such as `/data/models/qwen3`, after the weights have
  already been downloaded or mounted on the host.

## Using Local Paths

For reproducible deployments, downloading or mounting the model first and then
passing a local path to `--model` is often the most explicit option:

```bash
vllm serve /data/models/qwen3
```

The local directory should contain the model configuration, tokenizer files, and
weight files expected by the upstream model format. Keep the directory layout
compatible with the source from which the model was obtained.

## Mapping Sources to `--model`

Use this checklist when preparing a model:

1. Find the exact model variant that matches the supported model family.
2. Confirm that you are allowed to access and use the weights from the selected
   source.
3. Download, mount, or otherwise make the weights available to the runtime
   environment.
4. Pass either the accessible repository ID or the prepared local path as
   `--model`.
5. Keep a record of the source, revision, and local path used for deployment so
   the setup can be reproduced later.

If a model family is listed as supported but no public link is shown in the
matrix, use the model provider's official distribution channel, your
organization's approved source, or a local path prepared from those sources.

$ git diff --check origin/main..HEAD

$ PYTHONWARNINGS=ignore::UserWarning sphinx-build -b dummy -n -W --keep-going docs/source /tmp/vllm-kunlun-docs-model-source-pr-dummy
Running Sphinx v8.1.3
loading translations [en]... done
making output directory... done
[autosummary] generating autosummary for: community/contributors.md, community/governance.md, community/user_stories/index.md, community/versioning_policy.md, developer_guide/contribution/contributing.md, developer_guide/contribution/index.md, developer_guide/evaluation/accuracy/accuracy_kernel.md, developer_guide/evaluation/accuracy/accuracy_server.md, developer_guide/evaluation/accuracy/index.md, developer_guide/evaluation/accuracy_report/GLM-4.5-Air.md, ..., user_guide/configuration/index.md, user_guide/feature_guide/graph_mode.md, user_guide/feature_guide/index.md, user_guide/feature_guide/lora.md, user_guide/feature_guide/quantization.md, user_guide/release_notes.md, user_guide/support_matrix/index.md, user_guide/support_matrix/model_sources.md, user_guide/support_matrix/supported_features.md, user_guide/support_matrix/supported_models.md
myst v4.0.1: MdParserConfig(commonmark_only=False, gfm_only=False, enable_extensions={'substitution', 'colon_fence'}, disable_syntax=[], all_links_external=False, links_external_new_tab=False, url_schemes=('http', 'https', 'mailto', 'ftp'), ref_domains=None, fence_as_directive=set(), number_code_blocks=[], title_to_header=False, heading_anchors=5, heading_slug_func=None, html_meta={}, footnote_sort=True, footnote_transition=True, words_per_minute=200, substitutions={vllm_version: ..., vllm_kunlun_version: ..., pip_vllm_kunlun_version: ..., pip_vllm_version: ..., ci_vllm_version: ...}, linkify_fuzzy_links=True, dmath_allow_labels=True, dmath_allow_space=True, dmath_allow_digits=True, dmath_double_inline=False, update_mathjax=True, mathjax_classes='tex2jax_process|mathjax_process|math|output_area', enable_checkboxes=False, suppress_warnings=[], highlight_code_blocks=True)
building [mo]: targets for 0 po files that are out of date
writing output... 
building [dummy]: targets for 46 source files that are out of date
updating environment: [new config] 46 added, 0 changed, 0 removed
reading sources... [  2%] community/contributors
reading sources... [  4%] community/governance
reading sources... [  7%] community/user_stories/index
reading sources... [  9%] community/versioning_policy
reading sources... [ 11%] developer_guide/contribution/contributing
reading sources... [ 13%] developer_guide/contribution/index
reading sources... [ 15%] developer_guide/evaluation/accuracy/accuracy_kernel
reading sources... [ 17%] developer_guide/evaluation/accuracy/accuracy_server
reading sources... [ 20%] developer_guide/evaluation/accuracy/index
reading sources... [ 22%] developer_guide/evaluation/accuracy_report/GLM-4.5
reading sources... [ 24%] developer_guide/evaluation/accuracy_report/GLM-4.5-Air
reading sources... [ 26%] developer_guide/evaluation/accuracy_report/InternVL3_5-30B-A3B
reading sources... [ 28%] developer_guide/evaluation/accuracy_report/Qwen2.5-VL-7B-Instruct
reading sources... [ 30%] developer_guide/evaluation/accuracy_report/index
reading sources... [ 33%] developer_guide/evaluation/index
reading sources... [ 35%] developer_guide/feature_guide/Kunlun_Graph
reading sources... [ 37%] developer_guide/feature_guide/index
reading sources... [ 39%] developer_guide/performance/index
reading sources... [ 41%] developer_guide/performance/performance_benchmark/benchmark_kernel
reading sources... [ 43%] developer_guide/performance/performance_benchmark/benchmark_server
reading sources... [ 46%] developer_guide/performance/performance_benchmark/index
reading sources... [ 48%] developer_guide/performance/performance_benchmark/profiling
reading sources... [ 50%] faqs
reading sources... [ 52%] index
reading sources... [ 54%] installation
reading sources... [ 57%] quick_start
reading sources... [ 59%] tutorials/index
reading sources... [ 61%] tutorials/multi_xpu_DeepSeek-V3.2-Exp-w8a8
reading sources... [ 63%] tutorials/multi_xpu_GLM-4.5
reading sources... [ 65%] tutorials/multi_xpu_GLM-5-W8A8-INT8
reading sources... [ 67%] tutorials/multi_xpu_Qwen2.5-VL-32B
reading sources... [ 70%] tutorials/multi_xpu_Qwen3-Coder-480B-A35B(W8A8)
reading sources... [ 72%] tutorials/single_xpu_InternVL2_5-26B
reading sources... [ 74%] tutorials/single_xpu_Qwen3-8B
reading sources... [ 76%] tutorials/single_xpu_Qwen3-VL-32B
reading sources... [ 78%] user_guide/configuration/env_vars
reading sources... [ 80%] user_guide/configuration/index
reading sources... [ 83%] user_guide/feature_guide/graph_mode
reading sources... [ 85%] user_guide/feature_guide/index
reading sources... [ 87%] user_guide/feature_guide/lora
reading sources... [ 89%] user_guide/feature_guide/quantization
reading sources... [ 91%] user_guide/release_notes
reading sources... [ 93%] user_guide/support_matrix/index
reading sources... [ 96%] user_guide/support_matrix/model_sources
reading sources... [ 98%] user_guide/support_matrix/supported_features
reading sources... [100%] user_guide/support_matrix/supported_models

looking for now-outdated files... none found
pickling environment... done
checking consistency... done
preparing documents... done
copying assets... 
copying assets: done
writing output... [  2%] community/contributors
writing output... [  4%] community/governance
writing output... [  7%] community/user_stories/index
writing output... [  9%] community/versioning_policy
writing output... [ 11%] developer_guide/contribution/contributing
writing output... [ 13%] developer_guide/contribution/index
writing output... [ 15%] developer_guide/evaluation/accuracy/accuracy_kernel
writing output... [ 17%] developer_guide/evaluation/accuracy/accuracy_server
writing output... [ 20%] developer_guide/evaluation/accuracy/index
writing output... [ 22%] developer_guide/evaluation/accuracy_report/GLM-4.5
writing output... [ 24%] developer_guide/evaluation/accuracy_report/GLM-4.5-Air
writing output... [ 26%] developer_guide/evaluation/accuracy_report/InternVL3_5-30B-A3B
writing output... [ 28%] developer_guide/evaluation/accuracy_report/Qwen2.5-VL-7B-Instruct
writing output... [ 30%] developer_guide/evaluation/accuracy_report/index
writing output... [ 33%] developer_guide/evaluation/index
writing output... [ 35%] developer_guide/feature_guide/Kunlun_Graph
writing output... [ 37%] developer_guide/feature_guide/index
writing output... [ 39%] developer_guide/performance/index
writing output... [ 41%] developer_guide/performance/performance_benchmark/benchmark_kernel
writing output... [ 43%] developer_guide/performance/performance_benchmark/benchmark_server
writing output... [ 46%] developer_guide/performance/performance_benchmark/index
writing output... [ 48%] developer_guide/performance/performance_benchmark/profiling
writing output... [ 50%] faqs
writing output... [ 52%] index
writing output... [ 54%] installation
writing output... [ 57%] quick_start
writing output... [ 59%] tutorials/index
writing output... [ 61%] tutorials/multi_xpu_DeepSeek-V3.2-Exp-w8a8
writing output... [ 63%] tutorials/multi_xpu_GLM-4.5
writing output... [ 65%] tutorials/multi_xpu_GLM-5-W8A8-INT8
writing output... [ 67%] tutorials/multi_xpu_Qwen2.5-VL-32B
writing output... [ 70%] tutorials/multi_xpu_Qwen3-Coder-480B-A35B(W8A8)
writing output... [ 72%] tutorials/single_xpu_InternVL2_5-26B
writing output... [ 74%] tutorials/single_xpu_Qwen3-8B
writing output... [ 76%] tutorials/single_xpu_Qwen3-VL-32B
writing output... [ 78%] user_guide/configuration/env_vars
writing output... [ 80%] user_guide/configuration/index
writing output... [ 83%] user_guide/feature_guide/graph_mode
writing output... [ 85%] user_guide/feature_guide/index
writing output... [ 87%] user_guide/feature_guide/lora
writing output... [ 89%] user_guide/feature_guide/quantization
writing output... [ 91%] user_guide/release_notes
writing output... [ 93%] user_guide/support_matrix/index
writing output... [ 96%] user_guide/support_matrix/model_sources
writing output... [ 98%] user_guide/support_matrix/supported_features
writing output... [100%] user_guide/support_matrix/supported_models

build succeeded.

The dummy builder generates no files.
```

</details>

## Test plan
- [x] `git diff --check origin/main..HEAD`
- [x] `PYTHONWARNINGS=ignore::UserWarning sphinx-build -b dummy -n -W --keep-going docs/source /tmp/vllm-kunlun-docs-model-source-pr-dummy`
