### PR TITLE
Support Step3.5 compressed tensors MoE compatibility

### DIFF
--- a/docs/source/tutorials/index.md
+++ b/docs/source/tutorials/index.md
@@ -10,5 +10,6 @@ multi_xpu_Qwen2.5-VL-32B
 multi_xpu_GLM-4.5
 multi_xpu_Qwen3-Coder-480B-A35B(W8A8)
 multi_xpu_DeepSeek-V3.2-Exp-w8a8
+multi_xpu_Step-3.5-Flash
 multi_xpu_GLM-5-W8A8-INT8
 :::

--- a/docs/source/tutorials/multi_xpu_Step-3.5-Flash.md
+++ b/docs/source/tutorials/multi_xpu_Step-3.5-Flash.md
@@ -1,0 +1,148 @@
+# Multi XPU (Step-3.5-Flash)
+
+## Run vllm-kunlun on Multi XPU
+
+Setup environment using container:
+
+Please follow the [installation.md](../installation.md) document to set up the environment first.
+
+Create a container
+
+```bash
+# !/bin/bash
+# rundocker.sh
+XPU_NUM=8
+DOCKER_DEVICE_CONFIG=""
+if [ $XPU_NUM -gt 0 ]; then
+    for idx in $(seq 0 $((XPU_NUM-1))); do
+        DOCKER_DEVICE_CONFIG="${DOCKER_DEVICE_CONFIG} --device=/dev/xpu${idx}:/dev/xpu${idx}"
+    done
+    DOCKER_DEVICE_CONFIG="${DOCKER_DEVICE_CONFIG} --device=/dev/xpuctrl:/dev/xpuctrl"
+fi
+
+export build_image="xxx"
+
+docker run -itd ${DOCKER_DEVICE_CONFIG} \
+    --net=host \
+    --cap-add=SYS_PTRACE --security-opt seccomp=unconfined \
+    --tmpfs /dev/shm:rw,nosuid,nodev,exec,size=32g \
+    --cap-add=SYS_PTRACE \
+    -v /home/users/vllm-kunlun:/home/vllm-kunlun \
+    -v /usr/local/bin/xpu-smi:/usr/local/bin/xpu-smi \
+    --name "$1" \
+    -w /workspace \
+    "$build_image" /bin/bash
+```
+
+### Preparation Weight
+
+- Pull Step-3.5-Flash-W8A8-Dynamic weights and place them under `/home/step3p5/Step-3.5-Flash-W8A8-Dynamic/Step-3.5-Flash-W8A8-Dynamic-mlp-3d`
+
+- Ensure that the field `"quantization_config"` is included in `config.json`. If not, deployment will result in an OOM (Out of Memory) error.
+
+```bash
+vim /home/step3p5/Step-3.5-Flash-W8A8-Dynamic/Step-3.5-Flash-W8A8-Dynamic-mlp-3d/config.json
+```
+
+```json
+"quantization_config": {
+    "config_groups": {
+      "W8A8": {
+        "format": "int-quantized",
+        "input_activations": {
+          "actorder": null,
+          "block_structure": null,
+          "dynamic": true,
+          "group_size": null,
+          "num_bits": 8,
+          "observer": null,
+          "observer_kwargs": {},
+          "scale_dtype": null,
+          "strategy": "token",
+          "symmetric": true,
+          "type": "int",
+          "zp_dtype": null
+        },
+        "output_activations": null,
+        "targets": [
+          "Linear"
+        ],
+        "weights": {
+          "actorder": null,
+          "block_structure": null,
+          "dynamic": false,
+          "group_size": null,
+          "num_bits": 8,
+          "observer": "memoryless_minmax",
+          "observer_kwargs": {},
+          "scale_dtype": null,
+          "strategy": "channel",
+          "symmetric": true,
+          "type": "int",
+          "zp_dtype": null
+        }
+      }
+    },
+    "format": "int-quantized",
+    "global_compression_ratio": null,
+    "ignore": [
+      "lm_head",
+      "re:.*share_expert.*",
+      "re:.*self_attn.*",
+      "re:.*norm.*",
+      "re:.*eh_proj.*",
+      "re:.*transformer.*",
+      "re:.*embed_tokens.*",
+      "re:.*moe\\.gate$",
+      "re:.*mlp*"
+    ],
+    "kv_cache_scheme": null,
+    "quant_method": "compressed-tensors",
+    "quantization_status": "compressed",
+    "sparsity_config": {},
+    "transform_config": {},
+    "version": "0.14.0.1"
+  },
+```
+
+### Online Serving on Multi XPU
+
+Start the vLLM server on multi XPU:
+
+```bash
+unset XPU_DUMMY_EVENT
+export CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
+export XFT_USE_FAST_SWIGLU=1         # 使用快速 swiglu 实现
+export XPU_USE_FAST_SWIGLU=1         # 使用 MoE 算子中快速 swiglu 实现
+export XMLIR_CUDNN_ENABLED=1
+export XPU_USE_DEFAULT_CTX=1
+export XMLIR_FORCE_USE_XPU_GRAPH=1
+export XPU_USE_MOE_SORTED_THRES=128
+export VLLM_HOST_IP=127.0.0.1
+export XMLIR_ENABLE_MOCK_TORCH_COMPILE=false
+export VLLM_USE_V1=1
+export USE_ORI_ROPE=1
+export KUNLUN_DISABLE_SMALL_MOE=1    # Step-3.5-Flash temporary fix
+export XMLIR_DYNAMO_WORKAROUND=1
+export LD_LIBRARY_PATH=/home/step3p5/xmlir_runtime_links:$LD_LIBRARY_PATH
+
+python -m vllm.entrypoints.openai.api_server \
+      --host 0.0.0.0 \
+      --port 8356 \
+      --model /home/step3p5/Step-3.5-Flash-W8A8-Dynamic/Step-3.5-Flash-W8A8-Dynamic-mlp-3d \
+      --gpu-memory-utilization 0.9 \
+      --trust-remote-code \
+      --max-model-len 131072 \
+      --tensor-parallel-size 8 \
+      --dtype float16 \
+      --max_num_seqs 128 \
+      --max_num_batched_tokens 32768 \
+      --block-size 128 \
+      --no-enable-prefix-caching \
+      --enable-chunked-prefill \
+      --distributed-executor-backend mp \
+      --served-model-name Step-3.5-Flash \
+      --reasoning-parser step3p5 \
+      --enable-auto-tool-choice \
+      --tool-call-parser step3p5
+```

