### PR TITLE
[Misc] Bump ray from 2.48.0 to 2.55.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ partial-json-parser==0.2.1.1.post6
 prometheus_client==0.22.1
 pybase64==1.4.1
 pyzmq==27.0.1
-ray==2.48.0
+ray==2.55.1
 setproctitle==1.3.7
 watchfiles==1.1.0
 pydantic==2.11.7


### PR DESCRIPTION
## PR Description

Bump `ray` from `2.48.0` to `2.55.1` in `requirements.txt`.

**Context**

In local testing, `ray==2.48.0` fails to start the Ray cluster, while `ray==2.55.1` works as expected. This PR pins to the verified-working version to unblock local development for contributors hitting the same issue.

`2.55.1` was identified empirically as a known-good version (not a targeted fix for a specific root cause).

**Related issue**

May partially address #331 — the Ray version bump resolves the cluster startup failure observed locally, which appears to overlap with symptoms reported there. It is **not** a complete fix for #331; other aspects of that issue may still require follow-up.

**Scope**

- Single-line version bump in `requirements.txt`
- No code logic changes
- No test changes (deps-only)
---

## Checklist (Required)

- [x] All code changes pass the [`pre-commit`](https://github.com/baidu/vLLM-Kunlun/blob/main/CONTRIBUTING.md) checks.
- [x] Commits are signed off using `git commit -s`.
- [x] The PR title is properly classified (see below).

---

## PR Type

`[Misc]` — dependency version bump.

Refs #331