### PR TITLE
[Bugfix] Use reshape_and_cache for num_kv_heads > 1 in KunlunAttentionImpl

### DIFF
--- a/vllm_kunlun/v1/attention/backends/kunlun_attn.py
+++ b/vllm_kunlun/v1/attention/backends/kunlun_attn.py
@@ -790,14 +790,26 @@ class KunlunAttentionImpl(AttentionImpl[KunlunMetadata]):
                 # If kv_cache is not provided, the new key and value tensors are
                 # not cached. This happens during the initial memory
                 value = value.contiguous()
-                kunlun_ops.reshape_and_cache_flash(
-                    key[: attn_metadata.num_actual_tokens],
-                    value[: attn_metadata.num_actual_tokens],
-                    key_cache,
-                    value_cache,
-                    updated_slot_mapping,
-                    BLHD_LAYOUT=False,
-                )
+                if self.num_kv_heads > 1:
+                    # Note: When num_kv_heads > 1, reshape_and_cache_flash
+                    # has a value_cache write bug; fall back to
+                    # reshape_and_cache instead.
+                    kunlun_ops.reshape_and_cache(
+                        key[: attn_metadata.num_actual_tokens],
+                        value[: attn_metadata.num_actual_tokens],
+                        key_cache,
+                        value_cache,
+                        updated_slot_mapping,
+                    )
+                else:
+                    kunlun_ops.reshape_and_cache_flash(
+                        key[: attn_metadata.num_actual_tokens],
+                        value[: attn_metadata.num_actual_tokens],
+                        key_cache,
+                        value_cache,
+                        updated_slot_mapping,
+                        BLHD_LAYOUT=False,
+                    )
 
         assert attn_type == AttentionType.DECODER
         # Decoder self-attention supports chunked prefill.


### PR DESCRIPTION
## PR Description

`KunlunAttentionImpl.forward` (in `vllm_kunlun/v1/attention/backends/kunlun_attn.py`)
unconditionally calls `kunlun_ops.reshape_and_cache_flash(..., BLHD_LAYOUT=False)`
to write KV cache. However, this BHLD-compat path of the flash op writes
`value_cache` to incorrect slots when `num_kv_heads > 1`.

This caused observable accuracy degradation (model repeating its own output)
under TP=4 + large batch / high concurrency, while TP=8 was unaffected
because every rank only holds `num_kv_heads == 1`, masking the bug.

### Fix

Dispatch on `num_kv_heads`:

- `num_kv_heads > 1` → use `kunlun_ops.reshape_and_cache` (native BHLD layout,
  no compat flag, the same op that the legacy contiguous branch used).
- `num_kv_heads == 1` → keep `kunlun_ops.reshape_and_cache_flash(BLHD_LAYOUT=False)`,
  which is safe in the H=1 degenerate case (e.g. Qwen3-Next hybrid attention).

### Approach

Minimal, localized change in `KunlunAttentionImpl.forward`. Downstream
`paged_attention` / `prefill_attention` calls and the underlying KV cache
allocation are unchanged.

FIX #366 
<!-- Link the existing issue(s) this PR resolves, e.g.:
FIX #1234
-->

---

## Checklist (Required)

Before submitting this PR, please ensure that all the following items are completed:

- [x] All code changes pass the [`pre-commit`](https://github.com/baidu/vLLM-Kunlun/blob/main/CONTRIBUTING.md) checks.
- [x] Commits are signed off using `git commit -s`.
- [x] The PR title is properly classified (see below).

---

## PR Type

Please prefix the PR title with one or more of the following labels to help reviewers quickly understand the nature of the change:

- `[Feature]` – New features or enhancements (e.g. Attention, Communicator, Kernel, Worker, etc.)
- `[Bugfix]` – Bug fixes
- `[CI/Build]` – CI, build system, or infrastructure improvements
- `[Doc]` – Documentation updates or fixes
- `[Misc]` – Other changes that do not fit the above categories (use sparingly)

> **Note:** If the PR spans multiple categories, include all relevant prefixes.

---

<details>
<summary><b>Detailed Checklist (Click to Expand)</b></summary>

<p>Thank you for contributing to <b>vLLM Kunlun</b>!
To help us maintain high code quality and streamline the review process, please ensure your PR meets the following requirements.</p>

<h3>1. Code Quality</h3>

<ul>
    <li>All linting and formatting checks pass (<code>pre-commit</code>).</li>
    <li>The code is well-structured and sufficiently documented.</li>
    <li>The change is designed with maintainability and readability in mind.</li>
</ul>

<h3>2. Testing</h3>

<ul>
    <li>Relevant unit tests are added or updated.</li>
    <li>Integration tests are included when applicable.</li>
    <li>Existing tests continue to pass.</li>
</ul>

<h3>3. DCO Compliance</h3>

<p>This project follows the
<a href="https://github.com/vllm-project/vllm/blob/main/DCO">Developer Certificate of Origin (DCO)</a>.</p>

<ul>
    <li>All commits include a <code>Signed-off-by:</code> line.</li>
    <li>Use <code>git commit -s</code> to automatically add the sign-off.</li>
</ul>

<h3>4. Review Expectations</h3>

<p>During the review process, maintainers may:</p>

<ul>
    <li>Request code refactoring or additional tests.</li>
    <li>Ask for clarifications on design decisions.</li>
    <li>Suggest performance, stability, or maintainability improvements.</li>
</ul>

<p>We appreciate your patience and collaboration throughout the review process!</p>

</details>
