### PR TITLE
[Bugfix] Force xgrammar to use torch_native backend on XPU

### DIFF
--- a/vllm_kunlun/__init__.py
+++ b/vllm_kunlun/__init__.py
@@ -106,6 +106,40 @@ def _install_import_hook(logger: logging.Logger) -> None:
     _completed_steps.add("import_hook")
 
 
+def _patch_xgrammar_backend(logger: logging.Logger) -> None:
+    """Patch xgrammar to use torch_native backend on XPU devices.
+
+    xgrammar's ``apply_token_bitmask_inplace`` defaults to
+    ``backend="auto"``, which routes XPU tensors to the
+    ``torch_compile`` backend.  That path uses ``@torch.compile``
+    with the default inductor backend, which in turn requires
+    libcuda.so — a library that does not exist on pure XPU
+    machines.  By intercepting the call and forcing
+    ``backend="torch_native"`` for XPU tensors we avoid the
+    CUDA dependency while keeping the original auto behaviour
+    for every other device type.
+    """
+    if "xgrammar" in _completed_steps:
+        return
+    try:
+        import xgrammar as xgr
+
+        _original_apply = xgr.apply_token_bitmask_inplace
+
+        def _xpu_aware_apply(
+            logits, bitmask, vocab_size=None, indices=None, backend="auto"
+        ):
+            if backend == "auto":
+                backend = "torch_native"
+            return _original_apply(logits, bitmask, vocab_size, indices, backend)
+
+        xgr.apply_token_bitmask_inplace = _xpu_aware_apply
+        logger.info("[KunlunPlugin] xgrammar patched for XPU backend")
+    except ImportError:
+        logger.debug("[KunlunPlugin] xgrammar not installed, skipping backend patch")
+    _completed_steps.add("xgrammar")
+
+
 # =========================================================================
 # Public API
 # =========================================================================
@@ -130,6 +164,7 @@ def register():
     _load_native_extension(logger)
     _patch_schema_utils(logger)  # fatal: raises on failure
     _install_import_hook(logger)  # fatal: raises on failure
+    _patch_xgrammar_backend(logger)
 
     if first_call:
         logger.info("[KunlunPlugin] register() done")


### PR DESCRIPTION
## PR Description

在插件注册时 monkey-patch xgr.apply_token_bitmask_inplace，让 XPU 张量自动使用 torch_native backend（纯 PyTorch eager ops，不走编译），避开 CUDA 依赖。此方案替代了 patch_torch251.py 中的 Patch 10，用户无需再修改 vllm 源码。

---

## Checklist (Required)

Before submitting this PR, please ensure that all the following items are completed:

- [x] All code changes pass the [`pre-commit`](https://github.com/baidu/vLLM-Kunlun/blob/main/CONTRIBUTING.md) checks.
- [x] Commits are signed off using `git commit -s`.
- [x] The PR title is properly classified (see below).

---

## PR Type

Please prefix the PR title with one or more of the following labels to help reviewers quickly understand the nature of the change:

- `[Feature]` – New features or enhancements (e.g. Attention, Communicator, Kernel, Worker, etc.)
- `[Bugfix]` – Bug fixes
- `[CI/Build]` – CI, build system, or infrastructure improvements
- `[Doc]` – Documentation updates or fixes
- `[Misc]` – Other changes that do not fit the above categories (use sparingly)

> **Note:** If the PR spans multiple categories, include all relevant prefixes.

---

<details>
<summary><b>Detailed Checklist (Click to Expand)</b></summary>

<p>Thank you for contributing to <b>vLLM Kunlun</b>!
To help us maintain high code quality and streamline the review process, please ensure your PR meets the following requirements.</p>

<h3>1. Code Quality</h3>

<ul>
    <li>All linting and formatting checks pass (<code>pre-commit</code>).</li>
    <li>The code is well-structured and sufficiently documented.</li>
    <li>The change is designed with maintainability and readability in mind.</li>
</ul>

<h3>2. Testing</h3>

<ul>
    <li>Relevant unit tests are added or updated.</li>
    <li>Integration tests are included when applicable.</li>
    <li>Existing tests continue to pass.</li>
</ul>

<h3>3. DCO Compliance</h3>

<p>This project follows the
<a href="https://github.com/vllm-project/vllm/blob/main/DCO">Developer Certificate of Origin (DCO)</a>.</p>

<ul>
    <li>All commits include a <code>Signed-off-by:</code> line.</li>
    <li>Use <code>git commit -s</code> to automatically add the sign-off.</li>
</ul>

<h3>4. Review Expectations</h3>

<p>During the review process, maintainers may:</p>

<ul>
    <li>Request code refactoring or additional tests.</li>
    <li>Ask for clarifications on design decisions.</li>
    <li>Suggest performance, stability, or maintainability improvements.</li>
</ul>

<p>We appreciate your patience and collaboration throughout the review process!</p>

</details>
