### PR TITLE
[Bugfix] Warm up Qwen3-Next TP8 router GEMM for decode

### DIFF
--- a/vllm_kunlun/models/qwen3_next.py
+++ b/vllm_kunlun/models/qwen3_next.py
@@ -9,6 +9,7 @@ import kunlun_ops
 import torch
 from einops import rearrange
 from torch import nn
+from torch.nn import functional as F
 from transformers.activations import ACT2FN
 from vllm.attention.layer import Attention
 from vllm.compilation.decorators import support_torch_compile
@@ -143,7 +144,8 @@ class Qwen3NextSparseMoeBlock(nn.Module):
     def __init__(self, vllm_config: VllmConfig, prefix: str = ""):
         super().__init__()
 
-        config = vllm_config.model_config.hf_text_config
+        model_config = vllm_config.model_config
+        config = model_config.hf_text_config
         parallel_config = vllm_config.parallel_config
         quant_config = vllm_config.quant_config
 
@@ -184,6 +186,12 @@ class Qwen3NextSparseMoeBlock(nn.Module):
             quant_config=quant_config,
             prefix=f"{prefix}.gate",
         )
+        self._use_router_decode_gemm_warmup = (
+            config.model_type == "qwen3_next"
+            and model_config.enforce_eager
+            and self.tp_size == 8
+        )
+        self._router_decode_warmed = False
 
         self.shared_expert_gate = ReplicatedLinear(
             config.hidden_size,
@@ -222,6 +230,33 @@ class Qwen3NextSparseMoeBlock(nn.Module):
             is_sequence_parallel=self.is_sequence_parallel,
         )
 
+    def _warm_up_router_decode_gemm(
+        self,
+        hidden_states: torch.Tensor,
+    ) -> None:
+        """Avoid a first-decode hang in each TP8 FP16 router GEMM."""
+        if (
+            not self._use_router_decode_gemm_warmup
+            or self._router_decode_warmed
+            or hidden_states.shape[0] != 1
+            or hidden_states.dtype != torch.float16
+            or self.gate.weight.dtype != torch.float16
+        ):
+            return
+
+        probe_input = torch.ones(
+            (1, hidden_states.shape[-1]),
+            device=hidden_states.device,
+            dtype=hidden_states.dtype,
+        )
+        probe_weight = torch.ones_like(self.gate.weight)
+
+        torch.cuda.synchronize()
+        F.linear(probe_input, probe_weight, bias=None)
+        torch.cuda.synchronize()
+
+        self._router_decode_warmed = True
+
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
         # NOTE: hidden_states can have either 1D or 2D shape.
         orig_shape = hidden_states.shape
@@ -230,6 +265,8 @@ class Qwen3NextSparseMoeBlock(nn.Module):
 
         if self.is_sequence_parallel:
             hidden_states = sequence_parallel_chunk(hidden_states)
+
+        self._warm_up_router_decode_gemm(hidden_states)
 
         if self.experts.is_internal_router:
             # In this case, the gate/router runs inside the FusedMoE class


### PR DESCRIPTION
## Summary

- add a one-time FP16 M=1 router GEMM warmup for each Qwen3-Next Sparse MoE layer
- restrict the workaround to the reproduced configuration: TP=8, FP16, and eager mode
- run the warmup before both the internal and external `SharedFusedMoE` router paths

## Problem

On 8 Kunlun P800 96GB cards, Qwen3-Next-80B-A3B-Instruct with TP=8 and FP16 can load weights and complete prefill, but the first single-token decode router GEMM hangs independently in each Sparse MoE layer. Other ranks eventually report an XCCL collective timeout as a secondary failure.

The blocked operation has the shape:

```python
F.linear(
    hidden_states,  # [1, 2048]
    router_weight,  # [512, 2048]
    bias=None,
)
```

A standalone TP8 FP16 all-reduce test and standalone GEMM tests with M=4096, M=8, and M=1 all pass. A single global M=1 warmup only allows the first affected MoE layer to proceed; every Sparse MoE layer requires its own first-decode warmup.

## Implementation

Before the real router call, each affected layer performs one synthetic FP16 GEMM with the same M=1 shape and synchronizes the device. The layer records completion so the warmup runs only once.

The workaround is intentionally limited to:

- Qwen3-Next
- tensor parallel size 8
- eager mode
- single-token input
- FP16 input and router weights

The current main branch can run the router inside `SharedFusedMoE` or externally through `self.gate`. The warmup is placed before that branch so it covers both paths.

## Validation

The same per-layer workaround was validated on vLLM-Kunlun v0.11.0 with 8 x Kunlun P800 96GB:

- TP8 engine initialization completed
- `/v1/models` returned successfully
- prefill and decode completed
- a chat completion generated 85 tokens
- no XCCL timeout, EngineCore initialization failure, or Python traceback occurred

Checks on this main-branch adaptation:

- `python -m py_compile vllm_kunlun/models/qwen3_next.py`
- Black 26.1.0
- Ruff 0.14.14
- isort 5.13.2
- `git diff --check`

The repository unit suite could not run in the local Windows environment because the Kunlun/vLLM runtime is unavailable. The main-branch adaptation has not yet been rerun on P800, so this PR is opened as a draft.