--- a/vllm_kunlun/ops/_custom_ops.py
+++ b/vllm_kunlun/ops/_custom_ops.py
@@ -716,6 +716,20 @@ def silu_and_mul_cuda(
     )
 
 
+@custom_op("_C::swiglustep", mutates_args=())
+def swiglustep(
+    out: torch.Tensor, x: torch.Tensor, limit: float, axis: int = -1, turn: bool = True
+) -> None:
+    kunlun_ops.swiglustep(x=x, y=out, limit=limit)
+
+
+@impl("_C::swiglustep", "CUDA")
+def swiglustep_cuda(
+    out: torch.Tensor, x: torch.Tensor, limit: float, axis: int = -1, turn: bool = True
+) -> None:
+    kunlun_ops.swiglustep(x=x, y=out, limit=limit)
+
+
 def _fake_silu_and_mul(
     out: torch.Tensor, x: torch.Tensor, axis: int = -1, turn: bool = True
 ):

--- a/vllm_kunlun/ops/_kunlun_ops.py
+++ b/vllm_kunlun/ops/_kunlun_ops.py
@@ -17,6 +17,7 @@
 
 """kunlun custom op entry"""
 
+import os
 from typing import Optional
 
 import cocopod  # noqa
@@ -25,6 +26,7 @@ import xspeedgate_ops  # noqa
 from vllm.logger import init_logger
 from vllm.v1.worker.workspace import current_workspace_manager
 
+DISABLE_SMALL_MOE = os.environ.get("KUNLUN_DISABLE_SMALL_MOE", "0") == "1"
 logger = init_logger(__name__)
 
 try:
@@ -139,6 +141,18 @@ class KunlunOps:
             axis=-1,
             turn=True,
             out=out,
+        )
+
+    # Activation ops
+    @staticmethod
+    def swiglustep(out: torch.Tensor, x: torch.Tensor, limit: float):
+        """swiglustep"""
+        kunlun_ops.swiglustep(
+            x,
+            axis=-1,
+            turn=True,
+            out=out,
+            limit=limit,
         )
 
     # Activation ops
@@ -391,6 +405,8 @@ class KunlunOps:
         w2_bias: Optional[torch.Tensor] = None,
         scoring_func: str = "softmax",
         e_score_correction_bias: Optional[torch.Tensor] = None,
+        routed_scaling_factor: float = 1.0,
+        activation: str = "silu",
     ) -> torch.Tensor:
         """fused_moe"""
         global_num_experts, up_gate_size, _ = w1.shape
