### PR TITLE
[Bugfix] Remove an unreachable branch in Kunlun attention backend selection.

### DIFF
--- a/vllm_kunlun/platforms/kunlun.py
+++ b/vllm_kunlun/platforms/kunlun.py
@@ -273,14 +273,10 @@ class KunlunPlatform(Platform):
                     "FlashMLASparseBackend"
                 )
             return "vllm_kunlun.v1.attention.backends.mla.flashmla.FlashMLABackend"
-        elif not attn_selector_config.use_mla:
-            return (
-                "vllm_kunlun.v1.attention.backends.kunlun_attn.KunlunAttentionBackend"
-            )
-        else:
-            return (
-                "vllm_kunlun.v1.attention.backends.kunlun_mla.KunlunMLAAttentionBackend"
-            )
+
+        return (
+            "vllm_kunlun.v1.attention.backends.kunlun_attn.KunlunAttentionBackend"
+        )
 
     @classmethod
     def get_current_memory_usage(


### PR DESCRIPTION
## PR Description

`use_mla` and `not use_mla` already cover all valid cases, so the final `else` branch can never be reached. This change simplifies the control flow while preserving the existing behavior:

- MLA + sparse -> `FlashMLASparseBackend`
- MLA + non-sparse -> `FlashMLABackend`
- non-MLA -> `KunlunAttentionBackend`
