### PR TITLE
[Bugfix] Fix Kimi K2 streaming tool slot initialization

### DIFF
--- a/vllm_kunlun/entrypoints/openai/tool_parsers/kimi_k2_tool_parser.py
+++ b/vllm_kunlun/entrypoints/openai/tool_parsers/kimi_k2_tool_parser.py
@@ -493,10 +493,10 @@ class KimiK2ToolParser(ToolParser):
             # case - we haven't sent the tool name yet. If it's available, send
             #   it. otherwise, wait until it's available.
             if not self.current_tool_name_sent:
-                if current_tool_call is None:
-                    return None
                 function_name: str | None = current_tool_call.get("name")
                 tool_id = current_tool_call.get("id")
+                if not function_name:
+                    return None
 
                 # Validate function name against available tools
                 if request and request.tools:

--- a/vllm_kunlun/entrypoints/openai/tool_parsers/kimi_k2_tool_parser.py
+++ b/vllm_kunlun/entrypoints/openai/tool_parsers/kimi_k2_tool_parser.py
@@ -99,6 +99,12 @@ class KimiK2ToolParser(ToolParser):
                 "tokens in the tokenizer!"
             )
 
+    def _ensure_current_tool_slots(self) -> None:
+        while len(self.streamed_args_for_tool) <= self.current_tool_id:
+            self.streamed_args_for_tool.append("")
+        while len(self.prev_tool_call_arr) <= self.current_tool_id:
+            self.prev_tool_call_arr.append({})
+
     def _check_and_strip_markers(self, text: str) -> tuple[str, bool, bool]:
         """
         Check for section begin/end markers in text and strip them.
@@ -405,6 +411,7 @@ class KimiK2ToolParser(ToolParser):
                     if deferred_section_exit and self.in_tool_section:
                         self._reset_section_state()
                     return None
+                self._ensure_current_tool_slots()
                 diff = self.prev_tool_call_arr[self.current_tool_id].get("arguments")
                 if diff:
                     diff = (
@@ -424,6 +431,7 @@ class KimiK2ToolParser(ToolParser):
                         "been streamed yet: %s",
                         diff,
                     )
+                    self._ensure_current_tool_slots()
                     self.streamed_args_for_tool[self.current_tool_id] += diff
                     # Handle deferred section exit before returning
                     if deferred_section_exit and self.in_tool_section:
@@ -548,10 +556,7 @@ class KimiK2ToolParser(ToolParser):
                 "Trying to parse current tool call with ID %s", self.current_tool_id
             )
 
-            # if we're starting a new tool call, push an empty object in as
-            #   a placeholder for the arguments
-            if len(self.prev_tool_call_arr) <= self.current_tool_id:
-                self.prev_tool_call_arr.append({})
+            self._ensure_current_tool_slots()
 
             # main logic for tool parsing here - compare prev. partially-parsed
             #   JSON to the current partially-parsed JSON


### PR DESCRIPTION
## PR Description

This PR fixes a state initialization issue in the Kimi K2 streaming tool parser.

During streaming tool call parsing, `streamed_args_for_tool` and `prev_tool_call_arr` are both indexed by `current_tool_id`. Previously, only `prev_tool_call_arr` was initialized in one path, while other paths could access either array before the corresponding slot existed. This could lead to inconsistent parser state or index errors when handling streamed tool calls.

The change introduces a shared `_ensure_current_tool_slots()` helper to ensure both per-tool state arrays have slots for the current tool call before they are accessed. The streaming parsing paths now call this helper consistently before reading or updating tool-call state.

---

## Checklist (Required)

Before submitting this PR, please ensure that all the following items are completed:

- [x] All code changes pass the [`pre-commit`](https://github.com/baidu/vLLM-Kunlun/blob/main/CONTRIBUTING.md) checks.
- [x] Commits are signed off using `git commit -s`.
- [x] The PR title is properly classified (see below).

---

## PR Type

Please prefix the PR title with one or more of the following labels to help reviewers quickly understand the nature of the change:

- `[Feature]` – New features or enhancements (e.g. Attention, Communicator, Kernel, Worker, etc.)
- `[Bugfix]` – Bug fixes
- `[CI/Build]` – CI, build system, or infrastructure improvements
- `[Doc]` – Documentation updates or fixes
- `[Misc]` – Other changes that do not fit the above categories (use sparingly)

> **Note:** If the PR spans multiple categories, include all relevant prefixes.

---

<details>
<summary><b>Detailed Checklist (Click to Expand)</b></summary>

<p>Thank you for contributing to <b>vLLM Kunlun</b>!
To help us maintain high code quality and streamline the review process, please ensure your PR meets the following requirements.</p>

<h3>1. Code Quality</h3>

<ul>
    <li>All linting and formatting checks pass (<code>pre-commit</code>).</li>
    <li>The code is well-structured and sufficiently documented.</li>
    <li>The change is designed with maintainability and readability in mind.</li>
</ul>

<h3>2. Testing</h3>

<ul>
    <li>Relevant unit tests are added or updated.</li>
    <li>Integration tests are included when applicable.</li>
    <li>Existing tests continue to pass.</li>
</ul>

<h3>3. DCO Compliance</h3>

<p>This project follows the
<a href="https://github.com/vllm-project/vllm/blob/main/DCO">Developer Certificate of Origin (DCO)</a>.</p>

<ul>
    <li>All commits include a <code>Signed-off-by:</code> line.</li>
    <li>Use <code>git commit -s</code> to automatically add the sign-off.</li>
</ul>

<h3>4. Review Expectations</h3>

<p>During the review process, maintainers may:</p>

<ul>
    <li>Request code refactoring or additional tests.</li>
    <li>Ask for clarifications on design decisions.</li>
    <li>Suggest performance, stability, or maintainability improvements.</li>
</ul>

<p>We appreciate your patience and collaboration throughout the review process!</p>

</details>