@@ -419,15 +435,30 @@ class KunlunOps:
                 stable=False,
             )
         elif scoring_func == "sigmoid":
+            if use_grouped_topk:
+                if num_expert_group is None or topk_group is None:
+                    raise ValueError("num_expert_group and topk_group must be set")
+                n_group = int(num_expert_group)
+                n_topk_group = int(topk_group)
+                if n_group <= 0 or n_topk_group <= 0:
+                    raise ValueError("num_expert_group and topk_group must be positive")
+                if n_topk_group > n_group:
+                    raise ValueError(
+                        "topk_group must be less than or equal to num_expert_group"
+                    )
+            else:
+                n_group = 1
+                n_topk_group = 1
+
             torch.ops._C.moe_sigmoid_group_topk_norm(
                 x=router_logits,
                 topk_index=topk_ids,
                 norm_score=normed_score,
                 block_static=block_statistic,
                 bias=e_score_correction_bias,
-                scale=1.0,
-                n_group=num_expert_group,
-                topk_group=topk_group,
+                scale=routed_scaling_factor,
+                n_group=n_group,
+                topk_group=n_topk_group,
             )
 
         if w1_bias is not None or w2_bias is not None:
@@ -475,7 +506,7 @@ class KunlunOps:
             #     attn_metadata = attn_metadata[prefix]
 
             # if attn_metadata is None or attn_metadata.num_prefills > 0 or :
