### PR TITLE
[Feature] Support Qwen3.5 MoE MTP speculative decoding

### DIFF
--- a/vllm_kunlun/__init__.py
+++ b/vllm_kunlun/__init__.py
@@ -18,6 +18,7 @@ _MODULE_MAPPINGS = {
     "vllm.v1.sample.ops.topk_topp_sampler": "vllm_kunlun.v1.sample.ops.topk_topp_sampler",
     "vllm.v1.sample.rejection_sampler": "vllm_kunlun.v1.sample.rejection_sampler",
     "vllm.attention.ops.merge_attn_states": "vllm_kunlun.ops.attention.merge_attn_states",
+    "vllm.v1.attention.backends.gdn_attn": "vllm_kunlun.v1.attention.backends.gdn_attn",
     "vllm.model_executor.models.config": "vllm_kunlun.models.config",
 }
 
@@ -25,6 +26,96 @@ _MODULE_MAPPINGS = {
 # =========================================================================
 # Logger
 # =========================================================================
+
+
+def _apply_mamba_spec_patch(mamba_abstract_module) -> None:
+    """Patch MambaBase.get_kv_cache_spec to allow qwen3_5_moe with MTP.
+
+    Upstream vLLM only whitelists "qwen3_next" for mamba + speculative decoding.
+    Imports are kept local to avoid triggering a circular import of vllm.config
+    when this runs during plugin registration.
+    """
+    from vllm.v1.kv_cache_interface import MambaSpec
+
+    _ALLOWED = {"qwen3_next", "qwen3_5_moe"}
+
+    def _patched_get_kv_cache_spec(self, vllm_config):
+        if (
+            vllm_config.speculative_config is not None
+            and vllm_config.model_config.hf_config.model_type not in _ALLOWED
+        ):
+            raise NotImplementedError(
+                "Mamba with speculative decoding is not supported yet."
+            )
+        cache_config = vllm_config.cache_config
+        return MambaSpec(
+            shapes=self.get_state_shape(),
+            dtypes=self.get_state_dtype(),
+            block_size=cache_config.mamba_block_size,
+            page_size_padded=cache_config.mamba_page_size_padded,
+            mamba_type=self.mamba_type,
+            mamba_cache_mode=cache_config.mamba_cache_mode,
+            num_speculative_blocks=(
+                vllm_config.speculative_config.num_speculative_tokens
+                if vllm_config.speculative_config is not None
+                else 0
+            ),
+        )
+
+    mamba_abstract_module.MambaBase.get_kv_cache_spec = _patched_get_kv_cache_spec
+
+
+def _apply_qwen35_mtp_speculative_patch(speculative_module) -> None:
+    """Patch SpeculativeConfig to recognize Qwen3.5 MoE MTP drafts.
+
+    This is intentionally narrow: only the verified Qwen3.5 MoE target is
+    mapped to the local MTP draft implementation.
+    """
+    if getattr(speculative_module, "_kunlun_qwen35_mtp_patched", False):
+        return
+
+    from typing import Literal, get_args
+
+    mtp_types = get_args(speculative_module.MTPModelTypes)
+    if "qwen3_5_mtp" not in mtp_types:
+        speculative_module.MTPModelTypes = Literal.__getitem__(
+            mtp_types + ("qwen3_5_mtp",)
+        )
+
+    spec_config_cls = speculative_module.SpeculativeConfig
+    original_hf_config_override = spec_config_cls.hf_config_override
+
+    def _patched_hf_config_override(hf_config):
+        hf_config = original_hf_config_override(hf_config)
+        if hf_config.model_type == "qwen3_5_moe":
+            text_config = getattr(hf_config, "text_config", None)
+            n_predict = getattr(hf_config, "mtp_num_hidden_layers", None)
+            if n_predict is None:
+                n_predict = getattr(text_config, "mtp_num_hidden_layers", None)
+            hf_config.model_type = "qwen3_5_mtp"
+            hf_config.update(
+                {
+                    "n_predict": n_predict,
+                    "architectures": ["Qwen3_5MoeMTP"],
+                }
+            )
+        return hf_config
+
+    spec_config_cls.hf_config_override = staticmethod(_patched_hf_config_override)
+    speculative_module._kunlun_qwen35_mtp_patched = True
+
+
+def _apply_mtp_mamba_state_patch(module_name: str) -> None:
+    if module_name != "vllm.v1.worker.gpu_model_runner":
+        return
+    try:
+        from vllm_kunlun.v1.worker import mtp_mamba_state_patch
+
+        mtp_mamba_state_patch.patch_gpu_model_runner_module(sys.modules[module_name])
+    except Exception:
+        logging.getLogger("vllm_kunlun").exception(
+            "[KunlunPlugin] MTP Mamba state patch failed for %s", module_name
+        )
 
 
 def _configure_kunlun_logger() -> logging.Logger:
@@ -48,19 +139,56 @@ def _configure_kunlun_logger() -> logging.Logger:
 
 def _custom_import(module_name, globals=None, locals=None, fromlist=(), level=0):
     try:
-        if module_name in _MODULE_MAPPINGS:
-            if module_name in sys.modules:
-                return sys.modules[module_name]
+        if module_name in _MODULE_MAPPINGS and module_name not in sys.modules:
             target_module = _MODULE_MAPPINGS[module_name]
-            module = importlib.import_module(target_module)
-            sys.modules[module_name] = module
-            sys.modules[target_module] = module
+            mapped = importlib.import_module(target_module)
+            sys.modules[module_name] = mapped
+            sys.modules[target_module] = mapped
     except Exception:
         pass
 
-    return OLD_IMPORT_HOOK(
+    module = OLD_IMPORT_HOOK(
         module_name, globals=globals, locals=locals, fromlist=fromlist, level=level
     )
+
+    # Lazy patch for MambaBase.get_kv_cache_spec. Importing this module during
+    # register() triggers `from vllm.config import VllmConfig` while vllm.config
+    # is still initializing.
+    if (
+        module_name == "vllm.model_executor.layers.mamba.abstract"
+        and not getattr(_custom_import, "_mamba_spec_patched", False)
+    ):
+        _custom_import._mamba_spec_patched = True
+        try:
+            _apply_mamba_spec_patch(module)
+            logging.getLogger("vllm_kunlun").info(
+                "[KunlunPlugin] lazy-patched MambaBase.get_kv_cache_spec"
+            )
+        except Exception:
+            _custom_import._mamba_spec_patched = False
+            logging.getLogger("vllm_kunlun").exception(
+                "[KunlunPlugin] lazy MambaBase.get_kv_cache_spec patch failed"
+            )
+
+    if (
+        module_name == "vllm.config.speculative"
+        and not getattr(_custom_import, "_qwen35_mtp_spec_patched", False)
+    ):
+        _custom_import._qwen35_mtp_spec_patched = True
+        try:
+            _apply_qwen35_mtp_speculative_patch(module)
+            logging.getLogger("vllm_kunlun").info(
+                "[KunlunPlugin] lazy-patched SpeculativeConfig for Qwen3.5 MTP"
+            )
+        except Exception:
+            _custom_import._qwen35_mtp_spec_patched = False
+            logging.getLogger("vllm_kunlun").exception(
+                "[KunlunPlugin] lazy SpeculativeConfig MTP patch failed"
+            )
+
+    _apply_mtp_mamba_state_patch(module_name)
+
+    return module
 
 
 # =========================================================================
@@ -97,6 +225,52 @@ def _patch_schema_utils(logger: logging.Logger) -> None:
     _completed_steps.add("schema")
 
 
+def _patch_mamba_spec_if_loaded(logger: logging.Logger) -> None:
+    """Patch MambaBase when the upstream module was already imported."""
+    if "vllm.model_executor.layers.mamba.abstract" not in sys.modules:
+        return
+    if getattr(_custom_import, "_mamba_spec_patched", False):
+        return
+
+    _custom_import._mamba_spec_patched = True
+    try:
+        _apply_mamba_spec_patch(
+            sys.modules["vllm.model_executor.layers.mamba.abstract"]
+        )
+        logger.info(
+            "[KunlunPlugin] patched MambaBase.get_kv_cache_spec to allow qwen3_5_moe"
+        )
+    except Exception:
+        _custom_import._mamba_spec_patched = False
+        logger.exception("[KunlunPlugin] MambaBase.get_kv_cache_spec patch failed")
+
+
+def _patch_qwen35_mtp_spec_if_loaded(logger: logging.Logger) -> None:
+    """Patch SpeculativeConfig when vllm.config.speculative was already imported."""
+    if "vllm.config.speculative" not in sys.modules:
+        return
+    if getattr(_custom_import, "_qwen35_mtp_spec_patched", False):
+        return
+
+    _custom_import._qwen35_mtp_spec_patched = True
+    try:
+        _apply_qwen35_mtp_speculative_patch(sys.modules["vllm.config.speculative"])
+        logger.info("[KunlunPlugin] patched SpeculativeConfig for Qwen3.5 MTP")
+    except Exception:
+        _custom_import._qwen35_mtp_spec_patched = False
+        logger.exception("[KunlunPlugin] SpeculativeConfig MTP patch failed")
+
+
+def _patch_mtp_mamba_state_if_loaded(logger: logging.Logger) -> None:
+    """Patch already loaded GPUModelRunner for MTP Mamba state handling."""
+    try:
+        from vllm_kunlun.v1.worker import mtp_mamba_state_patch
+
+        mtp_mamba_state_patch.patch_loaded_modules()
+    except Exception:
+        logger.exception("[KunlunPlugin] eager MTP Mamba state patch failed")
+
+
 def _install_import_hook(logger: logging.Logger) -> None:
     """Replace builtins.__import__ to redirect vLLM modules to Kunlun."""
     if "import_hook" in _completed_steps:
@@ -129,7 +303,10 @@ def register():
 
     _load_native_extension(logger)
     _patch_schema_utils(logger)  # fatal: raises on failure
+    _patch_mamba_spec_if_loaded(logger)
+    _patch_qwen35_mtp_spec_if_loaded(logger)
     _install_import_hook(logger)  # fatal: raises on failure
+    _patch_mtp_mamba_state_if_loaded(logger)
 
     if first_call:
         logger.info("[KunlunPlugin] register() done")

--- a/vllm_kunlun/__init__.py
+++ b/vllm_kunlun/__init__.py
@@ -154,9 +154,8 @@ def _custom_import(module_name, globals=None, locals=None, fromlist=(), level=0)
     # Lazy patch for MambaBase.get_kv_cache_spec. Importing this module during
     # register() triggers `from vllm.config import VllmConfig` while vllm.config
     # is still initializing.
-    if (
-        module_name == "vllm.model_executor.layers.mamba.abstract"
-        and not getattr(_custom_import, "_mamba_spec_patched", False)
+    if module_name == "vllm.model_executor.layers.mamba.abstract" and not getattr(
+        _custom_import, "_mamba_spec_patched", False
     ):
         _custom_import._mamba_spec_patched = True
         try:
@@ -170,9 +169,8 @@ def _custom_import(module_name, globals=None, locals=None, fromlist=(), level=0)
                 "[KunlunPlugin] lazy MambaBase.get_kv_cache_spec patch failed"
             )
 
-    if (
-        module_name == "vllm.config.speculative"
-        and not getattr(_custom_import, "_qwen35_mtp_spec_patched", False)
+    if module_name == "vllm.config.speculative" and not getattr(
+        _custom_import, "_qwen35_mtp_spec_patched", False
     ):
         _custom_import._qwen35_mtp_spec_patched = True
         try:

--- a/vllm_kunlun/models/__init__.py
+++ b/vllm_kunlun/models/__init__.py
@@ -104,6 +104,10 @@ def register_model():
     )
 
     ModelRegistry.register_model(
+        "Qwen3_5MoeMTP", "vllm_kunlun.models.qwen3_5_mtp:Qwen3_5MoeMTP"
+    )
+
+    ModelRegistry.register_model(
         "Gemma4ForCausalLM", "vllm_kunlun.models.gemma4:Gemma4ForCausalLM"
     )
 

--- a/vllm_kunlun/models/qwen3_5_mtp.py
+++ b/vllm_kunlun/models/qwen3_5_mtp.py
@@ -1,0 +1,485 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Inference-only Qwen3_5 MTP model."""
+
+import typing
+from collections.abc import Callable, Iterable
+
+import torch
+from torch import nn
+
+from vllm.compilation.decorators import support_torch_compile
+from vllm.config import VllmConfig
+from vllm.distributed.parallel_state import get_pp_group
+from vllm.logger import init_logger
+from vllm.model_executor.layers.fused_moe import FusedMoE
+from vllm.model_executor.layers.linear import ColumnParallelLinear
+from vllm.model_executor.layers.logits_processor import LogitsProcessor
+from vllm.model_executor.layers.vocab_parallel_embedding import (
+    ParallelLMHead,
+    VocabParallelEmbedding,
+)
+from vllm.model_executor.model_loader.weight_utils import default_weight_loader
+from vllm_kunlun.models.qwen3_5 import Qwen3_5DecoderLayer, Qwen3_5RMSNorm
+from vllm_kunlun.models.qwen3_next import QwenNextMixtureOfExperts
+from vllm.sequence import IntermediateTensors
+from vllm_kunlun.transformers_utils.configs.qwen3_5 import Qwen3_5TextConfig
+from vllm_kunlun.transformers_utils.configs.qwen3_5_moe import Qwen3_5MoeTextConfig
+
+from vllm.model_executor.models.interfaces import (
+    MultiModalEmbeddings,
+    SupportsMultiModal,
+    _require_is_multimodal,
+)
+from vllm.model_executor.models.utils import (
+    AutoWeightsLoader,
+    PPMissingLayer,
+    _merge_multimodal_embeddings,
+    is_pp_missing_parameter,
+    make_empty_intermediate_tensors_factory,
+    maybe_prefix,
+)
+
+logger = init_logger(__name__)
+
+
+@support_torch_compile(
+    dynamic_arg_dims={
+        "input_ids": 0,
+        # positions is of shape (3, seq_len) if mrope is enabled for qwen2-vl,
+        # otherwise (seq_len, ).
+        "positions": -1,
+        "intermediate_tensors": 0,
+        "inputs_embeds": 0,
+        "hidden_states": 0,
+    }
+)
+class Qwen3_5MultiTokenPredictor(nn.Module):
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
+        super().__init__()
+
+        model_config = vllm_config.model_config
+        quant_config = vllm_config.quant_config
+
+        config: Qwen3_5TextConfig | Qwen3_5MoeTextConfig = model_config.hf_text_config
+
+        self.config = config
+
+        self.vocab_size = config.vocab_size
+
+        self.mtp_start_layer_idx = config.num_hidden_layers
+        self.num_mtp_layers = getattr(config, "mtp_num_hidden_layers", 1)
+
+        self.embed_tokens = VocabParallelEmbedding(
+            self.vocab_size,
+            config.hidden_size,
+        )
+
+        # NOTE: Originally this was forced unquantized under the assumption that
+        # mtp.fc is stored in FP16/BF16 in quantized checkpoints. That holds for
+        # NVFP4/FP8 checkpoints but NOT for this W8A8-INT8 compressed-tensors
+        # checkpoint, where `mtp.fc.weight` is int8 and `mtp.fc.weight_scale`
+        # is present. Forcing unquantized drops the scale -> int8 bytes are
+        # loaded directly into fp16 -> weights ~= +/-127 -> fc output overflows
+        # and produces NaN -> decoded tokens are all "!".
+        # Use the model quant_config so W8A8 int8 + weight_scale is honored.
+        fc_quant = quant_config
+        self.fc = ColumnParallelLinear(
+            self.config.hidden_size * 2,
+            self.config.hidden_size,
+            gather_output=True,
+            bias=False,
+            return_bias=False,
+            quant_config=fc_quant,
+            prefix=f"{prefix}.fc",
+        )
+
+        # Use mtp_start_layer_idx as offset so that extract_layer_index()
+        # assigns KV cache slots that do not collide with the target model's
+        # layers (which are numbered 0..num_hidden_layers-1).
+        # DeepSeek MTP uses the same strategy; without it, MTP layer 0
+        # shares the KV cache slot with target layer 0, causing inf/nan
+        # during decode.
+        self.layers = torch.nn.ModuleList(
+            Qwen3_5DecoderLayer(
+                vllm_config,
+                layer_type="full_attention",
+                prefix=f"{prefix}.layers.{self.mtp_start_layer_idx + idx}",
+            )
+            for idx in range(self.num_mtp_layers)
+        )
+
+        self.make_empty_intermediate_tensors = make_empty_intermediate_tensors_factory(
+            ["hidden_states", "residual"], config.hidden_size
+        )
+
+        self.norm = Qwen3_5RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.pre_fc_norm_hidden = Qwen3_5RMSNorm(
+            config.hidden_size, eps=config.rms_norm_eps
+        )
+        self.pre_fc_norm_embedding = Qwen3_5RMSNorm(
+            config.hidden_size, eps=config.rms_norm_eps
+        )
+
+    def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
+        return self.embed_tokens(input_ids)
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        intermediate_tensors: IntermediateTensors | None = None,
+        inputs_embeds: torch.Tensor | None = None,
+        spec_step_idx: int = 0,
+    ) -> torch.Tensor:
+        if get_pp_group().is_first_rank:
+            if inputs_embeds is None:
+                inputs_embeds = self.embed_input_ids(input_ids)
+            assert hidden_states.shape[-1] == inputs_embeds.shape[-1]
+            inputs_embeds = self.pre_fc_norm_embedding(inputs_embeds)
+            hidden_states = self.pre_fc_norm_hidden(hidden_states)
+            hidden_states = torch.cat([inputs_embeds, hidden_states], dim=-1)
+            hidden_states = self.fc(hidden_states)
+            residual = None
+        else:
+            assert intermediate_tensors is not None
+            hidden_states = intermediate_tensors["hidden_states"]
+            residual = intermediate_tensors["residual"]
+
+        current_step_idx = spec_step_idx % self.num_mtp_layers
+        hidden_states, residual = self.layers[current_step_idx](
+            positions=positions,
+            hidden_states=hidden_states,
+            residual=residual,
+        )
+
+        if not get_pp_group().is_last_rank:
+            return IntermediateTensors(
+                {"hidden_states": hidden_states, "residual": residual}
+            )
+
+        hidden_states, _ = self.norm(hidden_states, residual)
+        return hidden_states
+
+    def load_fused_expert_weights(
+        self,
+        name: str,
+        params_dict: dict,
+        loaded_weight: torch.Tensor,
+        shard_id: str,
+        num_experts: int,
+    ) -> bool:
+        param = params_dict[name]
+        weight_loader = typing.cast(Callable[..., bool], param.weight_loader)
+        loaded_local_expert = False
+        for expert_id in range(num_experts):
+            curr_expert_weight = loaded_weight[expert_id]
+            success = weight_loader(
+                param,
+                curr_expert_weight,
+                name,
+                shard_id,
+                expert_id,
+                return_success=True,
+            )
+            if success:
+                loaded_local_expert = True
+
+        return loaded_local_expert
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        # AutoWeightsLoader strips "model." prefix, so incoming names look like
+        # "layers.{mtp_start+k}.xxx". But self.named_parameters() uses ModuleList
+        # indices: "layers.{k}.xxx". Normalize before processing.
+        def _normalize_layer_idx(name: str) -> str:
+            if name.startswith("layers."):
+                parts = name.split(".", 2)
+                if len(parts) >= 2 and parts[1].isdigit():
+                    idx = int(parts[1])
+                    if idx >= self.mtp_start_layer_idx:
+                        parts[1] = str(idx - self.mtp_start_layer_idx)
+                        return ".".join(parts)
+            return name
+
+        weights = ((_normalize_layer_idx(n), w) for n, w in weights)
+
+        stacked_params_mapping = [
+            # (param_name, shard_name, shard_id)
+            ("qkv_proj", "q_proj", "q"),
+            ("qkv_proj", "k_proj", "k"),
+            ("qkv_proj", "v_proj", "v"),
+            ("gate_up_proj", "gate_proj", 0),
+            ("gate_up_proj", "up_proj", 1),
+        ]
+
+        # Params for weights, fp8 weight scales, fp8 activation scales
+        # (param_name, weight_name, expert_id, shard_id)
+        expert_params_mapping = FusedMoE.make_expert_params_mapping(
+            self,
+            ckpt_gate_proj_name="gate_proj",
+            ckpt_down_proj_name="down_proj",
+            ckpt_up_proj_name="up_proj",
+            num_experts=self.config.num_experts
+            if hasattr(self.config, "num_experts")
+            else 0,
+        )
+
+        params_dict = dict(self.named_parameters())
+        loaded_params: set[str] = set()
+        is_fused_expert = False
+        fused_expert_params_mapping = [
+            ("experts.w13_weight", "experts.gate_up_proj", 0, "w1"),
+            ("experts.w2_weight", "experts.down_proj", 0, "w2"),
+        ]
+        num_experts = (
+            self.config.num_experts if hasattr(self.config, "num_experts") else 0
+        )
+        for name, loaded_weight in weights:
+            if "rotary_emb.inv_freq" in name:
+                continue
+
+            for param_name, weight_name, shard_id in stacked_params_mapping:
+                if "experts.gate_up_proj" in name or "experts.down_proj" in name:
+                    is_fused_expert = True
+                    expert_params_mapping = fused_expert_params_mapping
+
+                if weight_name not in name:
+                    continue
+
+                if "mlp.experts" in name:
+                    continue
+
+                name = name.replace(weight_name, param_name)
+                # Skip loading extra bias for GPTQ models.
+                if name.endswith(".bias") and name not in params_dict:
+                    continue
+                # Skip layers on other devices.
+                if is_pp_missing_parameter(name, self):
+                    continue
+                if name not in params_dict:
+                    continue
+                param = params_dict[name]
+                weight_loader = param.weight_loader
+                weight_loader(param, loaded_weight, shard_id)
+                break
+            else:
+                is_expert_weight = False
+                for mapping in expert_params_mapping:
+                    param_name, weight_name, expert_id, shard_id = mapping
+                    if weight_name not in name:
+                        continue
+                    is_expert_weight = True
+                    name_mapped = name.replace(weight_name, param_name)
+                    # Skip layers on other devices.
+                    if is_pp_missing_parameter(name_mapped, self):
+                        continue
+                    if is_fused_expert:
+                        # qwen3.5 no need to transpose
+                        # loaded_weight = loaded_weight.transpose(-1, -2)
+                        if "experts.gate_up_proj" in name:
+                            loaded_weight = loaded_weight.chunk(2, dim=-2)
+                            success_w1 = self.load_fused_expert_weights(
+                                name_mapped,
+                                params_dict,
+                                loaded_weight[0],
+                                "w1",
+                                num_experts,
+                            )
+                            success_w3 = self.load_fused_expert_weights(
+                                name_mapped,
+                                params_dict,
+                                loaded_weight[1],
+                                "w3",
+                                num_experts,
+                            )
+                            success = success_w1 and success_w3
+                        else:
+                            # down_proj
+                            success = self.load_fused_expert_weights(
+                                name_mapped,
+                                params_dict,
+                                loaded_weight,
+                                shard_id,
+                                num_experts,
+                            )
+                        if success:
+                            name = name_mapped
+                            break
+                    else:
+                        # Skip loading extra bias for GPTQ models.
+                        if (
+                            name_mapped.endswith(".bias")
+                            or name_mapped.endswith("_bias")
+                        ) and name_mapped not in params_dict:
+                            continue
+                        param = params_dict[name_mapped]
+                        weight_loader = param.weight_loader
+                        success = weight_loader(
+                            param,
+                            loaded_weight,
+                            name_mapped,
+                            shard_id=shard_id,
+                            expert_id=expert_id,
+                            return_success=True,
+                        )
+                    if success:
+                        name = name_mapped
+                        break
+                else:
+                    if is_expert_weight:
+                        # We've checked that this is an expert weight
+                        # However it's not mapped locally to this rank
+                        # So we simply skip it
+                        continue
+                    # Skip loading extra bias for GPTQ models.
+                    if name.endswith(".bias") and name not in params_dict:
+                        continue
+                    if is_pp_missing_parameter(name, self):
+                        continue
+                    if name not in params_dict:
+                        logger.warning_once(
+                            f"Parameter {name} not found in params_dict, skip loading"
+                        )
+                        continue
+                    param = params_dict[name]
+                    weight_loader = getattr(
+                        param, "weight_loader", default_weight_loader
+                    )
+                    weight_loader(param, loaded_weight)
+            loaded_params.add(name)
+        return loaded_params
+
+
+@support_torch_compile(
+    dynamic_arg_dims={
+        "input_ids": 0,
+        # positions is of shape (3, seq_len) if mrope is enabled for qwen2-vl,
+        # otherwise (seq_len, ).
+        "positions": -1,
+        "intermediate_tensors": 0,
+        "inputs_embeds": 0,
+        "hidden_states": 0,
+    }
+)
+class Qwen3_5MTP(nn.Module, SupportsMultiModal):
+    packed_modules_mapping = {
+        "qkv_proj": [
+            "q_proj",
+            "k_proj",
+            "v_proj",
+        ],
+        "gate_up_proj": ["gate_proj", "up_proj"],
+    }
+
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
+        config = vllm_config.model_config.hf_text_config
+        self.vllm_config = vllm_config
+        cache_config = vllm_config.cache_config
+        if cache_config.mamba_cache_mode != "none":
+            raise NotImplementedError(
+                "Qwen3_5MTP currently requires '--mamba-cache-mode=none'. "
+                f"Got mamba_cache_mode='{cache_config.mamba_cache_mode}'."
+            )
+
+        self.quant_config = vllm_config.quant_config
+
+        super().__init__()
+        self.config = config
+        self.model = Qwen3_5MultiTokenPredictor(
+            vllm_config=vllm_config, prefix=maybe_prefix(prefix, "mtp")
+        )
+
+        if get_pp_group().is_last_rank:
+            if config.tie_word_embeddings:
+                self.lm_head = self.model.embed_tokens
+            else:
+                self.lm_head = ParallelLMHead(
+                    config.vocab_size,
+                    config.hidden_size,
+                    prefix=maybe_prefix(prefix, "lm_head"),
+                )
+        else:
+            self.lm_head = PPMissingLayer()
+
+        self.logits_processor = LogitsProcessor(config.vocab_size)
+
+    def embed_input_ids(
+        self,
+        input_ids: torch.Tensor,
+        multimodal_embeddings: MultiModalEmbeddings | None = None,
+        *,
+        is_multimodal: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        inputs_embeds = self._embed_text_input_ids(
+            input_ids,
+            self.model.embed_input_ids,
+            is_multimodal=is_multimodal,
+        )
+
+        if multimodal_embeddings is None or len(multimodal_embeddings) == 0:
+            return inputs_embeds
+
+        is_multimodal = _require_is_multimodal(is_multimodal)
+
+        inputs_embeds = _merge_multimodal_embeddings(
+            inputs_embeds=inputs_embeds,
+            multimodal_embeddings=multimodal_embeddings,
+            is_multimodal=is_multimodal,
+        )
+
+        return inputs_embeds
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        intermediate_tensors: IntermediateTensors | None = None,
+        inputs_embeds: torch.Tensor | None = None,
+        **kwargs: object,
+    ):
+        hidden_states = self.model(
+            input_ids, positions, hidden_states, intermediate_tensors, inputs_embeds
+        )
+        return hidden_states
+
+    def compute_logits(
+        self,
+        hidden_states: torch.Tensor,
+        spec_step_idx: int = 0,
+    ) -> torch.Tensor | None:
+        return self.logits_processor(self.lm_head, hidden_states)
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        mtp_start = self.model.mtp_start_layer_idx
+
+        def remap_weight_names(weights):
+            for name, weight in weights:
+                if name.startswith("mtp."):
+                    name = name.replace("mtp.", "model.", 1)
+                    # Remap "model.layers.0.xxx" -> "model.layers.{mtp_start}.xxx"
+                    # because MTP decoder layers use offset layer_idx to avoid
+                    # KV cache collision with target model.
+                    if name.startswith("model.layers."):
+                        parts = name.split(".", 3)  # ["model", "layers", "0", "rest..."]
+                        if len(parts) >= 3 and parts[2].isdigit():
+                            orig_idx = int(parts[2])
+                            parts[2] = str(mtp_start + orig_idx)
+                            name = ".".join(parts)
+                elif any(key in name for key in ["embed_tokens", "lm_head"]):
+                    if "embed_tokens" in name:
+                        name = name.replace("language_model.", "")
+                else:
+                    continue
+                yield name, weight
+
+        loader = AutoWeightsLoader(self)
+        loaded = loader.load_weights(remap_weight_names(weights))
+        return loaded
+
+
+class Qwen3_5MoeMTP(Qwen3_5MTP, QwenNextMixtureOfExperts):
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
+        super().__init__(vllm_config=vllm_config, prefix=prefix)
+        self.set_moe_parameters()

--- a/vllm_kunlun/models/qwen3_5_mtp.py
+++ b/vllm_kunlun/models/qwen3_5_mtp.py
@@ -7,7 +7,6 @@ from collections.abc import Callable, Iterable
 
 import torch
 from torch import nn
-
 from vllm.compilation.decorators import support_torch_compile
 from vllm.config import VllmConfig
 from vllm.distributed.parallel_state import get_pp_group
@@ -20,12 +19,6 @@ from vllm.model_executor.layers.vocab_parallel_embedding import (
     VocabParallelEmbedding,
 )
 from vllm.model_executor.model_loader.weight_utils import default_weight_loader
-from vllm_kunlun.models.qwen3_5 import Qwen3_5DecoderLayer, Qwen3_5RMSNorm
-from vllm_kunlun.models.qwen3_next import QwenNextMixtureOfExperts
-from vllm.sequence import IntermediateTensors
-from vllm_kunlun.transformers_utils.configs.qwen3_5 import Qwen3_5TextConfig
-from vllm_kunlun.transformers_utils.configs.qwen3_5_moe import Qwen3_5MoeTextConfig
-
 from vllm.model_executor.models.interfaces import (
     MultiModalEmbeddings,
     SupportsMultiModal,
@@ -39,6 +32,12 @@ from vllm.model_executor.models.utils import (
     make_empty_intermediate_tensors_factory,
     maybe_prefix,
 )
+from vllm.sequence import IntermediateTensors
+
+from vllm_kunlun.models.qwen3_5 import Qwen3_5DecoderLayer, Qwen3_5RMSNorm
+from vllm_kunlun.models.qwen3_next import QwenNextMixtureOfExperts
+from vllm_kunlun.transformers_utils.configs.qwen3_5 import Qwen3_5TextConfig
+from vllm_kunlun.transformers_utils.configs.qwen3_5_moe import Qwen3_5MoeTextConfig
 
 logger = init_logger(__name__)
 
@@ -220,9 +219,9 @@ class Qwen3_5MultiTokenPredictor(nn.Module):
             ckpt_gate_proj_name="gate_proj",
             ckpt_down_proj_name="down_proj",
             ckpt_up_proj_name="up_proj",
-            num_experts=self.config.num_experts
-            if hasattr(self.config, "num_experts")
-            else 0,
+            num_experts=(
+                self.config.num_experts if hasattr(self.config, "num_experts") else 0
+            ),
         )
 
         params_dict = dict(self.named_parameters())
@@ -462,7 +461,9 @@ class Qwen3_5MTP(nn.Module, SupportsMultiModal):
                     # because MTP decoder layers use offset layer_idx to avoid
                     # KV cache collision with target model.
                     if name.startswith("model.layers."):
-                        parts = name.split(".", 3)  # ["model", "layers", "0", "rest..."]
+                        parts = name.split(
+                            ".", 3
+                        )  # ["model", "layers", "0", "rest..."]
                         if len(parts) >= 3 and parts[2].isdigit():
                             orig_idx = int(parts[2])
                             parts[2] = str(mtp_start + orig_idx)

--- a/vllm_kunlun/models/qwen3_next.py
+++ b/vllm_kunlun/models/qwen3_next.py
@@ -576,6 +576,12 @@ class Qwen3NextGatedDeltaNet(nn.Module, MambaBase):
         spec_token_indx = attn_metadata.spec_token_indx
         non_spec_token_indx = attn_metadata.non_spec_token_indx
         spec_state_indices_tensor = attn_metadata.spec_state_indices_tensor  # noqa: E501
+        spec_conv_state_indices_tensor = (
+            attn_metadata.spec_conv_state_indices_tensor
+        )
+        spec_conv_state_indices_tensor_cpu = (
+            attn_metadata.spec_conv_state_indices_tensor_cpu
+        )
         non_spec_state_indices_tensor = attn_metadata.non_spec_state_indices_tensor  # noqa: E501
         non_spec_state_indices_tensor_cpu = (
             attn_metadata.non_spec_state_indices_tensor_cpu
@@ -585,6 +591,7 @@ class Qwen3NextGatedDeltaNet(nn.Module, MambaBase):
         ssm_state = self_kv_cache[1]
         num_actual_tokens = attn_metadata.num_actual_tokens
         num_accepted_tokens = attn_metadata.num_accepted_tokens
+        num_accepted_tokens_cpu = attn_metadata.num_accepted_tokens_cpu
 
         mixed_qkv = mixed_qkv[:num_actual_tokens]
         b = b[:num_actual_tokens]
@@ -608,20 +615,42 @@ class Qwen3NextGatedDeltaNet(nn.Module, MambaBase):
 
         # 1.1: Process the multi-query part
         if spec_sequence_masks is not None:
-            mixed_qkv_spec = causal_conv1d_update(
-                mixed_qkv_spec,
+            actual_num = attn_metadata.num_spec_decode_tokens
+            tmp_mixed_qkv_spec = causal_conv1d_update(
+                mixed_qkv_spec[:actual_num],
                 conv_state,
                 conv_weights,
                 self.conv1d.bias,
                 self.activation,
-                conv_state_indices=spec_state_indices_tensor[:, 0][
+                conv_state_indices=(
+                    spec_conv_state_indices_tensor[
+                        : attn_metadata.num_spec_decodes
+                    ]
+                    if spec_conv_state_indices_tensor is not None
+                    else spec_state_indices_tensor[:, 0][
+                        : attn_metadata.num_spec_decodes
+                    ]
+                ),
+                conv_state_indices_cpu=(
+                    spec_conv_state_indices_tensor_cpu[
+                        : attn_metadata.num_spec_decodes
+                    ]
+                    if spec_conv_state_indices_tensor_cpu is not None
+                    else None
+                ),
+                num_accepted_tokens=num_accepted_tokens[
                     : attn_metadata.num_spec_decodes
                 ],
-                num_accepted_tokens=num_accepted_tokens,
+                num_accepted_tokens_cpu=(
+                    num_accepted_tokens_cpu[: attn_metadata.num_spec_decodes]
+                    if num_accepted_tokens_cpu is not None
+                    else None
+                ),
                 query_start_loc=spec_query_start_loc,
                 max_query_len=spec_state_indices_tensor.size(-1),
                 validate_data=False,
             )
+            mixed_qkv_spec[:actual_num] = tmp_mixed_qkv_spec
 
         # 1.2: Process the remaining part
         if attn_metadata.num_prefills > 0:
@@ -690,19 +719,31 @@ class Qwen3NextGatedDeltaNet(nn.Module, MambaBase):
 
         # 2.1: Process the multi-query part
         if spec_sequence_masks is not None:
-            core_attn_out_spec, last_recurrent_state = fused_recurrent_gated_delta_rule(
-                q=query_spec,
-                k=key_spec,
-                v=value_spec,
-                g=g_spec,
-                beta=beta_spec,
-                initial_state=ssm_state,
-                inplace_final_state=True,
-                cu_seqlens=spec_query_start_loc[: attn_metadata.num_spec_decodes + 1],
-                ssm_state_indices=spec_state_indices_tensor,
-                num_accepted_tokens=num_accepted_tokens,
-                use_qk_l2norm_in_kernel=True,
+            core_attn_out_spec = torch.empty_like(value_spec)
+            tmp_cu_seqlens = spec_query_start_loc[
+                : attn_metadata.num_spec_decodes + 1
+            ]
+            recurrent_num_accepted_tokens = num_accepted_tokens[
+                : attn_metadata.num_spec_decodes
+            ].to(dtype=torch.int32)
+            tmp_core_attn_out_spec, last_recurrent_state = (
+                fused_recurrent_gated_delta_rule(
+                    q=query_spec[:, :actual_num],
+                    k=key_spec[:, :actual_num],
+                    v=value_spec[:, :actual_num],
+                    g=g_spec[:, :actual_num],
+                    beta=beta_spec[:, :actual_num],
+                    initial_state=ssm_state,
+                    inplace_final_state=True,
+                    cu_seqlens=tmp_cu_seqlens,
+                    ssm_state_indices=spec_state_indices_tensor[
+                        : attn_metadata.num_spec_decodes
+                    ],
+                    num_accepted_tokens=recurrent_num_accepted_tokens,
+                    use_qk_l2norm_in_kernel=True,
+                )
             )
+            core_attn_out_spec[:, :actual_num] = tmp_core_attn_out_spec
         else:
             core_attn_out_spec, last_recurrent_state = None, None
 
@@ -726,6 +767,7 @@ class Qwen3NextGatedDeltaNet(nn.Module, MambaBase):
                 output_final_state=True,
                 use_qk_l2norm_in_kernel=True,
                 cu_seqlens=non_spec_query_start_loc,
+                cu_seqlens_cpu=non_spec_query_start_loc_cpu,
             )
             # Init cache
             last_recurrent_state = (
@@ -931,7 +973,7 @@ class Qwen3NextDecoderLayer(nn.Module):
     ) -> None:
         super().__init__()
 
-        config = vllm_config.model_config.hf_config
+        config = vllm_config.model_config.hf_text_config
         model_config = vllm_config.model_config
         cache_config = vllm_config.cache_config
         quant_config = vllm_config.quant_config
@@ -963,9 +1005,11 @@ class Qwen3NextDecoderLayer(nn.Module):
         mlp_only_layers = (
             [] if not hasattr(config, "mlp_only_layers") else config.mlp_only_layers
         )
+        decoder_sparse_step = getattr(config, "decoder_sparse_step", 1)
+        num_experts = getattr(config, "num_experts", 0)
         if (self.layer_idx not in mlp_only_layers) and (
-            config.num_experts > 0
-            and (self.layer_idx + 1) % config.decoder_sparse_step == 0
+            num_experts > 0
+            and (self.layer_idx + 1) % decoder_sparse_step == 0
         ):
             self.mlp = Qwen3NextSparseMoeBlock(
                 vllm_config=vllm_config,

--- a/vllm_kunlun/ops/__init__.py
+++ b/vllm_kunlun/ops/__init__.py
@@ -16,19 +16,19 @@
 #
 
 import vllm_kunlun.ops._custom_ops
-import vllm_kunlun.ops.fused_moe.layer
-
-# base layers
-import vllm_kunlun.ops.layernorm
-import vllm_kunlun.ops.linear
-
-# embedding
-import vllm_kunlun.ops.rotary_embedding
-import vllm_kunlun.ops.vocab_parallel_embedding
-import vllm_kunlun.v1.sample.spec_decode.eagle  # noqa: F401
 
 # activation ops (SiluAndMul, GeluAndMul OOT registration)
-import vllm_kunlun.ops.activation
+import vllm_kunlun.ops.activation  # noqa: F401
+import vllm_kunlun.ops.fused_moe.layer  # noqa: F401
+
+# base layers
+import vllm_kunlun.ops.layernorm  # noqa: F401
+import vllm_kunlun.ops.linear  # noqa: F401
+
+# embedding
+import vllm_kunlun.ops.rotary_embedding  # noqa: F401
+import vllm_kunlun.ops.vocab_parallel_embedding  # noqa: F401
+import vllm_kunlun.v1.sample.spec_decode.eagle  # noqa: F401
 
 # TODO @xyDong0223 remove v0.16.0
 # import vllm_kunlun.ops.mla

--- a/vllm_kunlun/ops/activation.py
+++ b/vllm_kunlun/ops/activation.py
@@ -18,7 +18,7 @@
 
 import torch
 from vllm.model_executor.custom_op import CustomOp
-from vllm.model_executor.layers.activation import SiluAndMul, GeluAndMul
+from vllm.model_executor.layers.activation import GeluAndMul, SiluAndMul
 
 
 @CustomOp.register_oot(name="SiluAndMul")

--- a/vllm_kunlun/ops/fla/chunk.py
+++ b/vllm_kunlun/ops/fla/chunk.py
@@ -189,6 +189,7 @@ def chunk_gated_delta_rule(
     initial_state: torch.Tensor = None,
     output_final_state: bool = False,
     cu_seqlens: Optional[torch.LongTensor] = None,
+    cu_seqlens_cpu: Optional[torch.LongTensor] = None,
     head_first: bool = False,
     use_qk_l2norm_in_kernel: bool = False,
 ):
@@ -294,7 +295,7 @@ def chunk_gated_delta_rule(
     if scale is None:
         scale = k.shape[-1] ** -0.5
 
-    if False:
+    if cu_seqlens is not None and initial_state is not None:
         q = q.contiguous()
         k = k.contiguous()
         v = v.contiguous()
@@ -306,6 +307,8 @@ def chunk_gated_delta_rule(
         final_state = torch.empty_like(initial_state)
         import kunlun_ops
 
+        if cu_seqlens_cpu is None:
+            cu_seqlens_cpu = cu_seqlens.cpu()
         kunlun_ops.gated_delta_rule(
             q,
             k,
@@ -316,9 +319,9 @@ def chunk_gated_delta_rule(
             final_state,
             o,
             scale,
-            cu_seqlens.cpu(),
+            cu_seqlens_cpu,
             cu_seqlens,
-            cu_seqlens.cpu(),
+            cu_seqlens_cpu,
             cu_seqlens,
             use_qk_l2norm_in_kernel=True,
         )

--- a/vllm_kunlun/ops/fla/fused_recurrent.py
+++ b/vllm_kunlun/ops/fla/fused_recurrent.py
@@ -31,6 +31,15 @@ class FusedRecurrentFunction(torch.autograd.Function):
         num_accepted_tokens: Optional[torch.Tensor] = None,
         use_qk_l2norm_in_kernel: bool = False,
     ):
+        def _to_i32(t):
+            if t is None or t.dtype == torch.int32:
+                return t
+            return t.to(torch.int32)
+
+        cu_seqlens = _to_i32(cu_seqlens)
+        ssm_state_indices = _to_i32(ssm_state_indices)
+        num_accepted_tokens = _to_i32(num_accepted_tokens)
+
         o, final_state = kunlun_ops.fused_recurrent_gated_delta_rule_fwdv2(
             q.contiguous(),
             k.contiguous(),

--- a/vllm_kunlun/ops/mamba/causal_conv1d.py
+++ b/vllm_kunlun/ops/mamba/causal_conv1d.py
@@ -8,7 +8,6 @@ from typing import Optional, Union
 
 import kunlun_ops
 import torch
-import torch.nn.functional as F
 from vllm.v1.attention.backends.utils import PAD_SLOT_ID
 
 
@@ -74,45 +73,101 @@ def causal_conv1d_fn(
     return out
 
 
-def torch_causal_conv1d_update_spec(
-    hidden_states,
-    conv_state,
-    weight,
-    bias=None,
-    activation=None,
-    conv_state_indices=None,
-    num_accepted_tokens=None,
-):
+def causal_conv1d_update_spec_graphsafe(
+    hidden_states: torch.Tensor,
+    conv_state: torch.Tensor,
+    weight: torch.Tensor,
+    bias: Optional[torch.Tensor] = None,
+    conv_state_indices: Optional[torch.Tensor] = None,
+    num_accepted_tokens: Optional[torch.Tensor] = None,
+    conv_state_indices_cpu: Optional[torch.Tensor] = None,
+    num_accepted_tokens_cpu: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    if hidden_states.dim() != 3:
+        raise ValueError(
+            "causal_conv1d_update_spec_graphsafe expects "
+            "[batch, seq_len, hidden] hidden_states."
+        )
+    if (
+        conv_state_indices is None
+        or conv_state_indices_cpu is None
+        or num_accepted_tokens is None
+        or num_accepted_tokens_cpu is None
+    ):
+        raise ValueError(
+            "causal_conv1d_update_spec_graphsafe requires CPU and XPU "
+            "conv_state_indices and num_accepted_tokens."
+        )
     out = torch.empty_like(hidden_states)
-    _, seq_len, hidden_size = hidden_states.shape
-    for i in range(hidden_states.shape[0]):
-        tmp_conv_state = conv_state[conv_state_indices[i]]
-        state_len = tmp_conv_state.shape[-2]
-        hidden_states_i = hidden_states[i]
-        hidden_states_new = torch.cat(
-            [tmp_conv_state[: (2 + num_accepted_tokens[i]), :], hidden_states_i], dim=0
-        ).to(weight.dtype)
+    kunlun_ops.causal_conv1d_update(
+        hidden_states,
+        weight,
+        out,
+        conv_state,
+        None,
+        bias,
+        conv_state_indices_cpu=conv_state_indices_cpu,
+        conv_state_indices_xpu=conv_state_indices,
+        num_accepted_tokens_cpu=num_accepted_tokens_cpu,
+        num_accepted_tokens_xpu=num_accepted_tokens.to(torch.int32),
+        act="SWISH",
+        state_seq_stride=conv_state.stride(0),
+        is_ncw=False,
+    )
+    return out.view(-1, hidden_states.shape[-1])
 
-        hidden_states_new = hidden_states_new.unsqueeze(0)
 
-        conv_state[conv_state_indices[i]] = hidden_states_new[:, -state_len:, :]
-        for j in range(seq_len):
-            if j == seq_len - 1:
-                hidden_states_new_j = hidden_states_new
-            else:
-                hidden_states_new_j = hidden_states_new[:, : (1 - seq_len + j)]
-            hidden_states_new_j = hidden_states_new_j.transpose(-1, -2).contiguous()
-            out_i = F.conv1d(
-                hidden_states_new_j,
-                weight.unsqueeze(1),
-                bias,
-                padding=0,
-                groups=hidden_size,
+def _pad_spec_hidden_states(
+    hidden_states: torch.Tensor,
+    max_query_len: int,
+    num_accepted_tokens_cpu: torch.Tensor,
+) -> tuple[torch.Tensor, list[int]]:
+    dim = hidden_states.shape[-1]
+    num_spec_decodes = num_accepted_tokens_cpu.shape[0]
+    padded_num_tokens = num_spec_decodes * max_query_len
+
+    if hidden_states.shape[0] == padded_num_tokens:
+        return hidden_states.view(num_spec_decodes, max_query_len, dim), []
+
+    lengths = [int(length) for length in num_accepted_tokens_cpu.tolist()]
+    if sum(lengths) != hidden_states.shape[0]:
+        raise ValueError(
+            "spec conv token count does not match num_accepted_tokens_cpu: "
+            f"got {hidden_states.shape[0]} tokens, expected {sum(lengths)}."
+        )
+
+    first_length = lengths[0] if lengths else 0
+    if all(length == first_length for length in lengths):
+        return hidden_states.view(num_spec_decodes, first_length, dim), []
+
+    padded = hidden_states.new_zeros((num_spec_decodes, max_query_len, dim))
+    offset = 0
+    for index, length in enumerate(lengths):
+        if length > max_query_len:
+            raise ValueError(
+                f"spec conv length {length} exceeds max_query_len "
+                f"{max_query_len}."
             )
-            out_i = F.silu(out_i[:, :, -1:])
-            out_i = out_i.to(hidden_states.dtype).squeeze(-1).unsqueeze(0)
-            out[i, j] = out_i
-    return out.view(-1, hidden_size)
+        padded[index, :length].copy_(hidden_states[offset : offset + length])
+        offset += length
+    return padded, lengths
+
+
+def _unpad_spec_hidden_states(
+    hidden_states: torch.Tensor,
+    lengths: list[int],
+) -> torch.Tensor:
+    if not lengths:
+        return hidden_states.view(-1, hidden_states.shape[-1])
+
+    dim = hidden_states.shape[-1]
+    total_num_tokens = sum(lengths)
+    unpadded = hidden_states.new_empty((total_num_tokens, dim))
+    offset = 0
+    for index, length in enumerate(lengths):
+        unpadded[offset : offset + length].copy_(hidden_states[index, :length])
+        offset += length
+    return unpadded
 
 
 def causal_conv1d_update(
@@ -125,6 +180,7 @@ def causal_conv1d_update(
     conv_state_indices: Optional[torch.Tensor] = None,
     conv_state_indices_cpu: Optional[torch.Tensor] = None,
     num_accepted_tokens: Optional[torch.Tensor] = None,
+    num_accepted_tokens_cpu: Optional[torch.Tensor] = None,
     query_start_loc: torch.Tensor | None = None,
     max_query_len: int = -1,
     pad_slot_id: int = PAD_SLOT_ID,
@@ -189,13 +245,25 @@ def causal_conv1d_update(
         assert weight.stride(1) == 1  # Need this
         assert cache_seqlens is None  # not needed for vLLM - circular buffer
 
+    spec_lengths: list[int] = []
     if num_accepted_tokens is None:
         x = x.squeeze(-1).unsqueeze(1)
     else:
-        x = x.squeeze(-1).view(-1, max_query_len, dim)
+        if max_query_len <= 0:
+            max_query_len = seqlen
+        if num_accepted_tokens_cpu is None:
+            raise ValueError(
+                "spec conv requires num_accepted_tokens_cpu to handle "
+                "variable scheduled token counts."
+            )
+        x, spec_lengths = _pad_spec_hidden_states(
+            x.squeeze(-1),
+            max_query_len,
+            num_accepted_tokens_cpu,
+        )
+
     if num_accepted_tokens is None:
         out = torch.empty_like(x)
-        import kunlun_ops
 
         stride = conv_state.stride()[0]
         kunlun_ops.causal_conv1d_update(
@@ -214,12 +282,17 @@ def causal_conv1d_update(
         out = out.squeeze(1)
         return out
     else:
-        return torch_causal_conv1d_update_spec(
+        out = causal_conv1d_update_spec_graphsafe(
             x,
             conv_state,
             weight,
             bias,
-            activation,
             conv_state_indices=conv_state_indices,
+            conv_state_indices_cpu=conv_state_indices_cpu,
             num_accepted_tokens=num_accepted_tokens,
+            num_accepted_tokens_cpu=num_accepted_tokens_cpu,
+        )
+        return _unpad_spec_hidden_states(
+            out.view(x.shape[0], x.shape[1], dim),
+            spec_lengths,
         )

--- a/vllm_kunlun/ops/mamba/causal_conv1d.py
+++ b/vllm_kunlun/ops/mamba/causal_conv1d.py
@@ -145,8 +145,7 @@ def _pad_spec_hidden_states(
     for index, length in enumerate(lengths):
         if length > max_query_len:
             raise ValueError(
-                f"spec conv length {length} exceeds max_query_len "
-                f"{max_query_len}."
+                f"spec conv length {length} exceeds max_query_len " f"{max_query_len}."
             )
         padded[index, :length].copy_(hidden_states[offset : offset + length])
         offset += length

--- a/vllm_kunlun/transformers_utils/configs/qwen3_5_moe.py
+++ b/vllm_kunlun/transformers_utils/configs/qwen3_5_moe.py
@@ -179,6 +179,7 @@ class Qwen3_5MoeConfig(PretrainedConfig):
         text_config=None,
         vision_config=None,
         image_token_id=248056,
+        image_token_index=None,
         video_token_id=248057,
         vision_start_token_id=248053,
         vision_end_token_id=248054,
@@ -196,6 +197,9 @@ class Qwen3_5MoeConfig(PretrainedConfig):
             self.text_config = self.sub_configs["text_config"]()
 
         self.image_token_id = image_token_id
+        self.image_token_index = (
+            image_token_id if image_token_index is None else image_token_index
+        )
         self.video_token_id = video_token_id
         self.vision_start_token_id = vision_start_token_id
         self.vision_end_token_id = vision_end_token_id

--- a/vllm_kunlun/v1/attention/backends/gdn_attn.py
+++ b/vllm_kunlun/v1/attention/backends/gdn_attn.py
@@ -5,6 +5,7 @@
 from dataclasses import dataclass
 
 import torch
+
 from vllm.config import VllmConfig
 from vllm.v1.attention.backend import (
     AttentionBackend,
@@ -14,11 +15,11 @@ from vllm.v1.attention.backend import (
 )
 from vllm.v1.attention.backends import gdn_attn
 from vllm.v1.attention.backends.utils import (
-    PAD_SLOT_ID,
     compute_causal_conv1d_metadata,
     mamba_get_block_table_tensor,
     split_decodes_and_prefills,
 )
+
 from vllm.v1.kv_cache_interface import AttentionSpec, MambaSpec
 
 
@@ -51,6 +52,8 @@ class GDNAttentionMetadata:
     )
     non_spec_query_start_loc_cpu: torch.Tensor | None = None
     spec_state_indices_tensor: torch.Tensor | None = None  # shape: [batch, num_spec]
+    spec_conv_state_indices_tensor: torch.Tensor | None = None  # shape: [batch,]
+    spec_conv_state_indices_tensor_cpu: torch.Tensor | None = None  # shape: [batch,]
     non_spec_state_indices_tensor: torch.Tensor | None = (
         None  # shape: [batch - num_spec_decodes,]
     )
@@ -68,6 +71,7 @@ class GDNAttentionMetadata:
     non_spec_token_indx: torch.Tensor | None = None
 
     num_accepted_tokens: torch.Tensor | None = None  # shape: [batch,]
+    num_accepted_tokens_cpu: torch.Tensor | None = None  # shape: [batch,]
 
     # The following attributes are for triton implementation of causal_conv1d
     nums_dict: dict | None = None
@@ -119,6 +123,16 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
             dtype=torch.int32,
             device=device,
         )
+        self.spec_conv_state_indices_tensor = torch.empty(
+            (self.decode_cudagraph_max_bs,),
+            dtype=torch.int32,
+            device=device,
+        )
+        self.spec_conv_state_indices_tensor_cpu = torch.empty(
+            (self.decode_cudagraph_max_bs,),
+            dtype=torch.int32,
+            device="cpu",
+        )
         self.non_spec_state_indices_tensor = torch.empty(
             (self.decode_cudagraph_max_bs,),
             dtype=torch.int32,
@@ -159,6 +173,11 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
             dtype=torch.int32,
             device=device,
         )
+        self.num_accepted_tokens_cpu = torch.empty(
+            (self.decode_cudagraph_max_bs,),
+            dtype=torch.int32,
+            device="cpu",
+        )
 
     def build(  # type: ignore[override]
         self,
@@ -180,6 +199,19 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
             self.kv_cache_spec,
             self.vllm_config.cache_config.mamba_cache_mode,
         )
+        block_table_tensor_cpu = None
+        if m.block_table_tensor_cpu is not None:
+            assert m._seq_lens_cpu is not None
+            block_table_tensor_cpu = mamba_get_block_table_tensor(
+                m.block_table_tensor_cpu,
+                m._seq_lens_cpu,
+                self.kv_cache_spec,
+                self.vllm_config.cache_config.mamba_cache_mode,
+            )
+        spec_conv_state_indices_tensor: torch.Tensor | None = None
+        spec_conv_state_indices_tensor_cpu: torch.Tensor | None = None
+        non_spec_state_indices_tensor_cpu: torch.Tensor | None = None
+        num_accepted_tokens_cpu: torch.Tensor | None = None
 
         spec_sequence_masks_cpu: torch.Tensor | None = None
         if (
@@ -212,7 +244,11 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
             spec_token_masks = None
             non_spec_token_indx = None
             spec_state_indices_tensor = None
+            spec_conv_state_indices_tensor = None
             non_spec_state_indices_tensor = block_table_tensor[:, 0]
+            non_spec_state_indices_tensor_cpu = (
+                block_table_tensor_cpu[:, 0] if block_table_tensor_cpu is not None else None
+            )
             spec_query_start_loc = None
             non_spec_query_start_loc = query_start_loc
             non_spec_query_start_loc_cpu = query_start_loc_cpu
@@ -222,13 +258,16 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
             assert spec_sequence_masks_cpu is not None
             query_lens_cpu = query_start_loc_cpu[1:] - query_start_loc_cpu[:-1]
 
-            non_spec_query_lens = query_lens[~spec_sequence_masks]
-            num_decodes = (non_spec_query_lens == 1).sum().item()
-            num_prefills = non_spec_query_lens.size(0) - num_decodes
+            non_spec_query_lens_cpu = query_lens_cpu[~spec_sequence_masks_cpu]
+            num_decodes = (non_spec_query_lens_cpu == 1).sum().item()
+            num_zero_len = (non_spec_query_lens_cpu == 0).sum().item()
+            num_prefills = non_spec_query_lens_cpu.size(0) - num_decodes - num_zero_len
             num_decode_tokens = num_decodes
-            num_prefill_tokens = non_spec_query_lens.sum().item() - num_decode_tokens
+            num_prefill_tokens = (
+                non_spec_query_lens_cpu.sum().item() - num_decode_tokens
+            )
             num_spec_decode_tokens = (
-                query_lens.sum().item() - num_prefill_tokens - num_decode_tokens
+                query_lens_cpu.sum().item() - num_prefill_tokens - num_decode_tokens
             )
 
             if num_prefills == 0 and num_decodes == 0:
@@ -236,7 +275,7 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
                     (
                         min(
                             num_spec_decodes * (self.num_spec + 1),
-                            query_start_loc[-1].item(),
+                            query_start_loc_cpu[-1].item(),
                         )
                     ),
                     dtype=torch.bool,
@@ -244,7 +283,7 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
                 )
                 spec_token_size = min(
                     num_spec_decodes * (self.num_spec + 1),
-                    query_start_loc[-1].item(),
+                    query_start_loc_cpu[-1].item(),
                 )
                 spec_token_indx = torch.arange(
                     spec_token_size,
@@ -254,16 +293,27 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
                 non_spec_token_indx = torch.empty(
                     0, dtype=torch.int32, device=query_start_loc.device
                 )
-                spec_state_indices_tensor = block_table_tensor[:, : self.num_spec + 1]
+                spec_state_indices_tensor = block_table_tensor[
+                    spec_sequence_masks, : self.num_spec + 1
+                ]
+                spec_state_indices_tensor_cpu = (
+                    block_table_tensor_cpu[
+                        spec_sequence_masks_cpu, : self.num_spec + 1
+                    ]
+                    if block_table_tensor_cpu is not None
+                    else None
+                )
                 non_spec_state_indices_tensor = None
-                spec_query_start_loc = query_start_loc
+                spec_query_start_loc = query_start_loc[: num_spec_decodes + 1]
                 non_spec_query_start_loc = None
                 non_spec_query_start_loc_cpu = None
             else:
                 spec_token_masks = torch.repeat_interleave(
-                    spec_sequence_masks, query_lens
+                    spec_sequence_masks,
+                    query_lens,
+                    output_size=query_start_loc_cpu[-1].item(),
                 )
-                index = torch.argsort(spec_token_masks, stable=True)
+                index = torch.argsort(spec_token_masks.int(), stable=True)
                 num_non_spec_tokens = num_prefill_tokens + num_decode_tokens
                 non_spec_token_indx = index[:num_non_spec_tokens]
                 spec_token_indx = index[num_non_spec_tokens:]
@@ -271,9 +321,21 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
                 spec_state_indices_tensor = block_table_tensor[
                     spec_sequence_masks, : self.num_spec + 1
                 ]
+                spec_state_indices_tensor_cpu = (
+                    block_table_tensor_cpu[
+                        spec_sequence_masks_cpu, : self.num_spec + 1
+                    ]
+                    if block_table_tensor_cpu is not None
+                    else None
+                )
                 non_spec_state_indices_tensor = block_table_tensor[
                     ~spec_sequence_masks, 0
                 ]
+                non_spec_state_indices_tensor_cpu = (
+                    block_table_tensor_cpu[~spec_sequence_masks_cpu, 0]
+                    if block_table_tensor_cpu is not None
+                    else None
+                )
 
                 spec_query_start_loc = torch.zeros(
                     num_spec_decodes + 1,
@@ -307,8 +369,7 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
             num_accepted_tokens = num_accepted_tokens[spec_sequence_masks]
 
         if num_prefills > 0:
-            # has_initial_state = context_lens_tensor > 0
-            has_initial_state = (context_lens_tensor > 0).to(torch.int32)
+            has_initial_state = context_lens_tensor.clamp(min=0, max=1)
             if spec_sequence_masks is not None:
                 has_initial_state = has_initial_state[~spec_sequence_masks]
                 assert non_spec_query_start_loc_cpu is not None
@@ -335,21 +396,37 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
             self.spec_state_indices_tensor[:num_spec_decodes].copy_(
                 spec_state_indices_tensor, non_blocking=True
             )
-            spec_state_indices_tensor = self.spec_state_indices_tensor[:batch_size]
-            spec_state_indices_tensor[num_spec_decodes:].fill_(PAD_SLOT_ID)
-
-            self.spec_sequence_masks[:num_spec_decodes].copy_(
-                spec_sequence_masks, non_blocking=True
+            self.spec_conv_state_indices_tensor[:num_spec_decodes].copy_(
+                spec_state_indices_tensor[:, 0], non_blocking=True
             )
+            self.spec_conv_state_indices_tensor_cpu[:num_spec_decodes].copy_(
+                spec_state_indices_tensor_cpu[:num_spec_decodes, 0]
+                if spec_state_indices_tensor_cpu is not None
+                else spec_state_indices_tensor[:, 0].to(device="cpu", dtype=torch.int32)
+            )
+            spec_state_indices_tensor = self.spec_state_indices_tensor[:batch_size]
+            spec_state_indices_tensor[num_spec_decodes:].fill_(0)
+            spec_conv_state_indices_tensor = self.spec_conv_state_indices_tensor[
+                :batch_size
+            ]
+            spec_conv_state_indices_tensor[num_spec_decodes:].fill_(0)
+            spec_conv_state_indices_tensor_cpu = (
+                self.spec_conv_state_indices_tensor_cpu[:batch_size]
+            )
+            spec_conv_state_indices_tensor_cpu[num_spec_decodes:].fill_(0)
+
             spec_sequence_masks = self.spec_sequence_masks[:batch_size]
+            spec_sequence_masks[:num_spec_decodes].fill_(True)
             spec_sequence_masks[num_spec_decodes:].fill_(False)
 
             assert spec_token_masks is not None
-            self.spec_token_masks[: spec_token_masks.size(0)].copy_(
-                spec_token_masks, non_blocking=True
+            spec_token_size = spec_token_masks.size(0)
+            self.spec_token_masks[:spec_token_size].copy_(
+                spec_token_masks,
+                non_blocking=True,
             )
             spec_token_masks = self.spec_token_masks[: m.num_actual_tokens]
-            spec_token_masks[spec_token_masks.size(0) :].fill_(False)
+            spec_token_masks[spec_token_size:].fill_(False)
 
             assert non_spec_token_indx is not None and spec_token_indx is not None
             self.non_spec_token_indx[: non_spec_token_indx.size(0)].copy_(
@@ -371,11 +448,31 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
             spec_query_start_loc = self.spec_query_start_loc[: batch_size + 1]
             spec_query_start_loc[num_spec_decodes + 1 :].fill_(spec_num_query_tokens)
 
+            num_accepted_tokens = num_accepted_tokens.to(dtype=torch.int32)
+            self.num_accepted_tokens_cpu[:num_spec_decodes].copy_(
+                num_accepted_tokens.to(device="cpu", dtype=torch.int32)
+            )
             self.num_accepted_tokens[:num_spec_decodes].copy_(
                 num_accepted_tokens, non_blocking=True
             )
             num_accepted_tokens = self.num_accepted_tokens[:batch_size]
             num_accepted_tokens[num_spec_decodes:].fill_(1)
+            num_accepted_tokens_cpu = self.num_accepted_tokens_cpu[:batch_size]
+            num_accepted_tokens_cpu[num_spec_decodes:].fill_(1)
+        elif spec_state_indices_tensor is not None:
+            spec_conv_state_indices_tensor = (
+                spec_state_indices_tensor[:, 0].to(torch.int32).contiguous()
+            )
+            spec_conv_state_indices_tensor_cpu = (
+                spec_state_indices_tensor_cpu[:, 0].contiguous()
+                if spec_state_indices_tensor_cpu is not None
+                else spec_conv_state_indices_tensor.to(device="cpu", dtype=torch.int32)
+            )
+            assert num_accepted_tokens is not None
+            num_accepted_tokens = num_accepted_tokens.to(dtype=torch.int32)
+            num_accepted_tokens_cpu = num_accepted_tokens.to(
+                device="cpu", dtype=torch.int32
+            )
 
         if (
             self.use_full_cuda_graph
@@ -389,7 +486,7 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
             non_spec_state_indices_tensor = self.non_spec_state_indices_tensor[
                 :batch_size
             ]
-            non_spec_state_indices_tensor[num_decodes:].fill_(PAD_SLOT_ID)
+            non_spec_state_indices_tensor[num_decodes:].fill_(0)
 
             self.non_spec_query_start_loc[: num_decodes + 1].copy_(
                 non_spec_query_start_loc, non_blocking=True
@@ -397,6 +494,13 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
             non_spec_num_query_tokens = non_spec_query_start_loc[-1]  # type: ignore[index]
             non_spec_query_start_loc = self.non_spec_query_start_loc[: batch_size + 1]
             non_spec_query_start_loc[num_decodes + 1 :].fill_(non_spec_num_query_tokens)
+        elif (
+            non_spec_state_indices_tensor is not None
+            and non_spec_state_indices_tensor_cpu is None
+        ):
+            non_spec_state_indices_tensor_cpu = non_spec_state_indices_tensor.to(
+                device="cpu", dtype=torch.int32
+            )
 
         attn_metadata = GDNAttentionMetadata(
             num_prefills=num_prefills,
@@ -412,23 +516,26 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
             ),
             spec_query_start_loc=spec_query_start_loc,
             non_spec_query_start_loc=non_spec_query_start_loc,
-            non_spec_query_start_loc_cpu=(
-                non_spec_query_start_loc.cpu()
-                if non_spec_query_start_loc is not None
-                else None
-            ),
+            non_spec_query_start_loc_cpu=non_spec_query_start_loc_cpu,
             spec_state_indices_tensor=spec_state_indices_tensor,
+            spec_conv_state_indices_tensor=spec_conv_state_indices_tensor,
+            spec_conv_state_indices_tensor_cpu=spec_conv_state_indices_tensor_cpu,
             non_spec_state_indices_tensor=non_spec_state_indices_tensor,
-            non_spec_state_indices_tensor_cpu=(
-                non_spec_state_indices_tensor.cpu()
-                if non_spec_state_indices_tensor is not None
-                else None
-            ),
+            non_spec_state_indices_tensor_cpu=non_spec_state_indices_tensor_cpu,
             spec_sequence_masks=spec_sequence_masks,
             spec_token_masks=spec_token_masks,
             spec_token_indx=spec_token_indx,
             non_spec_token_indx=non_spec_token_indx,
             num_accepted_tokens=num_accepted_tokens,
+            num_accepted_tokens_cpu=(
+                num_accepted_tokens_cpu
+                if num_accepted_tokens_cpu is not None
+                else (
+                    num_accepted_tokens.to(device="cpu", dtype=torch.int32)
+                    if num_accepted_tokens is not None
+                    else None
+                )
+            ),
             nums_dict=nums_dict,
             batch_ptr=batch_ptr,
             token_chunk_offset_ptr=token_chunk_offset_ptr,
@@ -455,7 +562,7 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
             f"cudagraph capture sizes ({self.decode_cudagraph_max_bs})."
         )
 
-        num_accepted_tokens = torch.diff(m.query_start_loc)
+        num_accepted_tokens = torch.diff(m.query_start_loc).to(dtype=torch.int32)
         num_decode_draft_tokens_cpu = (num_accepted_tokens - 1).cpu()
 
         return self.build(0, m, num_accepted_tokens, num_decode_draft_tokens_cpu)

--- a/vllm_kunlun/v1/attention/backends/gdn_attn.py
+++ b/vllm_kunlun/v1/attention/backends/gdn_attn.py
@@ -5,7 +5,6 @@
 from dataclasses import dataclass
 
 import torch
-
 from vllm.config import VllmConfig
 from vllm.v1.attention.backend import (
     AttentionBackend,
@@ -19,7 +18,6 @@ from vllm.v1.attention.backends.utils import (
     mamba_get_block_table_tensor,
     split_decodes_and_prefills,
 )
-
 from vllm.v1.kv_cache_interface import AttentionSpec, MambaSpec
 
 
@@ -247,7 +245,9 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
             spec_conv_state_indices_tensor = None
             non_spec_state_indices_tensor = block_table_tensor[:, 0]
             non_spec_state_indices_tensor_cpu = (
-                block_table_tensor_cpu[:, 0] if block_table_tensor_cpu is not None else None
+                block_table_tensor_cpu[:, 0]
+                if block_table_tensor_cpu is not None
+                else None
             )
             spec_query_start_loc = None
             non_spec_query_start_loc = query_start_loc
@@ -297,9 +297,7 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
                     spec_sequence_masks, : self.num_spec + 1
                 ]
                 spec_state_indices_tensor_cpu = (
-                    block_table_tensor_cpu[
-                        spec_sequence_masks_cpu, : self.num_spec + 1
-                    ]
+                    block_table_tensor_cpu[spec_sequence_masks_cpu, : self.num_spec + 1]
                     if block_table_tensor_cpu is not None
                     else None
                 )
@@ -322,9 +320,7 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
                     spec_sequence_masks, : self.num_spec + 1
                 ]
                 spec_state_indices_tensor_cpu = (
-                    block_table_tensor_cpu[
-                        spec_sequence_masks_cpu, : self.num_spec + 1
-                    ]
+                    block_table_tensor_cpu[spec_sequence_masks_cpu, : self.num_spec + 1]
                     if block_table_tensor_cpu is not None
                     else None
                 )

--- a/vllm_kunlun/v1/attention/backends/kunlun_attn.py
+++ b/vllm_kunlun/v1/attention/backends/kunlun_attn.py
@@ -15,7 +15,9 @@
 # This file is a part of the vllm-kunlun project.
 #
 import copy
+import inspect
 from dataclasses import dataclass
+from itertools import accumulate
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -602,6 +604,13 @@ class KunlunAttentionMetadataBuilder:
         seq_lens = common_attn_metadata.seq_lens
         seq_lens_cpu = common_attn_metadata.seq_lens_cpu
 
+        seq_start_loc = list(accumulate(seq_lens, initial=0))
+
+        seq_start_loc_tensor = torch.empty(
+            len(seq_start_loc), dtype=torch.int32, device=self.device
+        )
+        seq_start_loc_tensor.copy_(torch.as_tensor(seq_start_loc, dtype=torch.int32))
+
         kv_lod_cpu = torch.zeros(num_reqs + 1, dtype=torch.int32, device="cpu")
         kv_lod_cpu[1:] = seq_lens_cpu.to(torch.int32).cumsum(dim=0)
         kv_lod_xpu = kv_lod_cpu.to(self.device)
@@ -896,47 +905,114 @@ class KunlunAttentionImpl(AttentionImpl[KunlunMetadata]):
                     decode_meta.block_tables * 2
                 )  # only test in Qwen3-Next
 
-            # Determine batch_size and qlen based on whether it's speculative
-            if not attn_metadata.is_speculative:
-                batch_size = decode_meta.block_tables.shape[0]
-                qlen = 1
-                # Reshape q for non-speculative case
-                q = decode_query.unsqueeze(
-                    0
-                )  # [1, batch_size*qlen, head_num, head_dim]
-                out = output[:num_decode_tokens]
+            sig = inspect.signature(kunlun_ops.speculative_attention)
+            if "max_window_size" in sig.parameters:
+                batch_size = attn_metadata.num_decodes
+                query_seq_len, head_num, head_dim = decode_query.shape
+                if (
+                    not attn_metadata.is_speculative
+                    or batch_size == 0
+                    or query_seq_len == batch_size
+                ):
+                    kunlun_ops.speculative_attention(
+                        out=output[:num_decode_tokens],
+                        q=decode_query.unsqueeze(0),
+                        k_cache=key_cache,
+                        v_cache=value_cache,
+                        context_lens_cpu=decode_meta.seq_lens_tensor_cpu,
+                        context_lens_xpu=decode_meta.seq_lens_tensor,
+                        batch_num=decode_meta.block_tables.shape[0],
+                        qlen=1,
+                        max_context_len=131072,
+                        head_num=self.num_heads,
+                        head_dim=self.head_size,
+                        scale=0.0,
+                        kv_head_num=self.num_kv_heads,
+                        block_size=key_cache.shape[2],
+                        max_num_blocks_per_seq=decode_meta.block_tables.shape[1],
+                        max_window_size=(
+                            self.sliding_window
+                            if self.sliding_window is not None
+                            else -1
+                        ),
+                        block_tables=tmp_block_tables,
+                        sink=(
+                            self.sinks.to(torch.float32)
+                            if self.sinks is not None
+                            else None
+                        ),
+                    )
+                else:
+                    assert query_seq_len % batch_size == 0
+                    qlen = query_seq_len // batch_size
+                    out = output[:num_decode_tokens]
+                    kunlun_ops.speculative_attention(
+                        out=out.view(batch_size, qlen, head_num, self.head_size),
+                        q=decode_query.view(batch_size, qlen, head_num, head_dim),
+                        k_cache=key_cache,
+                        v_cache=value_cache,
+                        context_lens_cpu=decode_meta.seq_lens_tensor_cpu,
+                        context_lens_xpu=decode_meta.seq_lens_tensor,
+                        batch_num=batch_size,
+                        qlen=qlen,
+                        max_context_len=decode_meta.max_model_len,
+                        head_num=self.num_heads,
+                        head_dim=self.head_size,
+                        scale=0.0,
+                        kv_head_num=self.num_kv_heads,
+                        block_size=key_cache.shape[2],
+                        max_num_blocks_per_seq=decode_meta.block_tables.shape[1],
+                        max_window_size=(
+                            self.sliding_window
+                            if self.sliding_window is not None
+                            else -1
+                        ),
+                        block_tables=tmp_block_tables,
+                        sink=(
+                            self.sinks.to(torch.float32)
+                            if self.sinks is not None
+                            else None
+                        ),
+                    )
+            elif not attn_metadata.is_speculative:
+                kunlun_ops.paged_attention(
+                    x=decode_query,
+                    k_cache=key_cache,
+                    v_cache=value_cache,
+                    block_tables=tmp_block_tables,
+                    context_lens_cpu=decode_meta.seq_lens_tensor_cpu,
+                    context_lens_xpu=decode_meta.seq_lens_tensor,
+                    is_context=False,
+                    is_causal=True,
+                    out=output[:num_decode_tokens],
+                    vo_head_dim=self.head_size,
+                )
             else:
                 batch_size = attn_metadata.num_decodes
                 query_seq_len, head_num, head_dim = decode_query.shape
                 assert query_seq_len % batch_size == 0
                 qlen = query_seq_len // batch_size
-                q = decode_query.view(batch_size, qlen, head_num, head_dim)
                 out = output[:num_decode_tokens]
                 assert out.is_contiguous()
-                out = out.view(batch_size, qlen, head_num, self.head_size)
 
-            kunlun_ops.speculative_attention(
-                out=out,
-                q=q,
-                k_cache=key_cache,
-                v_cache=value_cache,
-                context_lens_cpu=decode_meta.seq_lens_tensor_cpu,
-                context_lens_xpu=decode_meta.seq_lens_tensor,
-                batch_num=batch_size,
-                qlen=qlen,
-                max_context_len=decode_meta.max_model_len,
-                head_num=self.num_heads,
-                head_dim=self.head_size,
-                scale=self.scale,
-                kv_head_num=self.num_kv_heads,
-                block_size=key_cache.shape[2],
-                max_num_blocks_per_seq=decode_meta.block_tables.shape[1],
-                max_window_size=(
-                    self.sliding_window if self.sliding_window is not None else -1
-                ),
-                block_tables=tmp_block_tables,
-                sink=(self.sinks.to(torch.float32) if self.sinks is not None else None),
-            )
+                kunlun_ops.speculative_attention(
+                    out=out.view(batch_size, qlen, head_num, self.head_size),
+                    q=decode_query.view(batch_size, qlen, head_num, head_dim),
+                    k_cache=key_cache,
+                    v_cache=value_cache,
+                    context_lens_cpu=decode_meta.seq_lens_tensor_cpu,
+                    context_lens_xpu=decode_meta.seq_lens_tensor,
+                    batch_num=batch_size,
+                    qlen=qlen,
+                    max_context_len=decode_meta.max_model_len,
+                    head_num=self.num_heads,
+                    head_dim=self.head_size,
+                    scale=0.0,
+                    kv_head_num=self.num_kv_heads,
+                    block_size=key_cache.shape[2],
+                    max_num_blocks_per_seq=decode_meta.block_tables.shape[1],
+                    block_tables=tmp_block_tables,
+                )
         # Reshape the output tensor.
         return output.view(-1, self.num_heads * self.head_size)
 

--- a/vllm_kunlun/v1/sample/rejection_sampler.py
+++ b/vllm_kunlun/v1/sample/rejection_sampler.py
@@ -6,18 +6,18 @@ from dataclasses import replace
 
 import torch
 import torch.nn as nn
-
 from vllm.v1.outputs import LogprobsLists, LogprobsTensors, SamplerOutput
 from vllm.v1.sample.metadata import SamplingMetadata
 from vllm.v1.sample.ops.bad_words import apply_bad_words_with_drafts
 from vllm.v1.sample.ops.penalties import apply_all_penalties
+from vllm.v1.sample.ops.topk_topp_sampler import apply_top_k_top_p
 from vllm.v1.sample.sampler import Sampler
 from vllm.v1.spec_decode.metadata import SpecDecodeMetadata
-from vllm.v1.sample.ops.topk_topp_sampler import apply_top_k_top_p
+
 from vllm_kunlun.v1.sample.rejection_sampler_patch import (
-    _KernelLauncher,
     _expand_impl,
     _greedy_impl,
+    _KernelLauncher,
     _random_impl,
     _sample_recovered_impl,
 )
@@ -110,9 +110,9 @@ class RejectionSampler(nn.Module):
             predict_bonus_token=True,
             # Override the logprobs mode to return logits because they are
             # needed later to compute the accepted token logprobs.
-            logprobs_mode_override="processed_logits"
-            if self.is_processed_logprobs_mode
-            else "raw_logits",
+            logprobs_mode_override=(
+                "processed_logits" if self.is_processed_logprobs_mode else "raw_logits"
+            ),
         )
         bonus_token_ids = bonus_sampler_output.sampled_token_ids
 
@@ -132,21 +132,22 @@ class RejectionSampler(nn.Module):
             target_logits, sampling_metadata, metadata
         )
 
-        fast_output_token_ids = rejection_sample_small_spec_topk(
-            metadata.draft_token_ids,
-            metadata.num_draft_tokens,
-            metadata.max_spec_len,
-            metadata.cu_num_draft_tokens,
-            draft_probs,
-            target_logits,
-            bonus_token_ids,
-            sampling_metadata,
-        )
-        if fast_output_token_ids is not None:
-            return SamplerOutput(
-                sampled_token_ids=fast_output_token_ids,
-                logprobs_tensors=None,
+        if getattr(metadata, "_kunlun_qwen35_mtp", False):
+            fast_output_token_ids = rejection_sample_small_spec_topk(
+                metadata.draft_token_ids,
+                metadata.num_draft_tokens,
+                metadata.max_spec_len,
+                metadata.cu_num_draft_tokens,
+                draft_probs,
+                target_logits,
+                bonus_token_ids,
+                sampling_metadata,
             )
+            if fast_output_token_ids is not None:
+                return SamplerOutput(
+                    sampled_token_ids=fast_output_token_ids,
+                    logprobs_tensors=None,
+                )
 
         # [num_tokens, vocab_size]
         # NOTE(woosuk): `target_logits` can be updated in place inside the
@@ -490,9 +491,8 @@ def rejection_sample_small_spec_topk(
 
     batch_size = len(num_draft_tokens)
     num_tokens = draft_token_ids.shape[0]
-    if (
-        num_tokens != batch_size * max_spec_len
-        or any(n != max_spec_len for n in num_draft_tokens)
+    if num_tokens != batch_size * max_spec_len or any(
+        n != max_spec_len for n in num_draft_tokens
     ):
         return None
     assert cu_num_draft_tokens.ndim == 1
@@ -521,11 +521,7 @@ def rejection_sample_small_spec_topk(
     topk_vals, order = topk_vals.sort(dim=1, descending=True)
     topk_idx = topk_idx.gather(1, order)
     if sampling_metadata.top_k.numel() != 1:
-        k_idx = (
-            (top_k.to(torch.long) - 1)
-            .clamp_(min=0, max=select_k - 1)
-            .unsqueeze(1)
-        )
+        k_idx = (top_k.to(torch.long) - 1).clamp_(min=0, max=select_k - 1).unsqueeze(1)
         k_threshold = topk_vals.gather(1, k_idx)
         topk_vals = topk_vals.masked_fill(topk_vals < k_threshold, -float("inf"))
 
@@ -569,9 +565,7 @@ def rejection_sample_small_spec_topk(
     if len(sampling_metadata.generators) != batch_size:
         q.exponential_()
     for req_idx, generator in sampling_metadata.generators.items():
-        start_idx = (
-            0 if req_idx == 0 else int(cu_num_draft_tokens[req_idx - 1].item())
-        )
+        start_idx = 0 if req_idx == 0 else int(cu_num_draft_tokens[req_idx - 1].item())
         end_idx = int(cu_num_draft_tokens[req_idx].item())
         if end_idx > start_idx:
             q[start_idx:end_idx].exponential_(generator=generator)
@@ -644,7 +638,9 @@ def rejection_sample_small_spec_topk(
     output_token_ids[:, max_spec_len] = torch.where(
         accepted_prefix[:, -1],
         bonus_token_ids.view(-1).to(torch.int32),
-        torch.full((batch_size,), PLACEHOLDER_TOKEN_ID, dtype=torch.int32, device=device),
+        torch.full(
+            (batch_size,), PLACEHOLDER_TOKEN_ID, dtype=torch.int32, device=device
+        ),
     )
     return output_token_ids
 

--- a/vllm_kunlun/v1/sample/rejection_sampler.py
+++ b/vllm_kunlun/v1/sample/rejection_sampler.py
@@ -1,21 +1,32 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-from typing import Optional
+
+from collections.abc import Sequence
+from dataclasses import replace
 
 import torch
 import torch.nn as nn
-from vllm.logger import init_logger
-from vllm.v1.sample.metadata import SamplingMetadata
-from vllm.v1.sample.ops.topk_topp_sampler import apply_top_k_top_p
-from vllm.v1.spec_decode.metadata import SpecDecodeMetadata
 
-logger = init_logger(__name__)
+from vllm.v1.outputs import LogprobsLists, LogprobsTensors, SamplerOutput
+from vllm.v1.sample.metadata import SamplingMetadata
+from vllm.v1.sample.ops.bad_words import apply_bad_words_with_drafts
+from vllm.v1.sample.ops.penalties import apply_all_penalties
+from vllm.v1.sample.sampler import Sampler
+from vllm.v1.spec_decode.metadata import SpecDecodeMetadata
+from vllm.v1.sample.ops.topk_topp_sampler import apply_top_k_top_p
+from vllm_kunlun.v1.sample.rejection_sampler_patch import (
+    _KernelLauncher,
+    _expand_impl,
+    _greedy_impl,
+    _random_impl,
+    _sample_recovered_impl,
+)
 
 PLACEHOLDER_TOKEN_ID = -1
-GREEDY_TEMPERATURE = -1
+GREEDY_TEMPERATURE = 0
 # Maximum number of speculative draft tokens allowed per request in a single
 # step. This value is chosen to be large enough to handle typical use cases.
-MAX_SPEC_LEN = 32
+MAX_SPEC_LEN = 128
 
 
 class RejectionSampler(nn.Module):
@@ -41,17 +52,22 @@ class RejectionSampler(nn.Module):
         output tokens = accepted tokens + recovered tokens + bonus tokens
     """
 
+    def __init__(self, sampler: Sampler):
+        super().__init__()
+        self.sampler = sampler
+        logprobs_mode = self.sampler.logprobs_mode
+        self.is_processed_logprobs_mode = logprobs_mode.startswith("processed")
+        self.is_logits_logprobs_mode = logprobs_mode.endswith("logits")
+
     def forward(
         self,
         metadata: SpecDecodeMetadata,
         # [num_tokens, vocab_size]
-        draft_probs: Optional[torch.Tensor],
-        # [num_tokens, vocab_size]
-        target_logits: torch.Tensor,
-        # [batch_size, 1]
-        bonus_token_ids: torch.Tensor,
+        draft_probs: torch.Tensor | None,
+        # [num_tokens + batch_size, vocab_size]
+        logits: torch.Tensor,
         sampling_metadata: SamplingMetadata,
-    ) -> torch.Tensor:
+    ) -> SamplerOutput:
         """
         Args:
             metadata:
@@ -60,36 +76,88 @@ class RejectionSampler(nn.Module):
                 Probability distribution for the draft tokens. Shape is
                 [num_tokens, vocab_size]. Can be None if probabilities are
                 not provided, which is the case for ngram spec decode.
-            target_logits (torch.Tensor):
+            logits (torch.Tensor):
                 Target model's logits probability distribution.
-                Shape is [num_tokens, vocab_size]. Here, probabilities from
-                different requests are flattened into a single tensor because
-                this is the shape of the output logits.
-                NOTE: `target_logits` can be updated in place to save memory.
-            bonus_token_ids_tensor (torch.Tensor):
-                A tensor containing bonus tokens. Shape is [batch_size, 1].
-                Bonus tokens are added to the end of the sequence if all
-                proposed tokens are accepted. We generate the bonus tokens
-                outside of the rejection sampler with the default sampling
-                strategy. It allows for more flexibility in the sampling
-                process such as top_p, top_k sampling.
+                Shape is [num_tokens + batch_size, vocab_size]. Here,
+                probabilities from different requests are flattened into a
+                single tensor because this is the shape of the output logits.
+                NOTE: `logits` can be updated in place to save memory.
             sampling_metadata (vllm.v1.sample.metadata.SamplingMetadata):
                 Additional metadata needed for sampling, such as temperature,
                 top-k/top-p parameters, or other relevant information.
         Returns:
-            output_token_ids (torch.Tensor):
-                A tensor containing the final output token IDs.
+            SamplerOutput:
+                Contains the final output token IDs and their logprobs if
+                requested.
         """
         assert metadata.max_spec_len <= MAX_SPEC_LEN
+
+        bonus_logits_indices = metadata.bonus_logits_indices
+        target_logits_indices = metadata.target_logits_indices
+
+        # When indexing with a tensor (bonus_logits_indices), PyTorch
+        # creates a new tensor with separate storage from the original
+        # logits tensor. This means any in-place operations on bonus_logits
+        # won't affect the original logits tensor.
+        assert logits is not None
+        bonus_logits = logits[bonus_logits_indices]
+        bonus_sampler_output = self.sampler(
+            logits=bonus_logits,
+            sampling_metadata=replace(
+                sampling_metadata,
+                max_num_logprobs=-1,
+            ),
+            predict_bonus_token=True,
+            # Override the logprobs mode to return logits because they are
+            # needed later to compute the accepted token logprobs.
+            logprobs_mode_override="processed_logits"
+            if self.is_processed_logprobs_mode
+            else "raw_logits",
+        )
+        bonus_token_ids = bonus_sampler_output.sampled_token_ids
+
+        # Just like `bonus_logits`, `target_logits` is a new tensor with
+        # separate storage from the original `logits` tensor. Therefore,
+        # it is safe to update `target_logits` in place.
+        raw_target_logits = logits[target_logits_indices]
+        # Use float32 for the target_logits.
+        raw_target_logits = raw_target_logits.to(torch.float32)
+        target_logits = raw_target_logits
+        if not self.is_processed_logprobs_mode:
+            # Clone raw_target_logits before applying processors to preserve
+            # the original raw logits for logprobs computation, since
+            # apply_logits_processors modifies the tensor in-place.
+            target_logits = target_logits.clone()
+        target_logits = self.apply_logits_processors(
+            target_logits, sampling_metadata, metadata
+        )
+
+        fast_output_token_ids = rejection_sample_small_spec_topk(
+            metadata.draft_token_ids,
+            metadata.num_draft_tokens,
+            metadata.max_spec_len,
+            metadata.cu_num_draft_tokens,
+            draft_probs,
+            target_logits,
+            bonus_token_ids,
+            sampling_metadata,
+        )
+        if fast_output_token_ids is not None:
+            return SamplerOutput(
+                sampled_token_ids=fast_output_token_ids,
+                logprobs_tensors=None,
+            )
+
         # [num_tokens, vocab_size]
         # NOTE(woosuk): `target_logits` can be updated in place inside the
-        # `compute_probs` function.
-
-        target_probs = compute_probs(
+        # `apply_sampling_constraints` function.
+        target_logits = apply_sampling_constraints(
             target_logits,
             metadata.cu_num_draft_tokens,
             sampling_metadata,
         )
+        # Compute probability distribution from target logits.
+        target_probs = target_logits.softmax(dim=-1, dtype=torch.float32)
 
         output_token_ids = rejection_sample(
             metadata.draft_token_ids,
@@ -101,22 +169,88 @@ class RejectionSampler(nn.Module):
             bonus_token_ids,
             sampling_metadata,
         )
-        return output_token_ids
+
+        logprobs_tensors = None
+        if sampling_metadata.max_num_logprobs is not None:
+            logprobs_tensors = self._get_logprobs_tensors(
+                sampling_metadata.max_num_logprobs,
+                metadata,
+                logits,
+                target_logits if self.is_processed_logprobs_mode else raw_target_logits,
+                bonus_sampler_output.logprobs_tensors.logprobs,
+                output_token_ids,
+            )
+
+        return SamplerOutput(
+            sampled_token_ids=output_token_ids,
+            logprobs_tensors=logprobs_tensors,
+        )
+
+    def _get_logprobs_tensors(
+        self,
+        max_num_logprobs: int,
+        metadata: SpecDecodeMetadata,
+        logits: torch.Tensor,
+        target_logits: torch.Tensor,
+        bonus_logits: torch.Tensor,
+        sampled_token_ids: torch.Tensor,
+    ) -> LogprobsTensors:
+        cu_num_sampled_tokens = torch.zeros_like(metadata.cu_num_sampled_tokens)
+        cu_num_sampled_tokens[1:] = metadata.cu_num_sampled_tokens[:-1]
+
+        # Collect target and bonus logits.
+        bonus_logits_indices = metadata.bonus_logits_indices
+        target_logits_indices = metadata.target_logits_indices
+        final_logits = torch.zeros_like(logits, dtype=torch.float32)
+        final_logits[target_logits_indices] = target_logits.to(torch.float32)
+        final_logits[bonus_logits_indices] = bonus_logits.to(torch.float32)
+
+        # NOTE: To avoid cpu-gpu synchronization, we now simply compute indices for
+        # all draft tokens, including the rejected ones. The rejected tokens will
+        # be filtered out in the `parse_output`.
+        logit_start_indices = cu_num_sampled_tokens
+        offsets = torch.arange(
+            sampled_token_ids.shape[-1],
+            device=logit_start_indices.device,
+            dtype=logit_start_indices.dtype,
+        )
+        accepted_logit_indices = (
+            logit_start_indices.unsqueeze(1) + offsets.unsqueeze(0)
+        ).flatten()
+        accepted_logit_indices.clamp_(max=final_logits.shape[0] - 1)
+        accepted_tokens = sampled_token_ids.clone().flatten()
+        # we replace rejected token ids with 0 to avoid gather_logprobs error
+        accepted_tokens[accepted_tokens == PLACEHOLDER_TOKEN_ID] = 0
+
+        # Compute logprobs for accepted tokens.
+        accepted_logits = final_logits[accepted_logit_indices]
+        accepted_logprobs = (
+            accepted_logits
+            if self.is_logits_logprobs_mode
+            else self.sampler.compute_logprobs(accepted_logits)
+        )
+        return self.sampler.gather_logprobs(
+            accepted_logprobs,
+            max_num_logprobs,
+            accepted_tokens.to(torch.int64),
+        )
 
     @staticmethod
     def parse_output(
         output_token_ids: torch.Tensor,
         vocab_size: int,
-    ) -> list[list[int]]:
+        discard_req_indices: Sequence[int] = (),
+        logprobs_tensors: LogprobsTensors | None = None,
+    ) -> tuple[list[list[int]], LogprobsLists | None]:
         """Parse the output of the rejection sampler.
-
         Args:
             output_token_ids: The sampled token IDs in shape
                 [batch_size, max_spec_len + 1]. The rejected tokens are
                 replaced with `PLACEHOLDER_TOKEN_ID` by the rejection sampler
                 and will be filtered out in this function.
             vocab_size: The size of the vocabulary.
-
+            discard_req_indices: Optional row indices to discard tokens in.
+            logprobs_tensors: Optional logprobs tensors to filter.
         Returns:
             A list of lists of token IDs.
         """
@@ -125,10 +259,107 @@ class RejectionSampler(nn.Module):
         valid_mask = (output_token_ids_np != PLACEHOLDER_TOKEN_ID) & (
             output_token_ids_np < vocab_size
         )
+        output_logprobs = None
+        if logprobs_tensors is not None:
+            cu_num_tokens = [0] + valid_mask.sum(axis=1).cumsum().tolist()
+            filtered_tensors = logprobs_tensors.filter(valid_mask.flatten())
+            output_logprobs = filtered_tensors.tolists(cu_num_tokens)
+
+        if len(discard_req_indices) > 0:
+            valid_mask[discard_req_indices] = False
         outputs = [
             row[valid_mask[i]].tolist() for i, row in enumerate(output_token_ids_np)
         ]
-        return outputs
+        return outputs, output_logprobs
+
+    def apply_logits_processors(
+        self,
+        logits: torch.Tensor,
+        sampling_metadata: SamplingMetadata,
+        metadata: SpecDecodeMetadata,
+    ) -> torch.Tensor:
+        has_penalties = not sampling_metadata.no_penalties
+        any_penalties_or_bad_words = (
+            sampling_metadata.bad_words_token_ids or has_penalties
+        )
+
+        output_token_ids = sampling_metadata.output_token_ids
+        if any_penalties_or_bad_words:
+            output_token_ids = self._combine_outputs_with_spec_tokens(
+                output_token_ids,
+                sampling_metadata.spec_token_ids,
+            )
+
+        # Calculate indices of target logits.
+        if sampling_metadata.allowed_token_ids_mask is not None or has_penalties:
+            num_requests = len(sampling_metadata.output_token_ids)
+            num_draft_tokens = torch.tensor(metadata.num_draft_tokens, device="cpu")
+            original_indices = torch.arange(num_requests, device="cpu")
+            repeat_indices_cpu = original_indices.repeat_interleave(num_draft_tokens)
+            repeat_indices = repeat_indices_cpu.to(
+                device=logits.device, non_blocking=True
+            )
+            logits = self.apply_penalties(
+                logits, sampling_metadata, metadata, repeat_indices, output_token_ids
+            )
+
+            # Apply allowed token ids.
+            if sampling_metadata.allowed_token_ids_mask is not None:
+                token_mask = sampling_metadata.allowed_token_ids_mask[repeat_indices]
+                logits.masked_fill_(token_mask, float("-inf"))
+
+        # Apply bad words exclusion.
+        if bad_words_token_ids := sampling_metadata.bad_words_token_ids:
+            apply_bad_words_with_drafts(
+                logits, bad_words_token_ids, output_token_ids, metadata.num_draft_tokens
+            )
+
+        return logits
+
+    @staticmethod
+    def apply_penalties(
+        logits: torch.Tensor,
+        sampling_metadata: SamplingMetadata,
+        metadata: SpecDecodeMetadata,
+        repeat_indices: torch.Tensor,
+        output_token_ids: list[list[int]],
+    ) -> torch.Tensor:
+        if sampling_metadata.no_penalties:
+            return logits
+
+        assert sampling_metadata.prompt_token_ids is not None
+
+        prompt_token_ids = sampling_metadata.prompt_token_ids[repeat_indices]
+        presence_penalties = sampling_metadata.presence_penalties[repeat_indices]
+        frequency_penalties = sampling_metadata.frequency_penalties[repeat_indices]
+        repetition_penalties = sampling_metadata.repetition_penalties[repeat_indices]
+
+        logits = apply_all_penalties(
+            logits,
+            prompt_token_ids,
+            presence_penalties,
+            frequency_penalties,
+            repetition_penalties,
+            output_token_ids,
+        )
+        return logits
+
+    @staticmethod
+    def _combine_outputs_with_spec_tokens(
+        output_token_ids: list[list[int]],
+        spec_token_ids: list[list[int]] | None = None,
+    ) -> list[list[int]]:
+        if spec_token_ids is None:
+            return output_token_ids
+
+        result = []
+        for out, spec in zip(output_token_ids, spec_token_ids):
+            if len(spec) == 0:
+                continue
+            result.append(out)
+            for i in range(len(spec) - 1):
+                result.append([*result[-1], spec[i]])
+        return result
 
 
 def rejection_sample(
@@ -140,7 +371,7 @@ def rejection_sample(
     # [batch_size]
     cu_num_draft_tokens: torch.Tensor,
     # [num_tokens, vocab_size]
-    draft_probs: Optional[torch.Tensor],
+    draft_probs: torch.Tensor | None,
     # [num_tokens, vocab_size]
     target_probs: torch.Tensor,
     # [batch_size, 1]
@@ -163,12 +394,12 @@ def rejection_sample(
     assert target_probs.shape == (num_tokens, vocab_size)
 
     # Create output buffer.
-    output_token_ids = torch.empty(
+    output_token_ids = torch.full(
         (batch_size, max_spec_len + 1),
+        PLACEHOLDER_TOKEN_ID,
         dtype=torch.int32,  # Consistent with SamplerOutput.sampled_token_ids.
         device=device,
     )
-    output_token_ids.fill_(PLACEHOLDER_TOKEN_ID)
 
     if sampling_metadata.all_greedy:
         is_greedy = None
@@ -177,28 +408,15 @@ def rejection_sample(
     if not sampling_metadata.all_random:
         # Rejection sampling for greedy sampling requests.
         target_argmax = target_probs.argmax(dim=-1)
-        if (
-            min(num_draft_tokens) == 1
-            and max(num_draft_tokens) == 1
-            and sampling_metadata.all_greedy
-        ):
-            rejection_greedy_sample_spec_len_1_pytorch(
-                output_token_ids,
-                draft_token_ids,
-                target_argmax,
-                bonus_token_ids,
-            )
-        else:
-            rejection_greedy_sample_pytorch(
-                output_token_ids,
-                cu_num_draft_tokens,
-                draft_token_ids,
-                target_argmax,
-                bonus_token_ids,
-                num_draft_tokens,
-                max_spec_len,
-                is_greedy,
-            )
+        rejection_greedy_sample_kernel[(batch_size,)](
+            output_token_ids,
+            cu_num_draft_tokens,
+            draft_token_ids,
+            target_argmax,
+            bonus_token_ids,
+            is_greedy,
+            max_spec_len,
+        )
         if sampling_metadata.all_greedy:
             return output_token_ids
 
@@ -224,7 +442,8 @@ def rejection_sample(
         device,
     )
 
-    rejection_random_sample_pytorch(
+    # Rejection sampling for random sampling requests.
+    rejection_random_sample_kernel[(batch_size,)](
         output_token_ids,
         cu_num_draft_tokens,
         draft_token_ids,
@@ -236,33 +455,220 @@ def rejection_sample(
         is_greedy,
         max_spec_len,
         vocab_size,
-        IS_NGRAM=draft_probs is None,
-        # num_warps=1,
+        NO_DRAFT_PROBS=draft_probs is None,
     )
     return output_token_ids
 
 
-def compute_probs(
+def rejection_sample_small_spec_topk(
+    draft_token_ids: torch.Tensor,
+    num_draft_tokens: list[int],
+    max_spec_len: int,
+    cu_num_draft_tokens: torch.Tensor,
+    draft_probs: torch.Tensor | None,
+    target_logits: torch.Tensor,
+    bonus_token_ids: torch.Tensor,
+    sampling_metadata: SamplingMetadata,
+) -> torch.Tensor | None:
+    """Fast path for the common small-spec random top-k case.
+
+    This intentionally stays narrow. It avoids the full-vocab
+    `apply_top_k_top_p + softmax` path when every request has the same small
+    number of draft tokens and sampling is random top-k without logprobs. The
+    general path remains the source of truth for mixed greedy/random batches,
+    logprobs, missing/large top-k, partial draft batches, and larger spec
+    lengths. Extending this helper to those cases would duplicate more of the
+    upstream sampler semantics and increase review/correctness risk.
+    """
+    if (
+        max_spec_len not in (1, 2, 3)
+        or not sampling_metadata.all_random
+        or sampling_metadata.max_num_logprobs is not None
+        or sampling_metadata.top_k is None
+    ):
+        return None
+
+    batch_size = len(num_draft_tokens)
+    num_tokens = draft_token_ids.shape[0]
+    if (
+        num_tokens != batch_size * max_spec_len
+        or any(n != max_spec_len for n in num_draft_tokens)
+    ):
+        return None
+    assert cu_num_draft_tokens.ndim == 1
+
+    device = target_logits.device
+    vocab_size = target_logits.shape[-1]
+    logits = target_logits
+
+    if max_spec_len == 1:
+        temperature = sampling_metadata.temperature
+        top_k = sampling_metadata.top_k
+        top_p = sampling_metadata.top_p
+    else:
+        temperature = sampling_metadata.temperature.repeat_interleave(max_spec_len)
+        top_k = sampling_metadata.top_k.repeat_interleave(max_spec_len)
+        top_p = None
+        if sampling_metadata.top_p is not None:
+            top_p = sampling_metadata.top_p.repeat_interleave(max_spec_len)
+    logits = logits / temperature.unsqueeze(-1)
+
+    select_k = min(int(top_k.max().item()), vocab_size)
+    if select_k <= 0 or select_k == vocab_size:
+        return None
+
+    topk_vals, topk_idx = logits.topk(select_k, dim=1, largest=True, sorted=False)
+    topk_vals, order = topk_vals.sort(dim=1, descending=True)
+    topk_idx = topk_idx.gather(1, order)
+    if sampling_metadata.top_k.numel() != 1:
+        k_idx = (
+            (top_k.to(torch.long) - 1)
+            .clamp_(min=0, max=select_k - 1)
+            .unsqueeze(1)
+        )
+        k_threshold = topk_vals.gather(1, k_idx)
+        topk_vals = topk_vals.masked_fill(topk_vals < k_threshold, -float("inf"))
+
+    if top_p is not None:
+        probs = topk_vals.softmax(dim=-1)
+        probs_cumsum = probs.cumsum(dim=-1)
+        top_p_mask = (probs_cumsum - probs) >= top_p.unsqueeze(1)
+        top_p_mask[:, 0] = False
+        topk_vals = topk_vals.masked_fill(top_p_mask, -float("inf"))
+
+    topk_probs = topk_vals.softmax(dim=-1, dtype=torch.float32)
+    draft_token_ids_long = draft_token_ids.to(torch.long)
+    draft_matches = topk_idx.eq(draft_token_ids_long.unsqueeze(1))
+    target_draft_probs = torch.where(
+        draft_matches,
+        topk_probs,
+        torch.zeros_like(topk_probs),
+    ).sum(dim=1)
+
+    if draft_probs is None:
+        draft_token_probs = torch.ones_like(target_draft_probs)
+        recovered_probs = topk_probs.masked_fill(draft_matches, 0)
+    else:
+        draft_token_probs = draft_probs.gather(
+            1, draft_token_ids_long.unsqueeze(1)
+        ).squeeze(1)
+        draft_topk_probs = draft_probs.gather(1, topk_idx)
+        recovered_probs = (topk_probs - draft_topk_probs).clamp_min_(0)
+
+    uniform_probs = generate_uniform_probs(
+        num_tokens,
+        num_draft_tokens,
+        sampling_metadata.generators,
+        device,
+    )
+    accept_mask = (draft_token_probs > 0) & (
+        target_draft_probs / draft_token_probs >= uniform_probs
+    )
+
+    q = torch.empty_like(recovered_probs)
+    if len(sampling_metadata.generators) != batch_size:
+        q.exponential_()
+    for req_idx, generator in sampling_metadata.generators.items():
+        start_idx = (
+            0 if req_idx == 0 else int(cu_num_draft_tokens[req_idx - 1].item())
+        )
+        end_idx = int(cu_num_draft_tokens[req_idx].item())
+        if end_idx > start_idx:
+            q[start_idx:end_idx].exponential_(generator=generator)
+
+    recovered_token_ids = topk_idx.gather(
+        1, recovered_probs.div(q).argmax(dim=1, keepdim=True)
+    ).squeeze(1)
+
+    if max_spec_len == 2:
+        output_token_ids = torch.empty(
+            (batch_size, 3),
+            dtype=torch.int32,
+            device=device,
+        )
+        draft_matrix = draft_token_ids_long.view(batch_size, 2)
+        recovered_matrix = recovered_token_ids.view(batch_size, 2)
+        accept_matrix = accept_mask.view(batch_size, 2)
+        output_token_ids[:, 0] = torch.where(
+            accept_matrix[:, 0],
+            draft_matrix[:, 0],
+            recovered_matrix[:, 0],
+        ).to(torch.int32)
+        output_token_ids[:, 1] = torch.where(
+            accept_matrix[:, 0],
+            torch.where(
+                accept_matrix[:, 1],
+                draft_matrix[:, 1],
+                recovered_matrix[:, 1],
+            ),
+            torch.full(
+                (batch_size,),
+                PLACEHOLDER_TOKEN_ID,
+                dtype=torch.long,
+                device=device,
+            ),
+        ).to(torch.int32)
+        output_token_ids[:, 2] = torch.where(
+            accept_matrix[:, 0] & accept_matrix[:, 1],
+            bonus_token_ids.view(-1).to(torch.int32),
+            torch.full(
+                (batch_size,),
+                PLACEHOLDER_TOKEN_ID,
+                dtype=torch.int32,
+                device=device,
+            ),
+        )
+        return output_token_ids
+
+    output_token_ids = torch.full(
+        (batch_size, max_spec_len + 1),
+        PLACEHOLDER_TOKEN_ID,
+        dtype=torch.int32,
+        device=device,
+    )
+    accept_matrix = accept_mask.view(batch_size, max_spec_len)
+    accepted_prefix = accept_matrix.cumprod(dim=1).bool()
+    valid_positions = torch.ones_like(accept_matrix)
+    valid_positions[:, 1:] = accepted_prefix[:, :-1]
+
+    token_matrix = torch.where(
+        accept_matrix,
+        draft_token_ids_long.view(batch_size, max_spec_len),
+        recovered_token_ids.view(batch_size, max_spec_len),
+    ).to(torch.int32)
+    output_token_ids[:, :max_spec_len] = torch.where(
+        valid_positions,
+        token_matrix,
+        torch.full_like(token_matrix, PLACEHOLDER_TOKEN_ID),
+    )
+    output_token_ids[:, max_spec_len] = torch.where(
+        accepted_prefix[:, -1],
+        bonus_token_ids.view(-1).to(torch.int32),
+        torch.full((batch_size,), PLACEHOLDER_TOKEN_ID, dtype=torch.int32, device=device),
+    )
+    return output_token_ids
+
+
+def apply_sampling_constraints(
     logits: torch.Tensor,  # [num_tokens, vocab_size]
     cu_num_draft_tokens: torch.Tensor,  # [batch_size]
     sampling_metadata: SamplingMetadata,
 ) -> torch.Tensor:
-    """Compute probability distribution from logits based on sampling metadata.
+    """Process logits based on sampling metadata.
 
-    This function applies temperature scaling to the logits and converts
-    them to probabilities using softmax. For greedy decoding, it returns
+    This function applies temperature scaling to the logits,
+    as well as top-k and top-p. For greedy decoding, it returns
     the original logits.
 
     Args:
-        logits: Input logits tensor to be converted to probabilities.
+        logits: Input logits tensor to be processed.
         cu_num_draft_tokens: Cumulative number of draft tokens.
         sampling_metadata: Metadata containing sampling parameters such as
             temperature and whether greedy sampling is used.
 
     Returns:
-        torch.Tensor: Probability distribution (softmax of scaled logits)
-            if non-greedy sampling is used, otherwise returns the
-            original logits.
+        torch.Tensor: Processed logits if non-greedy sampling is used,
+        otherwise returns the original logits.
     """
     assert logits.ndim == 2
     assert cu_num_draft_tokens.ndim == 1
@@ -298,9 +704,7 @@ def compute_probs(
 
     # NOTE(woosuk): `apply_top_k_top_p` uses sorting to calculate the mask,
     # which is slow for large vocab sizes. This may cause performance issues.
-    logits = apply_top_k_top_p(logits, top_k, top_p)
-    output_prob = logits.softmax(dim=-1, dtype=torch.float32)
-    return output_prob
+    return apply_top_k_top_p(logits, top_k, top_p)
 
 
 def expand_batch_to_tokens(
@@ -332,7 +736,7 @@ def expand_batch_to_tokens(
     batch_size = x.shape[0]
     assert cu_num_tokens.shape[0] == batch_size
     expanded_x = x.new_empty(num_tokens)
-    expand_pytorch(
+    expand_kernel[(batch_size,)](
         expanded_x,
         x,
         cu_num_tokens,
@@ -360,23 +764,28 @@ def generate_uniform_probs(
     without a seed.
 
     Args:
-        num_tokens : int
+        num_tokens: int
             Total number of tokens.
-        num_draft_tokens : List[List[int]]
+        num_draft_tokens: List[List[int]]
             Number of draft tokens per request.
-        generators : Optional[Dict[int, torch.Generator]]
+        generators: Optional[Dict[int, torch.Generator]]
             A dictionary mapping indices in the batch to
             `torch.Generator` objects.
-        device : torch.device
+        device: torch.device
             The device on which to allocate the tensor.
     Returns:
-        uniform_rand : torch.Tensor
+        uniform_rand: torch.Tensor
             A tensor of shape `(num_tokens, )` containing uniform
             random values in the range [0, 1).
     """
+    # NOTE(woosuk): We deliberately use float64 instead of float32 here
+    # because when using float32, there's a non-negligible chance that
+    # uniform_prob is sampled to be exact 0.0 as reported in
+    # https://github.com/pytorch/pytorch/issues/16706. Using float64
+    # mitigates the issue.
     uniform_probs = torch.rand(
         (num_tokens,),
-        dtype=torch.float32,
+        dtype=torch.float64,
         device=device,
     )
     start_idx = 0
@@ -401,7 +810,7 @@ def sample_recovered_tokens(
     # [num_tokens]
     draft_token_ids: torch.Tensor,
     # [num_tokens, vocab_size]
-    draft_probs: Optional[torch.Tensor],
+    draft_probs: torch.Tensor | None,
     # [num_tokens, vocab_size]
     target_probs: torch.Tensor,
     sampling_metadata: SamplingMetadata,
@@ -423,7 +832,7 @@ def sample_recovered_tokens(
             q[i].exponential_(generator=generator)
 
     recovered_token_ids = torch.empty_like(draft_token_ids)
-    sample_recovered_tokens_pytorch(
+    sample_recovered_tokens_kernel[(batch_size, max_spec_len)](
         recovered_token_ids,
         cu_num_draft_tokens,
         draft_token_ids,
@@ -431,211 +840,18 @@ def sample_recovered_tokens(
         target_probs,
         q,
         vocab_size,
-        IS_NGRAM=draft_probs is None,
+        _next_power_of_2(vocab_size),
+        NO_DRAFT_PROBS=draft_probs is None,
     )
     return recovered_token_ids
 
 
-def rejection_greedy_sample_spec_len_1_pytorch(
-    output_token_ids,  # [batch_size, 2]
-    draft_token_ids,  # [num_tokens]
-    target_argmax,  # [num_tokens]
-    bonus_token_ids,  # [batch_size]
-):
-    batch_size = output_token_ids.size(0)
-    num_tokens = draft_token_ids.size(0)
-    assert batch_size == num_tokens
-    accept_req_mask = draft_token_ids == target_argmax
-    output_token_ids[:, 0] = target_argmax
-    bonus_token_ids = bonus_token_ids.squeeze(1)
-    output_token_ids[:, 1] = torch.where(
-        accept_req_mask, bonus_token_ids, output_token_ids[:, 1]
-    )
+def _next_power_of_2(x: int) -> int:
+    return 1 << (x - 1).bit_length()
 
 
-def rejection_greedy_sample_pytorch(
-    output_token_ids,  # [batch_size, max_spec_len + 1]
-    cu_num_draft_tokens,  # [batch_size]
-    draft_token_ids,  # [num_tokens]
-    target_argmax,  # [num_tokens]
-    bonus_token_ids,  # [batch_size]
-    draft_tokens_per_req,  # [batch_size], list
-    max_spec_len,
-    is_greedy=None,  # [batch_size] or None
-):
-    batch_size = output_token_ids.size(0)
-    num_tokens = draft_token_ids.size(0)
-    device = output_token_ids.device
-    draft_tokens_per_req = torch.tensor(draft_tokens_per_req).to(
-        device, non_blocking=True
-    )
-    if is_greedy is None:
-        is_greedy = torch.ones(batch_size, dtype=torch.bool, device=device)
-
-    start_indices = cu_num_draft_tokens - draft_tokens_per_req
-    req_ids = torch.arange(batch_size, device=device)
-    token_req_ids = torch.repeat_interleave(req_ids, draft_tokens_per_req)
-    token_positions = (
-        torch.arange(num_tokens, device=device) - start_indices[token_req_ids]
-    )
-
-    # Find the first mismatch position of each request.
-    mismatch_global = draft_token_ids != target_argmax
-    if max_spec_len == 0:
-        first_mismatch_pos_per_req = torch.zeros(
-            batch_size, dtype=torch.long, device=device
-        )
-    else:
-        # [bs, max_spec_len]
-        pos_matrix = torch.full(
-            (batch_size, max_spec_len), -1, dtype=torch.long, device=device
-        )
-        pos_matrix[token_req_ids, token_positions] = token_positions
-        mismatch_matrix = torch.full(
-            (batch_size, max_spec_len), False, dtype=torch.bool, device=device
-        )
-        mismatch_matrix[token_req_ids, token_positions] = mismatch_global
-        mismatch_positions = torch.where(mismatch_matrix, pos_matrix, max_spec_len * 2)
-        first_mismatch_pos_per_req, _ = torch.min(mismatch_positions, dim=1)
-        no_mismatch_mask = first_mismatch_pos_per_req == max_spec_len * 2
-        first_mismatch_pos_per_req[no_mismatch_mask] = draft_tokens_per_req[
-            no_mismatch_mask
-        ]
-
-    # Copy matched target tokens into output.
-    copy_len = torch.minimum(first_mismatch_pos_per_req + 1, draft_tokens_per_req)
-    copy_indices = torch.arange(max_spec_len + 1, device=device).expand(batch_size, -1)
-    copy_mask = copy_indices < copy_len.unsqueeze(1)
-    greedy_mask = is_greedy.unsqueeze(1)
-    final_copy_mask = copy_mask & greedy_mask
-    global_idx = start_indices.unsqueeze(1) + copy_indices
-    output_token_ids[final_copy_mask] = target_argmax[global_idx[final_copy_mask]].to(
-        output_token_ids.dtype
-    )
-    # Fill bonus token.
-    needs_bonus = is_greedy & (first_mismatch_pos_per_req >= draft_tokens_per_req)
-    if torch.any(needs_bonus):
-        bonus_rows = torch.where(needs_bonus)[0]
-        bonus_cols = draft_tokens_per_req[bonus_rows]
-        bonus_token_ids = bonus_token_ids.squeeze(1)
-        output_token_ids[bonus_rows, bonus_cols] = bonus_token_ids[bonus_rows]
-
-
-def rejection_random_sample_pytorch(
-    output_token_ids,  # [batch_size, max_spec_len + 1]
-    cu_num_draft_tokens,  # [batch_size]
-    draft_token_ids,  # [num_tokens]
-    draft_probs,  # [num_tokens, vocab_size] or None
-    target_probs,  # [num_tokens, vocab_size]
-    bonus_token_ids,  # [batch_size]
-    recovered_token_ids,  # [num_tokens]
-    uniform_probs,  # [num_tokens]
-    is_greedy,  # [batch_size]
-    max_spec_len,
-    vocab_size,
-    IS_NGRAM=False,
-):
-    batch_size = output_token_ids.shape[0]
-
-    for req_idx in range(batch_size):
-        if is_greedy[req_idx]:
-            continue
-
-        if req_idx == 0:
-            start_idx = 0
-        else:
-            start_idx = cu_num_draft_tokens[req_idx - 1].item()
-        end_idx = cu_num_draft_tokens[req_idx].item()
-        num_draft_tokens = end_idx - start_idx
-
-        rejected = False
-        for pos in range(num_draft_tokens):
-            if not rejected:
-                draft_token_id = draft_token_ids[start_idx + pos].item()
-
-                if IS_NGRAM:
-                    draft_prob = 1.0
-                else:
-                    draft_prob = draft_probs[start_idx + pos, draft_token_id].item()
-
-                target_prob = target_probs[start_idx + pos, draft_token_id].item()
-                uniform_prob = uniform_probs[start_idx + pos].item()
-
-                if draft_prob > 0 and target_prob / draft_prob >= uniform_prob:
-                    token_id = draft_token_id
-                else:
-                    rejected = True
-                    token_id = recovered_token_ids[start_idx + pos].item()
-
-                output_token_ids[req_idx, pos] = token_id
-
-        if not rejected:
-            bonus_token_id = bonus_token_ids[req_idx].item()
-            output_token_ids[req_idx, num_draft_tokens] = bonus_token_id
-
-
-def expand_pytorch(
-    output_ptr,  # [num_tokens]
-    input_ptr,  # [batch_size]
-    cu_num_tokens_ptr,  # [batch_size]
-    replace_from,
-    replace_to,
-    MAX_NUM_TOKENS,
-):
-    batch_size = len(input_ptr)
-
-    for req_idx in range(batch_size):
-        start_idx = 0 if req_idx == 0 else cu_num_tokens_ptr[req_idx - 1]
-        end_idx = cu_num_tokens_ptr[req_idx]
-        num_tokens = end_idx - start_idx
-
-        src_val = input_ptr[req_idx]
-        src_val = replace_to if src_val == replace_from else src_val
-
-        offset = torch.arange(MAX_NUM_TOKENS, device=num_tokens.device)
-        mask = offset < num_tokens
-
-        output_slice = start_idx + offset[mask]
-        output_ptr[output_slice] = src_val
-
-
-def sample_recovered_tokens_pytorch(
-    output_token_ids,  # [num_tokens]
-    cu_num_draft_tokens,  # [batch_size]
-    draft_token_ids,  # [num_tokens]
-    draft_probs,  # [num_tokens, vocab_size] or None
-    target_probs,  # [num_tokens, vocab_size]
-    q,  # [batch_size, vocab_size]
-    vocab_size,
-    IS_NGRAM=False,
-):
-    batch_size = len(cu_num_draft_tokens)
-
-    for req_idx in range(batch_size):
-        start_idx = 0 if req_idx == 0 else cu_num_draft_tokens[req_idx - 1]
-        end_idx = cu_num_draft_tokens[req_idx]
-        num_draft_tokens = end_idx - start_idx
-
-        for pos in range(num_draft_tokens):
-            token_idx = start_idx + pos
-
-            if IS_NGRAM:
-                draft_token_id = draft_token_ids[token_idx]
-                orig_prob = target_probs[token_idx, draft_token_id].item()
-                target_probs[token_idx, draft_token_id] = 0
-                prob = target_probs[token_idx].clone()
-            else:
-                draft_p = draft_probs[token_idx].clone()
-                target_p = target_probs[token_idx].clone()
-                prob = torch.maximum(
-                    target_p - draft_p, torch.tensor(0.0, device=target_p.device)
-                )
-
-            q_values = torch.full((vocab_size,), float("-inf"), device=q.device)
-            q_values[:vocab_size] = q[req_idx, :vocab_size]
-
-            recovered_id = torch.argmax(prob / q_values).item()
-            output_token_ids[token_idx] = recovered_id
-
-            if IS_NGRAM:
-                target_probs[token_idx, draft_token_id] = orig_prob
+# Kunlun keeps vLLM's launch protocol while using PyTorch fallback launchers.
+rejection_greedy_sample_kernel = _KernelLauncher(_greedy_impl)
+rejection_random_sample_kernel = _KernelLauncher(_random_impl)
+expand_kernel = _KernelLauncher(_expand_impl)
+sample_recovered_tokens_kernel = _KernelLauncher(_sample_recovered_impl)

--- a/vllm_kunlun/v1/sample/rejection_sampler_patch.py
+++ b/vllm_kunlun/v1/sample/rejection_sampler_patch.py
@@ -1,0 +1,221 @@
+# SPDX-License-Identifier: Apache-2.0
+"""PyTorch launch shims for the Triton kernels used in
+``vllm.v1.sample.rejection_sampler``.
+
+The upstream rejection sampler unconditionally launches Triton/CUDA kernels
+(``expand_kernel``, ``rejection_greedy_sample_kernel``,
+``rejection_random_sample_kernel``, ``sample_recovered_tokens_kernel``).
+On Kunlun XPU the CUDA runtime is unavailable, so every launch ends in
+``AssertionError: libcuda.so cannot found!``.
+
+This module provides shims that mimic the ``kernel[grid](args...)`` launch
+protocol while running a PyTorch implementation instead. The behavior is kept
+in sync with the upstream kernels at vLLM 0.15.1.
+"""
+from __future__ import annotations
+
+from typing import Callable
+
+import torch
+
+
+class _KernelLauncher:
+    """Shim that mimics a ``triton.JITFunction`` launcher."""
+
+    def __init__(self, fn: Callable):
+        self._fn = fn
+
+    def __getitem__(self, grid):
+        if not isinstance(grid, tuple):
+            grid = (grid,)
+        fn = self._fn
+
+        def _launch(*args, **kwargs):
+            return fn(grid, *args, **kwargs)
+
+        return _launch
+
+
+def _expand_impl(
+    grid,
+    output_ptr,
+    input_ptr,
+    cu_num_tokens_ptr,
+    replace_from,
+    replace_to,
+    MAX_NUM_TOKENS=None,
+    **_,
+):
+    batch_size = int(grid[0])
+    if batch_size == 0:
+        return
+    cu = cu_num_tokens_ptr.tolist()
+    inp = input_ptr.tolist()
+    for req_idx in range(batch_size):
+        start_idx = 0 if req_idx == 0 else cu[req_idx - 1]
+        end_idx = cu[req_idx]
+        if end_idx <= start_idx:
+            continue
+        src_val = inp[req_idx]
+        if src_val == replace_from:
+            src_val = replace_to
+        output_ptr[start_idx:end_idx] = src_val
+
+
+def _greedy_impl(
+    grid,
+    output_token_ids_ptr,
+    cu_num_draft_tokens_ptr,
+    draft_token_ids_ptr,
+    target_argmax_ptr,
+    bonus_token_ids_ptr,
+    is_greedy_ptr,
+    max_spec_len,
+    **_,
+):
+    batch_size = int(grid[0])
+    if batch_size == 0:
+        return
+    cu = cu_num_draft_tokens_ptr.tolist()
+    draft = draft_token_ids_ptr.tolist()
+    argmax = target_argmax_ptr.tolist()
+    bonus = bonus_token_ids_ptr.reshape(-1).tolist()
+    if is_greedy_ptr is None:
+        is_greedy_list = [True] * batch_size
+    else:
+        is_greedy_list = [bool(x) for x in is_greedy_ptr.tolist()]
+
+    out_cpu = output_token_ids_ptr.cpu()
+    out_list = out_cpu.tolist()
+
+    for req_idx in range(batch_size):
+        if not is_greedy_list[req_idx]:
+            continue
+        start_idx = 0 if req_idx == 0 else cu[req_idx - 1]
+        end_idx = cu[req_idx]
+        num_draft = end_idx - start_idx
+        rejected = False
+        for pos in range(num_draft):
+            if rejected:
+                break
+            d = draft[start_idx + pos]
+            a = argmax[start_idx + pos]
+            out_list[req_idx][pos] = a
+            if d != a:
+                rejected = True
+        if not rejected:
+            out_list[req_idx][num_draft] = bonus[req_idx]
+
+    output_token_ids_ptr.copy_(
+        torch.tensor(
+            out_list,
+            dtype=output_token_ids_ptr.dtype,
+            device=output_token_ids_ptr.device,
+        )
+    )
+
+
+def _random_impl(
+    grid,
+    output_token_ids_ptr,
+    cu_num_draft_tokens_ptr,
+    draft_token_ids_ptr,
+    draft_probs_ptr,
+    target_probs_ptr,
+    bonus_token_ids_ptr,
+    recovered_token_ids_ptr,
+    uniform_probs_ptr,
+    is_greedy_ptr,
+    max_spec_len,
+    vocab_size,
+    NO_DRAFT_PROBS=False,
+    **_,
+):
+    batch_size = int(grid[0])
+    if batch_size == 0:
+        return
+    cu = cu_num_draft_tokens_ptr.tolist()
+    draft = draft_token_ids_ptr.tolist()
+    bonus = bonus_token_ids_ptr.reshape(-1).tolist()
+    recovered = recovered_token_ids_ptr.tolist()
+    uniform = uniform_probs_ptr.tolist()
+    is_greedy_list = [bool(x) for x in is_greedy_ptr.tolist()]
+
+    out_cpu = output_token_ids_ptr.cpu()
+    out_list = out_cpu.tolist()
+    target_cpu = target_probs_ptr.detach().cpu()
+    draft_probs_cpu = None if NO_DRAFT_PROBS else draft_probs_ptr.detach().cpu()
+
+    for req_idx in range(batch_size):
+        if is_greedy_list[req_idx]:
+            continue
+        start_idx = 0 if req_idx == 0 else cu[req_idx - 1]
+        end_idx = cu[req_idx]
+        num_draft = end_idx - start_idx
+        rejected = False
+        for pos in range(num_draft):
+            if rejected:
+                break
+            tok = start_idx + pos
+            d = draft[tok]
+            if NO_DRAFT_PROBS:
+                draft_prob = 1.0
+            else:
+                draft_prob = float(draft_probs_cpu[tok, d].item())
+            target_prob = float(target_cpu[tok, d].item())
+            u = float(uniform[tok])
+            if draft_prob > 0 and target_prob / draft_prob >= u:
+                token_id = d
+            else:
+                rejected = True
+                token_id = recovered[tok]
+            out_list[req_idx][pos] = token_id
+        if not rejected:
+            out_list[req_idx][num_draft] = bonus[req_idx]
+
+    output_token_ids_ptr.copy_(
+        torch.tensor(
+            out_list,
+            dtype=output_token_ids_ptr.dtype,
+            device=output_token_ids_ptr.device,
+        )
+    )
+
+
+def _sample_recovered_impl(
+    grid,
+    output_token_ids_ptr,
+    cu_num_draft_tokens_ptr,
+    draft_token_ids_ptr,
+    draft_probs_ptr,
+    target_probs_ptr,
+    q_ptr,
+    vocab_size,
+    PADDED_VOCAB_SIZE=None,
+    NO_DRAFT_PROBS=False,
+    **_,
+):
+    batch_size = int(grid[0])
+    if batch_size == 0:
+        return
+    cu = cu_num_draft_tokens_ptr.tolist()
+
+    for req_idx in range(batch_size):
+        start_idx = 0 if req_idx == 0 else cu[req_idx - 1]
+        end_idx = cu[req_idx]
+        num_draft = end_idx - start_idx
+        if num_draft <= 0:
+            continue
+        q = q_ptr[req_idx, :vocab_size]
+        for pos in range(num_draft):
+            tok = start_idx + pos
+            if NO_DRAFT_PROBS:
+                d = int(draft_token_ids_ptr[tok].item())
+                prob = target_probs_ptr[tok, :vocab_size].clone()
+                prob[d] = 0
+            else:
+                draft_prob = draft_probs_ptr[tok, :vocab_size]
+                target_prob = target_probs_ptr[tok, :vocab_size]
+                prob = torch.clamp(target_prob - draft_prob, min=0)
+            recovered_id = int(torch.argmax(prob / q).item())
+            output_token_ids_ptr[tok] = recovered_id

--- a/vllm_kunlun/v1/sample/rejection_sampler_patch.py
+++ b/vllm_kunlun/v1/sample/rejection_sampler_patch.py
@@ -12,6 +12,7 @@ This module provides shims that mimic the ``kernel[grid](args...)`` launch
 protocol while running a PyTorch implementation instead. The behavior is kept
 in sync with the upstream kernels at vLLM 0.15.1.
 """
+
 from __future__ import annotations
 
 from typing import Callable

--- a/vllm_kunlun/v1/sample/spec_decode/eagle.py
+++ b/vllm_kunlun/v1/sample/spec_decode/eagle.py
@@ -1,255 +1,21 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-from typing import Optional
-
 import numpy as np
 import torch
-from vllm.forward_context import set_forward_context
-from vllm.logger import init_logger
-from vllm.model_executor.models.llama_eagle3 import Eagle3LlamaForCausalLM
-from vllm.v1.attention.backends.tree_attn import TreeAttentionMetadata
 from vllm.v1.attention.backends.utils import CommonAttentionMetadata
-from vllm.v1.sample.metadata import SamplingMetadata
 from vllm.v1.spec_decode.eagle import EagleProposer
 from vllm.v1.worker.gpu_input_batch import CachedRequestState, InputBatch
-from vllm.v1.worker.ubatching import dbo_current_ubatch_id
 
-logger = init_logger(__name__)
+_orig_prepare_next_token_ids_padded = EagleProposer.prepare_next_token_ids_padded
+_orig_prepare_inputs_padded = EagleProposer.prepare_inputs_padded
+_orig_eagle_init = EagleProposer.__init__
 
-PADDING_SLOT_ID = -1
 
-
-def propose(
-    self,
-    # [num_tokens]
-    target_token_ids: torch.Tensor,
-    # [num_tokens]
-    target_positions: torch.Tensor,
-    # [num_tokens, hidden_size]
-    target_hidden_states: torch.Tensor,
-    # [batch_size]
-    next_token_ids: torch.Tensor,
-    last_token_indices: Optional[torch.Tensor],
-    common_attn_metadata: CommonAttentionMetadata,
-    sampling_metadata: SamplingMetadata,
-    mm_embeds: Optional[list[torch.Tensor]] = None,
-) -> torch.Tensor:
-    num_tokens = target_token_ids.shape[0]
-    batch_size = next_token_ids.shape[0]
-
-    if last_token_indices is None:
-        last_token_indices = common_attn_metadata.query_start_loc[1:] - 1
-
-    if self.method == "eagle3":
-        assert isinstance(self.model, Eagle3LlamaForCausalLM)
-        target_hidden_states = self.model.combine_hidden_states(target_hidden_states)
-        assert target_hidden_states.shape[-1] == self.hidden_size
-
-    # Shift the input ids by one token.
-    # E.g., [a1, b1, b2, c1, c2, c3] -> [b1, b2, c1, c2, c3, c3]
-    self.input_ids[: num_tokens - 1] = target_token_ids[1:]
-    # Replace the last token with the next token.
-    # E.g., [b1, b2, c1, c2, c3, c3] -> [a2, b2, b3, c2, c3, c4]
-    self.input_ids[last_token_indices] = next_token_ids
-
-    assert self.runner is not None
-
-    ubatch_id = dbo_current_ubatch_id()
-    attn_metadata_builder = self.runner.attn_groups[0][0].metadata_builders[ubatch_id]
-    attn_metadata = attn_metadata_builder.build_for_drafting(
-        common_attn_metadata=common_attn_metadata, draft_index=0
-    )
-    if (
-        hasattr(attn_metadata, "decode")
-        and attn_metadata.decode is not None
-        and hasattr(attn_metadata.decode, "spec_num_seq_len")
-        and attn_metadata.decode.spec_num_seq_len is not None
-    ):
-        attn_metadata.decode.spec_num_seq_len = -1
-
-    if self.draft_indexer_metadata_builder:
-        draft_indexer_metadata = self.draft_indexer_metadata_builder.build_for_drafting(
-            common_attn_metadata=common_attn_metadata,
-            draft_index=0,
-        )
-    else:
-        draft_indexer_metadata = None
-
-    # At this moment, we assume all eagle layers belong to the same KV
-    # cache group, thus using the same attention metadata.
-    per_layer_attn_metadata = {}
-    for layer_name in self.attn_layer_names:
-        per_layer_attn_metadata[layer_name] = attn_metadata
-    for layer_name in self.indexer_layer_names:
-        assert draft_indexer_metadata is not None
-        per_layer_attn_metadata[layer_name] = draft_indexer_metadata
-    if self.use_cuda_graph and num_tokens <= self.cudagraph_batch_sizes[-1]:
-        num_input_tokens = self.vllm_config.pad_for_cudagraph(num_tokens)
-    else:
-        num_input_tokens = num_tokens
-
-    # copy inputs to buffer for cudagraph
-    self.positions[:num_tokens] = target_positions
-    self.hidden_states[:num_tokens] = target_hidden_states
-    if self.is_multimodal_model:
-        input_ids = self.input_ids[:num_tokens]
-        inputs_embeds = self.model.get_input_embeddings(
-            input_ids,
-            multimodal_embeddings=mm_embeds or None,
-        )
-        self.inputs_embeds[:num_tokens] = inputs_embeds
-        inputs_embeds = self.inputs_embeds[:num_input_tokens]
-        input_ids = None
-    else:
-        inputs_embeds = None
-        input_ids = self.input_ids[:num_input_tokens]
-
-    with set_forward_context(
-        per_layer_attn_metadata, self.vllm_config, num_tokens=num_input_tokens
-    ):
-        ret_hidden_states = self.model(
-            input_ids=input_ids,
-            positions=self.positions[:num_input_tokens],
-            hidden_states=self.hidden_states[:num_input_tokens],
-            inputs_embeds=inputs_embeds,
-        )
-        if self.method == "mtp":
-            last_hidden_states = ret_hidden_states
-            hidden_states = self.hidden_states[:num_input_tokens]
-        else:
-            last_hidden_states, hidden_states = ret_hidden_states
-    sample_hidden_states = last_hidden_states[last_token_indices]
-    if self.method == "mtp":
-        logits = self.model.compute_logits(sample_hidden_states, 0)
-    else:
-        logits = self.model.compute_logits(sample_hidden_states, None)
-    positions = target_positions[last_token_indices]
-    hidden_states = hidden_states[last_token_indices]
-
-    if isinstance(attn_metadata, TreeAttentionMetadata):
-        # Draft using tree attention.
-        draft_token_ids_list = self.propose_tree(
-            batch_size=batch_size,
-            logits=logits,
-            positions=positions,
-            hidden_states=hidden_states,
-            common_attn_metadata=common_attn_metadata,
-        )
-        # [batch_size, num_tree_tokens]
-        return torch.cat(draft_token_ids_list, dim=1)
-
-    draft_token_ids = logits.argmax(dim=-1)
-
-    # Early exit if there is only one draft token to be generated.
-    if self.num_speculative_tokens == 1:
-        # [batch_size, 1]
-        return draft_token_ids.view(-1, 1)
-
-    # TODO: Currently, MTP module released by deepseek only has
-    # one layer. Adapt this code to support multiple layers once
-    # there's a multi-layer MTP module.
-
-    # Generate the remaining draft tokens.
-    draft_token_ids_list = [draft_token_ids]
-    if self.use_cuda_graph and batch_size <= self.cudagraph_batch_sizes[-1]:
-        input_batch_size = self.vllm_config.pad_for_cudagraph(batch_size)
-    else:
-        input_batch_size = batch_size
-
-    common_attn_metadata.num_actual_tokens = batch_size
-    common_attn_metadata.max_query_len = 1
-    common_attn_metadata.query_start_loc = self.arange[: batch_size + 1].to(torch.int32)
-    common_attn_metadata.query_start_loc_cpu = (
-        torch.from_numpy(self.token_arange_np[: batch_size + 1]).clone().to(torch.int32)
-    )
-
-    attn_metadata_builder = self.runner.attn_groups[0][0].metadata_builder
-    for token_index in range(self.num_speculative_tokens - 1):
-        # Update the inputs.
-        # cast to int32 is crucial when eagle model is compiled.
-        # tensor.argmax() returns int64 by default.
-        input_ids = draft_token_ids_list[-1].int()
-        positions += 1
-
-        # NOTE(woosuk): We should handle the case where the draft model
-        # generates tokens beyond the max model length. Since it is complex
-        # to remove such requests from the batch, we keep them in the batch
-        # but adjust the position ids and slot mappings to avoid the
-        # out-of-range access during the model execution. The draft tokens
-        # generated with this adjustment should be ignored.
-        exceeds_max_model_len = positions >= self.max_model_len
-        # Mask out the position ids that exceed the max model length.
-        # Otherwise, we may get out-of-range error in RoPE.
-        clamped_positions = torch.where(exceeds_max_model_len, 0, positions)
-
-        # Increment the sequence lengths.
-        common_attn_metadata.seq_lens += 1
-        common_attn_metadata.seq_lens_cpu += 1
-        # For the requests that exceed the max model length, we set the
-        # sequence length to 1 to minimize their overheads in attention.
-        common_attn_metadata.seq_lens.masked_fill_(exceeds_max_model_len, 1)
-        common_attn_metadata.num_computed_tokens_cpu = (
-            common_attn_metadata.seq_lens_cpu - 1
-        )
-
-        # Compute the slot mapping.
-        block_numbers = clamped_positions // self.block_size
-        block_ids = common_attn_metadata.block_table_tensor.gather(
-            dim=1, index=block_numbers.view(-1, 1)
-        )
-        block_ids = block_ids.view(-1)
-        common_attn_metadata.slot_mapping = (
-            block_ids * self.block_size + clamped_positions % self.block_size
-        )
-        # Mask out the slot mappings that exceed the max model length.
-        # Otherwise, the KV cache will be inadvertently updated with the
-        # padding tokens.
-        common_attn_metadata.slot_mapping.masked_fill_(
-            exceeds_max_model_len, PADDING_SLOT_ID
-        )
-
-        attn_metadata = attn_metadata_builder.build_for_drafting(
-            common_attn_metadata=common_attn_metadata, draft_index=token_index + 1
-        )
-        for layer_name in self.attn_layer_names:
-            per_layer_attn_metadata[layer_name] = attn_metadata
-        # copy inputs to buffer for cudagraph
-        self.input_ids[:batch_size] = input_ids
-        self.positions[:batch_size] = clamped_positions
-        self.hidden_states[:batch_size] = hidden_states
-        if self.is_multimodal_model:
-            inputs_embeds = self.model.get_input_embeddings(input_ids)
-            self.inputs_embeds[:batch_size] = inputs_embeds
-            inputs_embeds = self.inputs_embeds[:input_batch_size]
-            input_ids = None
-        else:
-            inputs_embeds = None
-            input_ids = self.input_ids[:input_batch_size]
-
-        # Run the model.
-        with set_forward_context(
-            per_layer_attn_metadata, self.vllm_config, num_tokens=input_batch_size
-        ):
-            ret_hidden_states = self.model(
-                input_ids=input_ids,
-                positions=self.positions[:input_batch_size],
-                hidden_states=self.hidden_states[:input_batch_size],
-                inputs_embeds=inputs_embeds,
-            )
-            if self.method == "mtp":
-                last_hidden_states = ret_hidden_states
-                hidden_states = ret_hidden_states
-            else:
-                last_hidden_states, hidden_states = ret_hidden_states
-
-        hidden_states = hidden_states[:batch_size]
-        logits = self.model.compute_logits(last_hidden_states[:batch_size])
-        draft_token_ids = logits.argmax(dim=-1)
-        draft_token_ids_list.append(draft_token_ids)
-
-    # [batch_size, num_speculative_tokens]
-    draft_token_ids = torch.stack(draft_token_ids_list, dim=1)
-    return draft_token_ids
+def _is_qwen35_mtp(self) -> bool:
+    if getattr(self, "method", None) == "qwen3_next_mtp":
+        return True
+    hf_config = getattr(getattr(self, "draft_model_config", None), "hf_config", None)
+    return getattr(hf_config, "model_type", None) == "qwen3_5_mtp"
 
 
 def prepare_next_token_ids_padded(
@@ -270,6 +36,15 @@ def prepare_next_token_ids_padded(
     should not introduce any blocking CPU-GPU synchronization.
     """
     # TODO(Ben): Combine this into a custom fused kernel
+    if not _is_qwen35_mtp(self):
+        return _orig_prepare_next_token_ids_padded(
+            self,
+            common_attn_metadata,
+            sampled_token_ids,
+            requests,
+            gpu_input_batch,
+            discard_request_mask,
+        )
 
     # Precompute get_token_id for when there is no valid next token
     num_reqs = gpu_input_batch.num_reqs
@@ -340,6 +115,14 @@ def prepare_inputs_padded(
     valid_sampled_tokens_count: torch.Tensor,
 ):
     """XPU fallback for upstream's Triton prepare-inputs kernel."""
+    if not _is_qwen35_mtp(self):
+        return _orig_prepare_inputs_padded(
+            self,
+            common_attn_metadata,
+            spec_decode_metadata,
+            valid_sampled_tokens_count,
+        )
+
     num_reqs = common_attn_metadata.num_reqs
 
     cu_num_draft = spec_decode_metadata.cu_num_draft_tokens
@@ -384,12 +167,13 @@ def prepare_inputs_padded(
     )
 
 
-_orig_eagle_init = EagleProposer.__init__
-
-
 def _patched_eagle_init(self, *args, **kwargs):
     _orig_eagle_init(self, *args, **kwargs)
-    if getattr(self, "uses_mrope", False) and not hasattr(self, "positions"):
+    if (
+        _is_qwen35_mtp(self)
+        and getattr(self, "uses_mrope", False)
+        and not hasattr(self, "positions")
+    ):
         self.positions = self.mrope_positions
 
 

--- a/vllm_kunlun/v1/sample/spec_decode/eagle.py
+++ b/vllm_kunlun/v1/sample/spec_decode/eagle.py
@@ -258,8 +258,7 @@ def prepare_next_token_ids_padded(
     sampled_token_ids: torch.Tensor,
     requests: dict[str, CachedRequestState],
     gpu_input_batch: InputBatch,
-    discard_request_indices: torch.Tensor,
-    num_discarded_requests: int,
+    discard_request_mask: torch.Tensor,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """
     This function is used to prepare the inputs for speculative decoding.
@@ -280,44 +279,41 @@ def prepare_next_token_ids_padded(
                 common_attn_metadata.seq_lens_cpu[i].item()
             )
             for i in range(num_reqs)
-        ]
+        ],
+        dtype=np.int32,
     )
     self.backup_next_token_ids.copy_to_gpu(num_reqs)
 
     # Mask out the sampled tokens indices that should not be sampled.
-    discard_sampled_tokens_req_indices = discard_request_indices[
-        :num_discarded_requests
-    ]
+    discard_sampled_tokens_req_indices = torch.nonzero(
+        discard_request_mask[:num_reqs], as_tuple=False
+    ).flatten()
 
     valid_sampled_token_ids_gpu = sampled_token_ids.clone()
     # valid_sampled_token_ids_gpu.index_fill_(
     #     0, discard_sampled_tokens_req_indices, -1)
     # ---- FIX START ----
     # XPU/XMLIR index_fill_ does NOT accept empty index tensor.
-    if num_discarded_requests > 0:
+    if discard_sampled_tokens_req_indices.numel() > 0:
         # make sure index is on same device and is int64
         idx = discard_sampled_tokens_req_indices
         if idx.device != valid_sampled_token_ids_gpu.device:
             idx = idx.to(valid_sampled_token_ids_gpu.device, non_blocking=True)
         if idx.dtype != torch.long:
             idx = idx.to(torch.long)
-        if idx.numel() > 0:
-            valid_sampled_token_ids_gpu.index_fill_(0, idx, -1)
+        valid_sampled_token_ids_gpu.index_fill_(0, idx, -1)
     # ---- FIX END ----
     # Generate a mask for all valid tokens within those requests
-    max_gen_len = sampled_token_ids.shape[-1]
-    if max_gen_len == 1:
-        valid_mask = torch.ones_like(valid_sampled_token_ids_gpu, dtype=torch.bool)
-    else:
-        valid_mask = (valid_sampled_token_ids_gpu != -1) & (
-            valid_sampled_token_ids_gpu < gpu_input_batch.vocab_size
-        )
+    valid_mask = (valid_sampled_token_ids_gpu != -1) & (
+        valid_sampled_token_ids_gpu < gpu_input_batch.vocab_size
+    )
 
     # Count the number of valid tokens in each request
-    valid_sampled_tokens_count = valid_mask.sum(dim=1)
+    valid_sampled_tokens_count_long = valid_mask.sum(dim=1)
+    valid_sampled_tokens_count = valid_sampled_tokens_count_long.to(torch.int32)
 
     # Get the rightmost valid index per row
-    last_valid_indices = valid_sampled_tokens_count - 1
+    last_valid_indices = valid_sampled_tokens_count_long - 1
     last_valid_indices_safe = torch.clamp(last_valid_indices, min=0)
 
     # Get last valid token from each row
@@ -337,5 +333,66 @@ def prepare_next_token_ids_padded(
     return next_token_ids, valid_sampled_tokens_count
 
 
-EagleProposer.propose = propose
+def prepare_inputs_padded(
+    self,
+    common_attn_metadata: CommonAttentionMetadata,
+    spec_decode_metadata,
+    valid_sampled_tokens_count: torch.Tensor,
+):
+    """XPU fallback for upstream's Triton prepare-inputs kernel."""
+    num_reqs = common_attn_metadata.num_reqs
+
+    cu_num_draft = spec_decode_metadata.cu_num_draft_tokens
+    num_draft = cu_num_draft.clone()
+    if num_reqs > 1:
+        num_draft[1:] = cu_num_draft[1:] - cu_num_draft[:-1]
+
+    valid_count = valid_sampled_tokens_count.to(num_draft.dtype)
+    num_rejected = num_draft + 1 - valid_count
+    num_rejected = torch.where(
+        num_draft > 0, num_rejected, torch.zeros_like(num_rejected)
+    )
+
+    q_last_tok_idx = common_attn_metadata.query_start_loc[1:] - 1
+    token_indices_to_sample = (q_last_tok_idx - num_rejected).to(torch.int32)
+    num_rejected_tokens_gpu = num_rejected.to(torch.int32)
+
+    query_start_loc_cpu = common_attn_metadata.query_start_loc_cpu
+    new_query_len_per_req = query_start_loc_cpu[1:] - query_start_loc_cpu[:-1]
+    total_num_tokens = query_start_loc_cpu[-1].item()
+
+    spec_common_attn_metadata = CommonAttentionMetadata(
+        query_start_loc=common_attn_metadata.query_start_loc,
+        seq_lens=common_attn_metadata.seq_lens,
+        query_start_loc_cpu=query_start_loc_cpu,
+        _seq_lens_cpu=common_attn_metadata._seq_lens_cpu,
+        _num_computed_tokens_cpu=common_attn_metadata._num_computed_tokens_cpu,
+        num_reqs=common_attn_metadata.num_reqs,
+        num_actual_tokens=total_num_tokens,
+        max_query_len=new_query_len_per_req.max().item(),
+        max_seq_len=common_attn_metadata.seq_lens_cpu.max().item(),
+        block_table_tensor=common_attn_metadata.block_table_tensor,
+        slot_mapping=common_attn_metadata.slot_mapping[:total_num_tokens],
+        causal=True,
+        dcp_local_seq_lens=common_attn_metadata.dcp_local_seq_lens,
+    )
+
+    return (
+        spec_common_attn_metadata,
+        token_indices_to_sample,
+        num_rejected_tokens_gpu,
+    )
+
+
+_orig_eagle_init = EagleProposer.__init__
+
+
+def _patched_eagle_init(self, *args, **kwargs):
+    _orig_eagle_init(self, *args, **kwargs)
+    if getattr(self, "uses_mrope", False) and not hasattr(self, "positions"):
+        self.positions = self.mrope_positions
+
+
 EagleProposer.prepare_next_token_ids_padded = prepare_next_token_ids_padded
+EagleProposer.prepare_inputs_padded = prepare_inputs_padded
+EagleProposer.__init__ = _patched_eagle_init

--- a/vllm_kunlun/v1/worker/mtp_mamba_state_patch.py
+++ b/vllm_kunlun/v1/worker/mtp_mamba_state_patch.py
@@ -1,0 +1,147 @@
+# SPDX-License-Identifier: Apache-2.0
+"""MTP Mamba state lifecycle fixes."""
+
+from __future__ import annotations
+
+import sys
+from typing import Any
+
+import torch
+
+
+def _is_torch_compiling() -> bool:
+    try:
+        compiler = getattr(torch, "compiler", None)
+        if compiler is not None and compiler.is_compiling():
+            return True
+    except Exception:
+        pass
+    try:
+        import torch._dynamo as dynamo
+
+        return bool(dynamo.is_compiling())
+    except Exception:
+        return False
+
+
+def _is_mamba_group(group: Any) -> bool:
+    spec = getattr(group, "kv_cache_spec", None)
+    return spec is not None and spec.__class__.__name__ == "MambaSpec"
+
+
+def _collect_new_mamba_block_ids(
+    runner: Any, scheduler_output: Any
+) -> dict[int, set[int]]:
+    kv_cache_config = getattr(runner, "kv_cache_config", None)
+    groups = getattr(kv_cache_config, "kv_cache_groups", ())
+    mamba_group_ids = [gid for gid, group in enumerate(groups) if _is_mamba_group(group)]
+    if not mamba_group_ids:
+        return {}
+
+    new_block_ids_by_group: dict[int, set[int]] = {gid: set() for gid in mamba_group_ids}
+
+    for new_req_data in getattr(scheduler_output, "scheduled_new_reqs", ()):
+        if int(getattr(new_req_data, "num_computed_tokens", 0)) != 0:
+            continue
+        block_ids = getattr(new_req_data, "block_ids", ())
+        for gid in mamba_group_ids:
+            if gid >= len(block_ids):
+                continue
+            group_block_ids = block_ids[gid]
+            if len(group_block_ids) > 1:
+                group_block_ids = group_block_ids[1:]
+            new_block_ids_by_group[gid].update(
+                int(block_id) for block_id in group_block_ids if int(block_id) >= 0
+            )
+
+    return {
+        gid: block_ids
+        for gid, block_ids in new_block_ids_by_group.items()
+        if block_ids
+    }
+
+
+def _iter_contiguous_ranges(block_ids: list[int]):
+    if not block_ids:
+        return
+    start = prev = block_ids[0]
+    for block_id in block_ids[1:]:
+        if block_id == prev + 1:
+            prev = block_id
+            continue
+        yield start, prev + 1
+        start = prev = block_id
+    yield start, prev + 1
+
+
+def _clear_new_mamba_blocks(runner: Any, scheduler_output: Any) -> int:
+    if getattr(runner, "speculative_config", None) is None:
+        return 0
+    if _is_torch_compiling():
+        return 0
+
+    new_block_ids_by_group = _collect_new_mamba_block_ids(runner, scheduler_output)
+    if not new_block_ids_by_group:
+        return 0
+
+    kv_cache_config = getattr(runner, "kv_cache_config", None)
+    groups = getattr(kv_cache_config, "kv_cache_groups", ())
+    forward_context = getattr(
+        getattr(runner, "compilation_config", None),
+        "static_forward_context",
+        {},
+    )
+    cleared_rows = 0
+
+    for gid, raw_block_ids in new_block_ids_by_group.items():
+        if gid >= len(groups):
+            continue
+        group = groups[gid]
+        layer_names = getattr(group, "layer_names", ())
+        for layer_name in layer_names:
+            attention = forward_context.get(layer_name)
+            kv_cache = getattr(attention, "kv_cache", None)
+            if not kv_cache:
+                continue
+            state_tensors = kv_cache[0]
+            if not isinstance(state_tensors, (list, tuple)):
+                continue
+            for state in state_tensors:
+                if not isinstance(state, torch.Tensor):
+                    continue
+                valid_block_ids = sorted(
+                    block_id
+                    for block_id in raw_block_ids
+                    if 0 <= block_id < state.size(0)
+                )
+                if not valid_block_ids:
+                    continue
+                for start, stop in _iter_contiguous_ranges(valid_block_ids):
+                    state[start:stop].zero_()
+                    cleared_rows += stop - start
+
+    return cleared_rows
+
+
+def patch_gpu_model_runner_module(module: Any) -> None:
+    runner_cls = getattr(module, "GPUModelRunner", None)
+    if runner_cls is None or getattr(runner_cls, "_kunlun_mtp_mamba_state_patched", False):
+        return
+
+    original_update_states = runner_cls._update_states
+
+    def _patched_update_states(self: Any, scheduler_output: Any) -> Any:
+        if getattr(self, "speculative_config", None) is None:
+            return original_update_states(self, scheduler_output)
+        result = original_update_states(self, scheduler_output)
+        _clear_new_mamba_blocks(self, scheduler_output)
+        return result
+
+    runner_cls._update_states = _patched_update_states
+    runner_cls._kunlun_mtp_mamba_state_patched = True
+
+
+def patch_loaded_modules() -> None:
+    runner_module = sys.modules.get("vllm.v1.worker.gpu_model_runner")
+    if runner_module is not None:
+        patch_gpu_model_runner_module(runner_module)

--- a/vllm_kunlun/v1/worker/mtp_mamba_state_patch.py
+++ b/vllm_kunlun/v1/worker/mtp_mamba_state_patch.py
@@ -29,16 +29,27 @@ def _is_mamba_group(group: Any) -> bool:
     return spec is not None and spec.__class__.__name__ == "MambaSpec"
 
 
+def _is_qwen35_mtp_runner(runner: Any) -> bool:
+    spec_config = getattr(runner, "speculative_config", None)
+    draft_model_config = getattr(spec_config, "draft_model_config", None)
+    hf_config = getattr(draft_model_config, "hf_config", None)
+    return getattr(hf_config, "model_type", None) == "qwen3_5_mtp"
+
+
 def _collect_new_mamba_block_ids(
     runner: Any, scheduler_output: Any
 ) -> dict[int, set[int]]:
     kv_cache_config = getattr(runner, "kv_cache_config", None)
     groups = getattr(kv_cache_config, "kv_cache_groups", ())
-    mamba_group_ids = [gid for gid, group in enumerate(groups) if _is_mamba_group(group)]
+    mamba_group_ids = [
+        gid for gid, group in enumerate(groups) if _is_mamba_group(group)
+    ]
     if not mamba_group_ids:
         return {}
 
-    new_block_ids_by_group: dict[int, set[int]] = {gid: set() for gid in mamba_group_ids}
+    new_block_ids_by_group: dict[int, set[int]] = {
+        gid: set() for gid in mamba_group_ids
+    }
 
     for new_req_data in getattr(scheduler_output, "scheduled_new_reqs", ()):
         if int(getattr(new_req_data, "num_computed_tokens", 0)) != 0:
@@ -55,9 +66,7 @@ def _collect_new_mamba_block_ids(
             )
 
     return {
-        gid: block_ids
-        for gid, block_ids in new_block_ids_by_group.items()
-        if block_ids
+        gid: block_ids for gid, block_ids in new_block_ids_by_group.items() if block_ids
     }
 
 
@@ -125,10 +134,21 @@ def _clear_new_mamba_blocks(runner: Any, scheduler_output: Any) -> int:
 
 def patch_gpu_model_runner_module(module: Any) -> None:
     runner_cls = getattr(module, "GPUModelRunner", None)
-    if runner_cls is None or getattr(runner_cls, "_kunlun_mtp_mamba_state_patched", False):
+    if runner_cls is None or getattr(
+        runner_cls, "_kunlun_mtp_mamba_state_patched", False
+    ):
         return
 
+    original_init = runner_cls.__init__
     original_update_states = runner_cls._update_states
+    original_calc_spec_decode_metadata = runner_cls._calc_spec_decode_metadata
+
+    def _patched_init(self: Any, *args: Any, **kwargs: Any) -> None:
+        original_init(self, *args, **kwargs)
+        if _is_qwen35_mtp_runner(self) and hasattr(self, "rejection_sampler"):
+            from vllm_kunlun.v1.sample.rejection_sampler import RejectionSampler
+
+            self.rejection_sampler = RejectionSampler(self.sampler)
 
     def _patched_update_states(self: Any, scheduler_output: Any) -> Any:
         if getattr(self, "speculative_config", None) is None:
@@ -137,7 +157,15 @@ def patch_gpu_model_runner_module(module: Any) -> None:
         _clear_new_mamba_blocks(self, scheduler_output)
         return result
 
+    def _patched_calc_spec_decode_metadata(self: Any, *args: Any, **kwargs: Any) -> Any:
+        metadata = original_calc_spec_decode_metadata(self, *args, **kwargs)
+        if _is_qwen35_mtp_runner(self):
+            metadata._kunlun_qwen35_mtp = True
+        return metadata
+
+    runner_cls.__init__ = _patched_init
     runner_cls._update_states = _patched_update_states
+    runner_cls._calc_spec_decode_metadata = _patched_calc_spec_decode_metadata
     runner_cls._kunlun_mtp_mamba_state_patched = True
 
 


### PR DESCRIPTION
## PR Description

This PR adds and scopes Qwen3.5 MoE MTP speculative decoding support for Kunlun XPU.

It addresses the gaps that prevent Qwen3.5 MoE MTP from running correctly on Kunlun, including draft model registration, Mamba/GDN metadata handling, speculative sampling behavior, EAGLE helper compatibility, and Mamba state lifecycle handling.

Overall approach:

- Add the Qwen3.5 MoE MTP draft model implementation and register it with vLLM Kunlun.
- Patch speculative config handling so Qwen3.5 MoE can map to the local `qwen3_5_mtp` draft model.
- Add Kunlun-compatible paths for rejection sampling and EAGLE input preparation where upstream uses CUDA/Triton-only helpers.
- Fix GDN/Mamba speculative metadata, accepted-token handling, conv state indexing, and new-request Mamba state cleanup.
- Scope the Kunlun-specific speculative patches to Qwen3.5 MTP to avoid affecting unrelated speculative decoding paths.
- Keep non-MTP decoding on the regular upstream path.

This change is needed because Qwen3.5 MoE cannot enable MTP speculative decoding on Kunlun without the draft model path and runtime patches.

### Known Limitations

- Qwen3.5 MTP currently supports only --mamba-cache-mode=none; other Mamba cache modes are not supported.
- Prefix cache is currently not supported when MTP speculative decoding is enabled. Please launch with `--no-enable-prefix-caching`.
- Using `--max_num_batched_tokens 32768` may hit GPU OOM on some machines. The validation below uses `--max_num_batched_tokens 8192`.


---

## Validation

### Pre-commit

```bash
pre-commit run --all-files
```

Result: passed.

### Service Smoke Test

Started Qwen3.5 with MTP speculative decoding enabled and verified `/health` plus a basic request.

Key launch options:

```bash
--no-enable-prefix-caching \
--max_num_batched_tokens 8192 \
--speculative-config '{"method":"qwen3_next_mtp","num_speculative_tokens":2}'
```

### IFEval

| Mode | prompt strict | inst strict | prompt loose | inst loose |
|---|---:|---:|---:|---:|
| no-thinking | 0.8891 | 0.9295 | 0.9261 | 0.9541 |
| thinking + remove_until `</think>` | 0.8946 | 0.9239 | 0.9224 | 0.9461 |

### vLLM Bench

Decode-heavy benchmark:

```bash
vllm bench serve \
  --host localhost \
  --port 8866 \
  --backend vllm \
  --model /home/models/Qwen3.5-397B-A17B-W8A8-INT8-Dynamic \
  --dataset-name random \
  --num-prompts 1 \
  --random-input-len 4096 \
  --random-output-len 4096 \
  --max-concurrency 1 \
  --temperature 0 \
  --ignore-eos
```

| Mode | Output tok/s | Benchmark duration | TPOT |
|---|---:|---:|---:|
| no MTP | 46.89 tok/s | 87.35s | 21.19 ms |
| MTP | 57.56 tok/s | 71.16s | 17.23 ms |

MTP improves output throughput by about **1.23x** in this decode-heavy case.

---

## Checklist

- [x] All code changes pass the pre-commit checks.
- [x] Commits are signed off using `git commit -s`.
- [x] The PR title is properly classified.