-            if M * moe_top_k < 400:
+            if M * moe_top_k < 400 and not DISABLE_SMALL_MOE:
                 sorted_tokens_idx, sorted_tokens_num_lod, moe_expand = (
                     torch.ops.xspeedgate_ops.moe_pre_small(
                         topk_ids, global_num_experts, False, False, hidden_states
@@ -518,7 +549,7 @@ class KunlunOps:
             workspace_a_numel = out_numel
             workspace_b_numel = y_numel
 
-            if M < 1024:
+            if M < 1024 or activation == "swiglustep":
                 workspace_a_numel = out1_numel
                 workspace_b_numel = max(y_numel, out_numel)
 
@@ -574,7 +605,7 @@ class KunlunOps:
             moe_expand = moe_expand.reshape(M * moe_top_k, hidden_dim)
             y = workspace_b[:y_numel].view(M, moe_top_k, w1.shape[1])
 
-            if M < 1024:
+            if M < 1024 or activation == "swiglustep":
                 torch.ops._C.moe_fc(
                     x=moe_expand,
                     weight=w1,
@@ -586,7 +617,10 @@ class KunlunOps:
                 # Reuse `workspace_a` for `out1` after `moe_expand` is no longer
                 # needed.
                 out1 = workspace_a[:out1_numel].view(M, moe_top_k, w1.shape[1] // 2)
-                torch.ops._C.silu_and_mul(out1, y)
+                if activation == "swiglustep":
+                    torch.ops._C.swiglustep(out1, y)
+                else:
+                    torch.ops._C.silu_and_mul(out1, y)
                 out1 = out1.reshape(-1, out1.shape[-1])
                 # Reuse `workspace_b` for `out` after `y` has been consumed by
                 # the activation.

--- a/vllm_kunlun/ops/fused_moe/layer.py
+++ b/vllm_kunlun/ops/fused_moe/layer.py
@@ -38,6 +38,7 @@ class KunlunUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod):
         layer,
         x: torch.Tensor,
         router_logits: torch.Tensor,
+        routed_scaling_factor: float = 1.0,
     ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
         """
         Monolithic mode entry point.
@@ -78,4 +79,8 @@ class KunlunUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod):
                 e_score_correction_bias=layer.e_score_correction_bias,
                 w1_bias=getattr(layer, "w13_bias", None),
                 w2_bias=getattr(layer, "w2_bias", None),
+                routed_scaling_factor=getattr(
+                    layer, "routed_scaling_factor", routed_scaling_factor
+                ),
+                activation=getattr(layer, "activation", "silu"),
             )

--- a/vllm_kunlun/quantization/compressed_tensors/compressed_tensors_moe.py
+++ b/vllm_kunlun/quantization/compressed_tensors/compressed_tensors_moe.py
@@ -136,12 +136,20 @@ class KunlunCompressedTensorsW8A8Int8MoEMethod(CompressedTensorsW8A8Int8MoEMetho
         # Read correct config from FusedMoE layer attributes (MiniMax-M2.7 fix)
         if hasattr(layer, "scoring_func") and scoring_func == "softmax":
             scoring_func = layer.scoring_func
-        if hasattr(layer, "e_score_correction_bias") and e_score_correction_bias is None:
+        if (
+            hasattr(layer, "e_score_correction_bias")
+            and e_score_correction_bias is None
+        ):
             e_score_correction_bias = layer.e_score_correction_bias
         if hasattr(layer, "num_expert_group") and num_expert_group is None:
             num_expert_group = layer.num_expert_group
         if hasattr(layer, "topk_group") and topk_group is None:
             topk_group = layer.topk_group
+        # Step-3.5-Flash fix
+        routed_scaling_factor = getattr(
+            layer, "routed_scaling_factor", routed_scaling_factor
+        )
+        activation = getattr(layer, "activation", "silu")
 
         global_num_experts, up_gate_size, _ = layer.w13_weight.shape
         M, N = hidden_states.shape
@@ -169,14 +177,21 @@ class KunlunCompressedTensorsW8A8Int8MoEMethod(CompressedTensorsW8A8Int8MoEMetho
                 stable=True,
             )
         elif scoring_func == "sigmoid":
+            # 与 ops.fused_moe 保持一致：use_grouped_topk=False 时用 n_group=1, topk_group=1
+            if num_expert_group is not None and topk_group is not None:
+                n_group = int(num_expert_group)
+                n_topk_group = int(topk_group)
+            else:
+                n_group = 1
+                n_topk_group = 1
             torch.ops._C.moe_sigmoid_group_topk_norm(
                 x=router_logits,
                 norm_score=normed_score,
                 topk_index=topk_ids,
                 block_static=block_statistic,
                 bias=e_score_correction_bias,
-                n_group=num_expert_group,
-                topk_group=topk_group,
+                n_group=n_group,
+                topk_group=n_topk_group,
                 scale=routed_scaling_factor,
             )
 
@@ -251,8 +266,10 @@ class KunlunCompressedTensorsW8A8Int8MoEMethod(CompressedTensorsW8A8Int8MoEMetho
         d = y.shape[-1] // 2
         output_shape = y.shape[:-1] + (d,)
         out1 = torch.empty(output_shape, dtype=y.dtype, device=y.device)
-        torch.ops._C.silu_and_mul(out1, y)
-
+        if activation == "swiglustep":
+            torch.ops._C.swiglustep(out1, y)
+        else:
+            torch.ops._C.silu_and_mul(out1, y)
         del y
 
         out1 = out1.reshape(-1, out1.shape[-1])


### PR DESCRIPTION
## Summary

This PR adds compatibility support for **Step-3.5-Flash** model in the MoE (Mixture of Experts) path, covering both unquantized and W8A8 Int8 quantized scenarios.

## Changes

### `vllm_kunlun/quantization/compressed_tensors/compressed_tensors_moe.py`
- Read `routed_scaling_factor` and `activation` from layer attributes to support Step-3.5-Flash config
- Fix `e_score_correction_bias` attribute guard to avoid `AttributeError`
- When `use_grouped_topk=False`, default `n_group=1, topk_group=1` to stay consistent with `ops.fused_moe`
- Support `swiglustep` activation: dispatch to `torch.ops._C.swiglustep` instead of `silu_and_mul`

### `vllm_kunlun/ops/fused_moe/layer.py`
- Pass `routed_scaling_factor` and `activation` through `KunlunUnquantizedFusedMoEMethod.apply()`, reading from layer attributes with safe defaults

### `vllm_kunlun/ops/_kunlun_ops.py`
- Add `KUNLUN_DISABLE_SMALL_MOE` env flag to optionally disable small-MoE fast path
- Add `KunlunOps.swiglustep()` static method wrapping `kunlun_ops.swiglustep`
- Thread `routed_scaling_factor` and `activation` into `fused_moe` kernel dispatch
- Add validation for `num_expert_group` / `topk_group` when `use_grouped_topk=True`
- Branch on `activation == "swiglustep"` in both small-MoE and large-MoE paths

### `vllm_kunlun/ops/_custom_ops.py`
- Register `_C::swiglustep` as a custom op with CUDA implementation, wrapping `kunlun_ops.swiglustep`

### `docs/source/tutorials/multi_xpu_Step-3.5-Flash.md`
- Add deployment guide for Step-3.5-Flash on multi XPU, including container setup, weight preparation, quantization config check, and serving launch command

## Test

- [ ] Verified unquantized MoE path with Step-3.5-Flash config
- [ ] Verified W8A8 Int8 quantized MoE path with Step-3.5-Flash config
