### PR TITLE
[Feature] Support Qwen3.6 35B on vLLM 0.25.1

### DIFF
--- a/vllm_kunlun/__init__.py
+++ b/vllm_kunlun/__init__.py
@@ -33,6 +33,7 @@ def _configure_kunlun_logger() -> logging.Logger:
 # run per real import event.
 _POST_IMPORT_DISPATCH_IN_PROGRESS = {"v": False}
 
+
 _MODULE_MAPPINGS = {
     "vllm.compilation.wrapper": "vllm_kunlun.compilation.wrapper",
     "vllm.model_executor.model_loader.bitsandbytes_loader": "vllm_kunlun.models.model_loader.bitsandbytes_loader",
@@ -40,10 +41,10 @@ _MODULE_MAPPINGS = {
     "vllm.v1.sample.ops.logprobs": "vllm_kunlun.v1.sample.ops.logprobs",
     "vllm.v1.sample.rejection_sampler": "vllm_kunlun.v1.sample.rejection_sampler",
     "vllm.attention.ops.merge_attn_states": "vllm_kunlun.ops.attention.merge_attn_states",
-    # "vllm.model_executor.models.config": "vllm_kunlun.models.config",
-    # "vllm.v1.worker.mamba_utils": "vllm_kunlun.v1.worker.mamba_utils",
+    "vllm.v1.worker.mamba_utils": "vllm_kunlun.v1.worker.mamba_utils",
     # "vllm.v1.worker.gpu_model_runner": "vllm_kunlun.v1.worker.gpu_model_runner",
 }
+
 
 # ---------------------------------------------------------------------------
 # Post-import hook registry
@@ -171,19 +172,67 @@ _register_post_import_hook(
 )
 
 
-# --- hook 5: SiluAndMul.forward_native ------------------------------
-# Replace SiluAndMul.forward_native with fused silu_and_mul kernel.
-def _activation_applied(mod):
-    cls = getattr(mod, "SiluAndMul", None)
-    return cls is None or getattr(cls, "_kunlun_silu_and_mul_patched", False)
+# --- hook 5: Worker._maybe_get_memory_pool_context -----------------------
+# vllm 0.25.1 _maybe_get_memory_pool_context() gates on is_cuda_alike() /
+# is_xpu(). KunlunPlatform is OOT so neither returns True, causing it to
+# fall through to get_mem_allocator_instance() which raises RuntimeError.
+# Patch the method to return nullcontext() for Kunlun.
+def _memory_pool_applied(mod):
+    cls = getattr(mod, "Worker", None)
+    return cls is None or getattr(cls, "_kunlun_memory_pool_patched", False)
 
 
-def _activation_apply(mod):
-    import vllm_kunlun.ops.activation  # noqa: F401  (self-applies on import)
+def _memory_pool_apply(mod):
+    from contextlib import nullcontext as _nullcontext
+
+    _orig = mod.Worker._maybe_get_memory_pool_context
+
+    def _patched(self, tag: str):
+        from vllm.platforms import current_platform
+
+        if type(current_platform).__name__ == "KunlunPlatform":
+            return _nullcontext()
+        return _orig(self, tag)
+
+    mod.Worker._maybe_get_memory_pool_context = _patched
+    mod.Worker._kunlun_memory_pool_patched = True
+    logging.getLogger("vllm_kunlun").info(
+        "[KunlunPlugin] patched Worker._maybe_get_memory_pool_context"
+    )
 
 
 _register_post_import_hook(
-    "vllm.model_executor.layers.activation", _activation_applied, _activation_apply
+    "vllm.v1.worker.gpu_worker", _memory_pool_applied, _memory_pool_apply
+)
+
+
+# --- hook 6: skip qwen_triton_warmup on Kunlun XPU ---
+def _qwen_triton_warmup_applied(mod):
+    fn = getattr(mod, "qwen_triton_warmup", None)
+    return fn is not None and getattr(fn, "_kunlun_patched", False)
+
+
+def _qwen_triton_warmup_apply(mod):
+    def _noop(*args, **kwargs):
+        import logging
+
+        logging.getLogger("vllm_kunlun").info(
+            "[KunlunPlugin] Skipping qwen_triton_warmup"
+        )
+
+    _noop._kunlun_patched = True
+    mod.qwen_triton_warmup = _noop
+    import logging
+
+    logging.getLogger("vllm_kunlun").info(
+        "[KunlunPlugin] patched kernel_warmup.qwen_triton_warmup -> no-op"
+    )
+
+
+_register_post_import_hook(
+    "vllm.model_executor.warmup.kernel_warmup",
+    _qwen_triton_warmup_applied,
+    _qwen_triton_warmup_apply,
 )
 
 
@@ -313,6 +362,35 @@ def register():
         logger.info("[KunlunPlugin] import_hook() ok")
     except Exception:
         logger.exception("[KunlunPlugin] import_hook() failed")
+        raise
+
+    # --- patch torch.accelerator.get_memory_info for Kunlun XPU ---
+    # vllm 0.25.1 uses torch.accelerator.get_memory_info() which does not exist
+    # in torch_xmlir 2.9. Patch it to use torch.cuda.mem_get_info which works on XPU.
+    try:
+        import torch as _torch
+
+        def _kunlun_get_memory_info(device=None):
+            if device is None:
+                idx = _torch.cuda.current_device()
+            elif isinstance(device, _torch.device):
+                idx = (
+                    device.index
+                    if device.index is not None
+                    else _torch.cuda.current_device()
+                )
+            elif isinstance(device, int):
+                idx = device
+            else:
+                idx = _torch.cuda.current_device()
+            return _torch.cuda.mem_get_info(idx)
+
+        _torch.accelerator.get_memory_info = _kunlun_get_memory_info
+        logger.info("[KunlunPlugin] patched torch.accelerator.get_memory_info")
+    except Exception:
+        logger.exception(
+            "[KunlunPlugin] failed to patch torch.accelerator.get_memory_info"
+        )
         raise
 
     # --- register reasoning parser override (lazy, to avoid circular import) ---

--- a/vllm_kunlun/models/config.py
+++ b/vllm_kunlun/models/config.py
@@ -1,0 +1,651 @@
+# # SPDX-License-Identifier: Apache-2.0
+# # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# from copy import deepcopy
+# from math import lcm
+# from typing import TYPE_CHECKING
+
+# from vllm.logger import init_logger
+# from vllm.model_executor.models import ModelRegistry
+# from vllm.platforms import current_platform
+# from vllm.utils.math_utils import cdiv, round_up
+# from vllm.utils.torch_utils import STR_DTYPE_TO_TORCH_DTYPE
+# from vllm.v1.attention.backends.registry import AttentionBackendEnum
+# from vllm.v1.kv_cache_interface import FullAttentionSpec, MambaSpec, MLAAttentionSpec
+
+# if TYPE_CHECKING:
+#     from vllm.config import ModelConfig, VllmConfig
+
+# logger = init_logger(__name__)
+
+
+# class VerifyAndUpdateConfig:
+#     @staticmethod
+#     def verify_and_update_config(vllm_config: "VllmConfig") -> None:
+#         return
+
+#     @staticmethod
+#     def verify_and_update_model_config(model_config: "ModelConfig") -> None:
+#         return
+
+
+# class Gemma3TextModelConfig(VerifyAndUpdateConfig):
+#     @staticmethod
+#     def verify_and_update_model_config(model_config: "ModelConfig") -> None:
+#         hf_config = model_config.hf_config
+#         hf_config.is_causal = not hf_config.use_bidirectional_attention
+
+
+# class GteNewModelConfig(VerifyAndUpdateConfig):
+#     @staticmethod
+#     def verify_and_update_model_config(model_config: "ModelConfig") -> None:
+#         config = model_config.hf_config
+
+#         assert config.__class__.__name__ == "NewConfig"
+#         assert config.hidden_act == "gelu"
+
+#         config.hidden_act = "geglu"
+
+#         head_dim = config.hidden_size // config.num_attention_heads
+#         rotary_dim = getattr(config, "rotary_emb_dim", head_dim)
+#         config.rope_parameters["partial_rotary_factor"] = rotary_dim / head_dim
+#         config.rotary_kwargs = {
+#             "head_size": head_dim,
+#             "max_position": config.max_position_embeddings,
+#             "rope_parameters": config.rope_parameters,
+#         }
+
+
+# class JambaForSequenceClassificationConfig(VerifyAndUpdateConfig):
+#     @staticmethod
+#     def verify_and_update_model_config(model_config: "ModelConfig") -> None:
+#         pooler_config = model_config.pooler_config
+#         if pooler_config.use_activation is None:
+#             pooler_config.use_activation = False
+
+
+# class JinaRobertaModelConfig(VerifyAndUpdateConfig):
+#     @staticmethod
+#     def verify_and_update_model_config(model_config: "ModelConfig") -> None:
+#         config = model_config.hf_config
+
+#         if config.position_embedding_type == "rotary":
+#             assert config.__class__.__name__ == "XLMRobertaFlashConfig"
+
+#             head_dim = config.hidden_size // config.num_attention_heads
+#             max_position = config.max_position_embeddings
+#             # Jina-embeddings-v3 has max_position_embeddings=8194, which will cause
+#             # out-of-bound index issue at RoPE for long prompts with torch.compile,
+#             # because it can't be divided by triton num_warps(default=4 or 8).
+#             # To deal with this, we increase max_position to multiple of n_warps,
+#             # so that triton kernel won't hit out-of-bound index in RoPE cache.
+#             if not model_config.enforce_eager:
+#                 max_position = round_up(max_position, 8)
+
+#             rotary_dim = getattr(config, "rotary_emb_dim", head_dim)
+#             config.rope_parameters["partial_rotary_factor"] = rotary_dim / head_dim
+
+#             config.rotary_kwargs = {
+#                 "head_size": head_dim,
+#                 "max_position": max_position,
+#                 "rope_parameters": config.rope_parameters,
+#             }
+
+
+# class LlamaBidirectionalConfig(VerifyAndUpdateConfig):
+#     @staticmethod
+#     def verify_and_update_model_config(model_config: "ModelConfig") -> None:
+#         from vllm.config.pooler import SequencePoolingType
+
+#         hf_config = model_config.hf_config
+#         hf_config.is_causal = False
+
+#         pooling_type_map: dict[str, SequencePoolingType] = {
+#             "avg": "MEAN",
+#             "cls": "CLS",
+#             "last": "LAST",
+#         }
+
+#         pooling_type = pooling_type_map.get(hf_config.pooling, None)
+#         if pooling_type is None:
+#             raise ValueError(f"pool_type {hf_config.pooling!r} not supported")
+
+#         model_config.pooler_config.seq_pooling_type = pooling_type
+
+
+# class NomicBertModelConfig(VerifyAndUpdateConfig):
+#     @staticmethod
+#     def verify_and_update_model_config(model_config: "ModelConfig") -> None:
+#         config = model_config.hf_config
+
+#         assert config.__class__.__name__ == "NomicBertConfig"
+#         assert config.activation_function in ["swiglu", "gelu"]
+#         config.position_embedding_type = getattr(
+#             config, "position_embedding_type", "rope"
+#         )
+
+#         if config.activation_function == "swiglu":
+#             config.hidden_act = "silu"
+#         else:
+#             config.hidden_act = config.activation_function
+
+#         assert config.mlp_fc1_bias == config.mlp_fc2_bias == config.qkv_proj_bias
+#         config.bias = config.qkv_proj_bias
+
+#         assert config.rotary_emb_scale_base is None
+#         assert not config.rotary_emb_interleaved
+
+#         config.layer_norm_eps = config.layer_norm_epsilon
+#         config.intermediate_size = config.n_inner
+#         config.hidden_size = config.n_embd
+#         config.num_hidden_layers = config.n_layer
+#         model_config.model_arch_config.hidden_size = config.hidden_size
+#         model_config.model_arch_config.total_num_hidden_layers = (
+#             config.num_hidden_layers
+#         )
+
+#         head_dim = config.hidden_size // config.num_attention_heads
+#         max_trained_positions = getattr(config, "max_trained_positions", 2048)
+
+#         config.rotary_kwargs = {
+#             "head_size": head_dim,
+#             "max_position": max_trained_positions,
+#             "rope_parameters": config.rope_parameters,
+#         }
+
+#         # we ignore config.rotary_scaling_factor so that for datasets shorter
+#         # than max_trained_positions 2048, the results are consistent
+#         # with SentenceTransformer.
+#         # The context extension uses vllm style rope_theta and rope_parameters.
+#         # See #17785 #18755
+#         if (
+#             not model_config.hf_overrides
+#             and model_config.original_max_model_len is None
+#         ):
+#             # Default
+#             # Reset max_model_len to max_trained_positions.
+#             # nomic-embed-text-v2-moe the length is set to 512
+#             # by sentence_bert_config.json.
+#             max_model_len_before = model_config.max_model_len
+#             max_model_len = min(model_config.max_model_len, max_trained_positions)
+
+#             model_config.max_model_len = model_config.get_and_verify_max_len(
+#                 max_model_len
+#             )
+
+#             if model_config.max_model_len != max_model_len_before:
+#                 logger.warning(
+#                     "Nomic context extension is disabled. "
+#                     "Changing max_model_len from %s to %s. "
+#                     "To enable context extension, see: "
+#                     "https://github.com/vllm-project/vllm/tree/main/examples/offline_inference/context_extension.html",
+#                     max_model_len_before,
+#                     model_config.max_model_len,
+#                 )
+#         else:
+#             # We need to re-verify max_model_len to avoid lengths
+#             # greater than position_embedding.
+#             hf_text_config = model_config.hf_text_config
+
+#             if isinstance(model_config.hf_overrides, dict):
+#                 # hf_overrides_kw
+#                 max_model_len = model_config.hf_overrides.get(
+#                     "max_model_len", model_config.max_model_len
+#                 )
+#             else:
+#                 # hf_overrides_fn
+#                 # This might be overridden by sentence_bert_config.json.
+#                 max_model_len = model_config.max_model_len
+
+#             # reset hf_text_config for recalculate_max_model_len.
+#             if hasattr(hf_text_config, "max_model_len"):
+#                 delattr(hf_text_config, "max_model_len")
+#             hf_text_config.max_position_embeddings = max_trained_positions
+#             hf_text_config.rope_parameters = config.rotary_kwargs["rope_parameters"]
+
+#             # Update the cached derived_max_model_len to enforce the limit
+#             model_config.model_arch_config.derived_max_model_len_and_key = (
+#                 float(max_trained_positions),
+#                 "max_position_embeddings",
+#             )
+
+#             # The priority of sentence_bert_config.json is higher
+#             # than max_position_embeddings
+#             encoder_config = deepcopy(model_config.encoder_config)
+#             encoder_config.pop("max_seq_length", None)
+#             model_config.encoder_config = encoder_config
+
+#             model_config.max_model_len = model_config.get_and_verify_max_len(
+#                 max_model_len
+#             )
+
+
+# class Qwen2ForProcessRewardModelConfig(VerifyAndUpdateConfig):
+#     @staticmethod
+#     def verify_and_update_model_config(model_config: "ModelConfig") -> None:
+#         pooler_config = model_config.pooler_config
+
+#         if pooler_config.step_tag_id is None:
+#             pooler_config.step_tag_id = 151651
+
+
+# class Qwen2ForRewardModelConfig(VerifyAndUpdateConfig):
+#     @staticmethod
+#     def verify_and_update_model_config(model_config: "ModelConfig") -> None:
+#         pooler_config = model_config.pooler_config
+
+#         if pooler_config.softmax is None:
+#             pooler_config.softmax = False
+
+
+# class Qwen3ForSequenceClassificationConfig(VerifyAndUpdateConfig):
+#     @staticmethod
+#     def verify_and_update_model_config(model_config: "ModelConfig") -> None:
+#         config = model_config.hf_config
+
+#         is_original_qwen3_reranker = getattr(
+#             config, "is_original_qwen3_reranker", False
+#         )
+
+#         if not is_original_qwen3_reranker:
+#             return
+
+#         tokens = getattr(config, "classifier_from_token", None)
+#         assert tokens is not None and len(tokens) == 2, (
+#             "Try loading the original Qwen3 Reranker?, see: "
+#             "https://github.com/vllm-project/vllm/tree/main/examples/pooling/score/qwen3_reranker_offline.py"
+#         )
+#         text_config = config.get_text_config()
+#         text_config.method = "from_2_way_softmax"
+#         text_config.classifier_from_token = tokens
+
+
+# class Qwen3VLForSequenceClassificationConfig(Qwen3ForSequenceClassificationConfig):
+#     pass
+
+
+# class JinaVLForSequenceClassificationConfig(VerifyAndUpdateConfig):
+#     @staticmethod
+#     def verify_and_update_model_config(model_config: "ModelConfig") -> None:
+#         config = model_config.hf_config
+#         config.num_labels = 1
+#         pooler_config = model_config.pooler_config
+#         if pooler_config.logit_bias is None:
+#             pooler_config.logit_bias = 2.65
+
+
+# class SnowflakeGteNewModelConfig(VerifyAndUpdateConfig):
+#     @staticmethod
+#     def verify_and_update_model_config(model_config: "ModelConfig") -> None:
+#         config = model_config.hf_config
+
+#         assert config.__class__.__name__ == "GteConfig"
+#         assert config.hidden_act == "gelu"
+
+#         config.hidden_act = "geglu"
+
+#         head_dim = config.hidden_size // config.num_attention_heads
+#         rotary_dim = getattr(config, "rotary_emb_dim", head_dim)
+#         config.rope_parameters["partial_rotary_factor"] = rotary_dim / head_dim
+#         config.rotary_kwargs = {
+#             "head_size": head_dim,
+#             "max_position": config.max_position_embeddings,
+#             "rope_parameters": config.rope_parameters,
+#         }
+
+
+# class GptOssForCausalLMConfig(VerifyAndUpdateConfig):
+#     @staticmethod
+#     def verify_and_update_config(vllm_config: "VllmConfig") -> None:
+#         structured_outputs_config = vllm_config.structured_outputs_config
+#         if structured_outputs_config.reasoning_parser == "":
+#             structured_outputs_config.reasoning_parser = "openai_gptoss"
+
+#         # Increase the max capture size from 512 to 1024 for performance.
+#         # NOTE(woosuk): This will increase the number of CUDA graphs
+#         # from 67 to 83.
+#         compilation_config = vllm_config.compilation_config
+#         # Only override when the user has not set either of
+#         # cudagraph_capture_sizes or max_cudagraph_capture_size.
+#         if (
+#             compilation_config.cudagraph_capture_sizes is None
+#             and compilation_config.max_cudagraph_capture_size is None
+#         ):
+#             compilation_config.max_cudagraph_capture_size = 1024
+#             logger.info(
+#                 "Overriding max cuda graph capture size to %d for performance.", 1024
+#             )
+
+
+# class MambaModelConfig(VerifyAndUpdateConfig):
+#     @classmethod
+#     def verify_and_update_config(cls, vllm_config: "VllmConfig") -> None:
+#         """
+#         Enable FULL_AND_PIECEWISE cuda graph mode by default (required
+#         to get good performance for mamba layers in V1).
+
+#         Args:
+#             vllm_config: vLLM Config
+#         """
+#         model_config = vllm_config.model_config
+#         cache_config = vllm_config.cache_config
+
+#         if cache_config.enable_prefix_caching:
+#             if cache_config.mamba_cache_mode == "none":
+#                 cache_config.mamba_cache_mode = (
+#                     "all" if model_config.supports_mamba_prefix_caching else "align"
+#                 )
+#                 logger.warning(
+#                     "Mamba cache mode is set to '%s' for %s by default "
+#                     "when prefix caching is enabled",
+#                     cache_config.mamba_cache_mode,
+#                     model_config.architecture,
+#                 )
+#             if (
+#                 cache_config.mamba_cache_mode == "all"
+#                 and not model_config.supports_mamba_prefix_caching
+#             ):
+#                 cache_config.mamba_cache_mode = "align"
+#                 logger.warning(
+#                     "Hybrid or mamba-based model detected without support "
+#                     "for prefix caching with Mamba cache 'all' mode: "
+#                     "falling back to 'align' mode."
+#                 )
+#             if cache_config.mamba_cache_mode == "align":
+#                 assert (
+#                     vllm_config.scheduler_config.enable_chunked_prefill
+#                 ), "Chunked prefill is required for mamba cache mode 'align'."
+#                 assert not vllm_config.speculative_config, (
+#                     "Mamba cache mode 'align' is currently not compatible "
+#                     "with speculative decoding."
+#                 )
+#             logger.info(
+#                 "Warning: Prefix caching in Mamba cache '%s' "
+#                 "mode is currently enabled. "
+#                 "Its support for Mamba layers is experimental. "
+#                 "Please report any issues you may observe.",
+#                 cache_config.mamba_cache_mode,
+#             )
+#             # By default, mamba block size will be set to max_model_len (see
+#             # below). When enabling prefix caching, we align mamba block size
+#             # to the block size as the basic granularity for prefix caching.
+#             if cache_config.mamba_block_size is None:
+#                 cache_config.mamba_block_size = cache_config.block_size
+#         else:
+#             if cache_config.mamba_cache_mode != "none":
+#                 cache_config.mamba_cache_mode = "none"
+#                 logger.warning(
+#                     "Mamba cache mode is set to 'none' when prefix caching is disabled"
+#                 )
+#             if cache_config.mamba_block_size is None:
+#                 cache_config.mamba_block_size = model_config.max_model_len
+
+
+# class HybridAttentionMambaModelConfig(VerifyAndUpdateConfig):
+#     @classmethod
+#     def verify_and_update_config(cls, vllm_config: "VllmConfig") -> None:
+#         """
+#         Ensure that page size of attention layers is greater than or
+#         equal to the mamba layers. If not, automatically set the attention
+#         block size to ensure that it is. If the attention page size is
+#         strictly greater than the mamba page size, we pad the mamba page size
+#         to make them equal.
+
+#         Args:
+#             vllm_config: vLLM Config
+#         """
+#         # Save the user input before it gets modified by MambaModelConfig
+#         mamba_block_size = vllm_config.cache_config.mamba_block_size
+#         # Enable FULL_AND_PIECEWISE by default
+#         MambaModelConfig.verify_and_update_config(vllm_config)
+
+#         attention_config = vllm_config.attention_config
+#         cache_config = vllm_config.cache_config
+#         model_config = vllm_config.model_config
+#         parallel_config = vllm_config.parallel_config
+
+#         if cache_config.cache_dtype == "auto":
+#             kv_cache_dtype = model_config.dtype
+#         else:
+#             kv_cache_dtype = STR_DTYPE_TO_TORCH_DTYPE[cache_config.cache_dtype]
+
+#         # get attention page size (for 1 token)
+#         # Attention backend constraints:
+#         # - FlashAttention (FA) requires block size to be multiple of 16
+#         # - MLA (Multi-head Latent Attention) requires larger alignment:
+#         #   * CUTLASS_MLA backend: kernel_block_size 128 alignment
+#         #   * Other MLA backends: kernel_block_size 64 alignment
+#         if model_config.use_mla:
+#             use_cutlass_mla = (
+#                 attention_config.backend == AttentionBackendEnum.CUTLASS_MLA
+#             )
+#             kernel_block_alignment_size = 128 if use_cutlass_mla else 64
+#             attn_page_size_1_token = MLAAttentionSpec(
+#                 block_size=1,
+#                 num_kv_heads=model_config.get_num_kv_heads(parallel_config),
+#                 head_size=model_config.get_head_size(),
+#                 dtype=kv_cache_dtype,
+#             ).page_size_bytes
+#         else:
+#             kernel_block_alignment_size = 16
+#             if (
+#                 current_platform.is_device_capability_family(100)
+#                 and model_config.get_head_size() == 256
+#                 and (
+#                     attention_config.backend is None
+#                     or attention_config.backend == AttentionBackendEnum.FLASHINFER
+#                 )
+#             ):
+#                 # https://github.com/flashinfer-ai/flashinfer/issues/1993 reports that`
+#                 # head size 256 and block size 16 is not supported on blackwell.
+#                 kernel_block_alignment_size = 32
+#             attn_page_size_1_token = FullAttentionSpec(
+#                 block_size=1,
+#                 num_kv_heads=model_config.get_num_kv_heads(parallel_config),
+#                 head_size=model_config.get_head_size(),
+#                 dtype=kv_cache_dtype,
+#             ).page_size_bytes
+
+#         model_cls, _ = ModelRegistry.resolve_model_cls(
+#             model_config.architecture,
+#             model_config=model_config,
+#         )
+
+#         # get mamba page size
+#         mamba_page_size = MambaSpec(
+#             shapes=model_cls.get_mamba_state_shape_from_config(vllm_config),
+#             dtypes=model_cls.get_mamba_state_dtype_from_config(vllm_config),
+#             block_size=-1,  # block_size doesn't matter for mamba page size
+#         ).page_size_bytes
+
+#         # Model may be marked as is_hybrid
+#         #  but mamba is skipped via config,
+#         #  return directly
+#         if mamba_page_size == 0:
+#             return
+
+#         if cache_config.mamba_cache_mode == "all":
+#             # With prefix caching, select attention block size to
+#             # optimize for mamba kernel performance
+
+#             # Mamba2 SSD kernel uses a chunk_size, e.g. 256
+#             # Align the block to the kernel: use lowest multiple of chunk_size
+#             # of attention tokens that would fit mamba_page_size:
+#             # e.g. for mamba page size = 788kB
+#             #          attn_1_token = 2kB -> fits ~394 tokens
+#             #      then round up to a multiple of 256 -> 512 tokens
+#             # End result:
+#             #  attn_block_size = 512
+#             #  mamba_block_size = 512 (aligned to a multiple of chunk_size)
+#             # TODO(tdoublep): this constraint can be relaxed fairly
+#             # easily by changing the way we layout chunks in the
+#             # mamba2 kernels.
+
+#             base_chunk_size = mamba_block_size or model_config.get_mamba_chunk_size()
+#             attn_tokens_per_mamba_state = cdiv(mamba_page_size, attn_page_size_1_token)
+#             chunk_size = lcm(base_chunk_size, kernel_block_alignment_size)
+#             attn_block_size = chunk_size * cdiv(attn_tokens_per_mamba_state, chunk_size)
+#             cache_config.mamba_block_size = attn_block_size
+#         else:
+#             # Without prefix caching, select minimum valid attention block size
+#             # to minimize mamba state padding
+
+#             # Calculate minimum attention block size that satisfies both:
+#             # 1. Backend alignment requirements (kernel_block_alignment_size)
+#             # 2. Mamba page size compatibility (attn_page_size >= mamba_page_size)
+#             attn_block_size = kernel_block_alignment_size * cdiv(
+#                 mamba_page_size, kernel_block_alignment_size * attn_page_size_1_token
+#             )
+
+#         # override attention block size if either (a) the
+#         # user has not set it or (b) the user has set it
+#         # too small.
+#         if cache_config.block_size is None or cache_config.block_size < attn_block_size:
+#             cache_config.block_size = attn_block_size
+#             logger.info(
+#                 "Setting attention block size to %d tokens "
+#                 "to ensure that attention page size is >= mamba page size.",
+#                 attn_block_size,
+#             )
+
+#         # By default, mamba block size will be set to max_model_len.
+#         # When enabling prefix caching and using align mamba cache
+#         # mode, we align mamba block size to the block size as the
+#         # basic granularity for prefix caching.
+#         if cache_config.mamba_cache_mode == "align":
+#             cache_config.mamba_block_size = cache_config.block_size
+
+#         # compute new attention page size
+#         attn_page_size = cache_config.block_size * attn_page_size_1_token
+
+#         assert attn_page_size >= mamba_page_size
+
+#         if attn_page_size == mamba_page_size:
+#             # don't need to pad mamba page size
+#             return
+
+#         # pad mamba page size to exactly match attention
+#         if (
+#             cache_config.mamba_page_size_padded is None
+#             or cache_config.mamba_page_size_padded != attn_page_size
+#         ):
+#             cache_config.mamba_page_size_padded = attn_page_size
+#             mamba_padding_pct = (
+#                 100 * (attn_page_size - mamba_page_size) / mamba_page_size
+#             )
+#             logger.info(
+#                 "Padding mamba page size by %.2f%% to ensure "
+#                 "that mamba page size and attention page size are "
+#                 "exactly equal.",
+#                 mamba_padding_pct,
+#             )
+
+
+# class DeepseekV32ForCausalLM(VerifyAndUpdateConfig):
+#     @classmethod
+#     def verify_and_update_config(cls, vllm_config: "VllmConfig") -> None:
+#         """
+#         Updated fp8 cache to custom "fp8_ds_mla" format for DeepSeekV32
+#         """
+#         hf_config = vllm_config.model_config.hf_config
+
+#         # Mirror the check in vllm/model_executor/models/deepseek_v2.py
+#         is_v32 = hasattr(hf_config, "index_topk")
+#         assert is_v32
+
+#         # For DeepSeekV3.2, a custom fp8 format is used when fp8 kv-cache is enabled.
+#         cache_config = vllm_config.cache_config
+#         if cache_config.cache_dtype.startswith("fp8"):
+#             cache_config.cache_dtype = "fp8_ds_mla"
+#             logger.info("Using custom fp8 kv-cache format for DeepSeekV3.2")
+#         if cache_config.cache_dtype == "bfloat16":
+#             cache_config.cache_dtype = "auto"
+#             logger.info("Using bfloat16 kv-cache for DeepSeekV3.2")
+
+
+# class NemotronHForCausalLMConfig(VerifyAndUpdateConfig):
+#     @staticmethod
+#     def verify_and_update_config(vllm_config: "VllmConfig") -> None:
+#         """Update mamba_ssm_cache_dtype for NemotronH models when set to 'auto'
+#         (or not explicitly set), to the value specified in the HF config, or to
+#         float16 if not specified.
+#         """
+#         cache_config = vllm_config.cache_config
+#         if cache_config.mamba_ssm_cache_dtype == "auto":
+#             hf_config = vllm_config.model_config.hf_config
+#             mamba_ssm_cache_dtype = getattr(
+#                 hf_config, "mamba_ssm_cache_dtype", "float16"
+#             )
+#             logger.info(
+#                 "Updating mamba_ssm_cache_dtype to '%s' for NemotronH model",
+#                 mamba_ssm_cache_dtype,
+#             )
+#             cache_config.mamba_ssm_cache_dtype = mamba_ssm_cache_dtype
+
+
+# class Qwen3_5ForConditionalGenerationConfig(VerifyAndUpdateConfig):
+#     @staticmethod
+#     def verify_and_update_config(vllm_config: "VllmConfig") -> None:
+#         """Update mamba_ssm_cache_dtype for Qwen3.5 models when set to 'auto'
+#         (or not explicitly set), to the value specified in the HF config's
+#         mamba_ssm_dtype field. Warn if the user explicitly overrides it to a
+#         different value.
+#         """
+#         # cache_config = vllm_config.cache_config
+#         hf_text_config = vllm_config.model_config.hf_text_config
+#         mamba_ssm_dtype = getattr(hf_text_config, "mamba_ssm_dtype", None)
+#         if mamba_ssm_dtype is not None and mamba_ssm_dtype == "float32":
+#             logger.warning(
+#                 "Qwen3.5 model specifies mamba_ssm_dtype='%s' in its config, "
+#                 "but vllm_kunlun does not support float32 GDN forward. "
+#                 "Ignoring this setting; KVCache will use model_dtype instead "
+#                 "to avoid wasting memory.",
+#                 mamba_ssm_dtype,
+#             )
+#         # if cache_config.mamba_ssm_cache_dtype == "auto":
+#         #     if mamba_ssm_dtype is not None:
+#         #         cache_config.mamba_ssm_cache_dtype = mamba_ssm_dtype
+#         # elif (
+#         #     mamba_ssm_dtype is not None
+#         #     and cache_config.mamba_ssm_cache_dtype != mamba_ssm_dtype
+#         # ):
+#         #     logger.warning(
+#         #         "Qwen3.5 model specifies mamba_ssm_dtype='%s' in its config, "
+#         #         "but --mamba-ssm-cache-dtype='%s' was passed. "
+#         #         "Using the user-specified value.",
+#         #         mamba_ssm_dtype,
+#         #         cache_config.mamba_ssm_cache_dtype,
+#         #     )
+
+
+# class VoyageQwen3BidirectionalEmbedModelConfig(VerifyAndUpdateConfig):
+#     @staticmethod
+#     def verify_and_update_model_config(model_config: "ModelConfig") -> None:
+#         model_config.hf_config.is_causal = False
+#         model_config.hf_config.embedding_size = model_config.hf_config.num_labels
+
+
+# MODELS_CONFIG_MAP: dict[str, type[VerifyAndUpdateConfig]] = {
+#     "GteModel": SnowflakeGteNewModelConfig,
+#     "GteNewModel": GteNewModelConfig,
+#     "GteNewForSequenceClassification": GteNewModelConfig,
+#     "Gemma3TextModel": Gemma3TextModelConfig,
+#     "LlamaBidirectionalForSequenceClassification": LlamaBidirectionalConfig,
+#     "LlamaBidirectionalModel": LlamaBidirectionalConfig,
+#     "NomicBertModel": NomicBertModelConfig,
+#     "Qwen2ForProcessRewardModel": Qwen2ForProcessRewardModelConfig,
+#     "Qwen2ForRewardModel": Qwen2ForRewardModelConfig,
+#     "Qwen3ForSequenceClassification": Qwen3ForSequenceClassificationConfig,
+#     "Qwen3VLForSequenceClassification": Qwen3VLForSequenceClassificationConfig,
+#     "XLMRobertaModel": JinaRobertaModelConfig,
+#     "JinaVLForRanking": JinaVLForSequenceClassificationConfig,
+#     "JambaForSequenceClassification": JambaForSequenceClassificationConfig,
+#     "GptOssForCausalLM": GptOssForCausalLMConfig,
+#     "MambaForCausalLM": MambaModelConfig,
+#     "Mamba2ForCausalLM": MambaModelConfig,
+#     "FalconMambaForCausalLM": MambaModelConfig,
+#     "DeepseekV32ForCausalLM": DeepseekV32ForCausalLM,
+#     "NemotronHForCausalLM": NemotronHForCausalLMConfig,
+#     "Qwen3_5ForConditionalGeneration": Qwen3_5ForConditionalGenerationConfig,
+#     "Qwen3_5MoeForConditionalGeneration": Qwen3_5ForConditionalGenerationConfig,
+#     "VoyageQwen3BidirectionalEmbedModel": VoyageQwen3BidirectionalEmbedModelConfig,
+# }

--- a/vllm_kunlun/models/internvl.py
+++ b/vllm_kunlun/models/internvl.py
@@ -21,7 +21,7 @@ from PIL import Image
 from transformers import BatchEncoding, PretrainedConfig, TensorType
 from vllm.config import VllmConfig
 from vllm.model_executor.layers.quantization import QuantizationConfig
-from vllm.model_executor.layers.quantization.awq import AWQConfig
+from vllm.model_executor.layers.quantization.auto_awq import AutoAWQConfig as AWQConfig
 from vllm.model_executor.models.interfaces import (
     MultiModalEmbeddings,
     SupportsLoRA,

--- a/vllm_kunlun/models/qwen3_5.py
+++ b/vllm_kunlun/models/qwen3_5.py
@@ -33,6 +33,7 @@ from vllm.compilation.decorators import support_torch_compile
 from vllm.config import VllmConfig
 from vllm.distributed import get_pp_group
 from vllm.logger import init_logger
+from vllm.model_executor.layers.fused_moe.routed_experts import RoutedExperts
 from vllm.model_executor.layers.layernorm import GemmaRMSNorm as Qwen3_5RMSNorm
 from vllm.model_executor.layers.linear import MergedColumnParallelLinear
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
@@ -353,6 +354,17 @@ class Qwen3_5Model(Qwen3NextModel):
 
         return loaded_local_expert
 
+    def get_expert_mapping(self) -> list[tuple[str, str, int, str]]:
+        return RoutedExperts.build_expert_params_mapping(
+            ckpt_gate_proj_name="gate_proj",
+            ckpt_down_proj_name="down_proj",
+            ckpt_up_proj_name="up_proj",
+            num_experts=getattr(self.config, "num_experts", 0),
+            num_redundant_experts=self.num_redundant_experts,
+            routed_experts_prefix="routed_experts",
+            include_fused=True,
+        )
+
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
         stacked_params_mapping = [
             # (param_name, shard_name, shard_id)
@@ -373,14 +385,6 @@ class Qwen3_5Model(Qwen3NextModel):
         params_dict = dict(self.named_parameters())
         loaded_params: set[str] = set()
         expert_params_mapping = self.get_expert_mapping()
-        is_fused_expert = False
-        fused_expert_params_mapping = [
-            ("experts.w13_weight", "experts.gate_up_proj", 0, "w1"),
-            ("experts.w2_weight", "experts.down_proj", 0, "w2"),
-        ]
-        num_experts = (
-            self.config.num_experts if hasattr(self.config, "num_experts") else 0
-        )
         for name, loaded_weight in weights:
             if "rotary_emb.inv_freq" in name:
                 continue
@@ -395,10 +399,6 @@ class Qwen3_5Model(Qwen3NextModel):
                     continue
 
             for param_name, weight_name, shard_id in stacked_params_mapping:
-                if "experts.gate_up_proj" in name or "experts.down_proj" in name:
-                    is_fused_expert = True
-                    expert_params_mapping = fused_expert_params_mapping
-
                 if weight_name not in name:
                     continue
 
@@ -412,7 +412,6 @@ class Qwen3_5Model(Qwen3NextModel):
                 # Skip layers on other devices.
                 if is_pp_missing_parameter(name, self):
                     continue
-                # name = apply_attn_prefix(name, params_dict)
                 if name not in params_dict:
                     continue
                 param = params_dict[name]
@@ -421,6 +420,34 @@ class Qwen3_5Model(Qwen3NextModel):
                 break
             else:
                 is_expert_weight = False
+                # gate_up_proj 是 gate+up 两部分合并存储的，需要先切成两半分别加载
+                if "experts.gate_up_proj" in name:
+                    # 找到对应的 w13_weight param 路径
+                    w13_name = name.replace(
+                        "experts.gate_up_proj", "experts.routed_experts.w13_weight"
+                    )
+                    if is_pp_missing_parameter(w13_name, self):
+                        continue
+                    if w13_name not in params_dict:
+                        logger.warning_once(
+                            f"Parameter {w13_name} not found in params_dict, skip loading"
+                        )
+                        continue
+                    # 沿 dim=-2 切成两半：w1=gate, w3=up
+                    w1_weight, w3_weight = loaded_weight.chunk(2, dim=-2)
+                    param = params_dict[w13_name]
+                    weight_loader = param.weight_loader
+                    # 加载 w1（gate）
+                    weight_loader(
+                        param, w1_weight, w13_name, shard_id="w1", expert_id=0
+                    )
+                    # 加载 w3（up）
+                    weight_loader(
+                        param, w3_weight, w13_name, shard_id="w3", expert_id=0
+                    )
+                    name = w13_name
+                    loaded_params.add(name)
+                    continue
                 for mapping in expert_params_mapping:
                     param_name, weight_name, expert_id, shard_id = mapping
                     if weight_name not in name:
@@ -430,63 +457,26 @@ class Qwen3_5Model(Qwen3NextModel):
                     # Skip layers on other devices.
                     if is_pp_missing_parameter(name_mapped, self):
                         continue
-                    if is_fused_expert:
-                        # qwen3.5 no need to transpose
-                        # loaded_weight = loaded_weight.transpose(-1, -2)
-                        if "experts.gate_up_proj" in name:
-                            loaded_weight = loaded_weight.chunk(2, dim=-2)
-                            success_w1 = self.load_fused_expert_weights(
-                                name_mapped,
-                                params_dict,
-                                loaded_weight[0],
-                                "w1",
-                                num_experts,
-                            )
-                            success_w3 = self.load_fused_expert_weights(
-                                name_mapped,
-                                params_dict,
-                                loaded_weight[1],
-                                "w3",
-                                num_experts,
-                            )
-                            success = success_w1 and success_w3
-                        else:
-                            # down_proj
-                            success = self.load_fused_expert_weights(
-                                name_mapped,
-                                params_dict,
-                                loaded_weight,
-                                shard_id,
-                                num_experts,
-                            )
-                        if success:
-                            name = name_mapped
-                            break
-                    else:
-                        # Skip loading extra bias for GPTQ models.
-                        if (
-                            name_mapped.endswith(".bias")
-                            or name_mapped.endswith("_bias")
-                        ) and name_mapped not in params_dict:
-                            continue
-                        param = params_dict[name_mapped]
-                        weight_loader = param.weight_loader
-                        success = weight_loader(
-                            param,
-                            loaded_weight,
-                            name_mapped,
-                            shard_id=shard_id,
-                            expert_id=expert_id,
-                            return_success=True,
-                        )
-                    if success:
-                        name = name_mapped
-                        break
+                    # Skip loading extra bias for GPTQ models.
+                    if (
+                        name_mapped.endswith(".bias") or name_mapped.endswith("_bias")
+                    ) and name_mapped not in params_dict:
+                        continue
+                    if name_mapped not in params_dict:
+                        continue
+                    param = params_dict[name_mapped]
+                    weight_loader = param.weight_loader
+                    weight_loader(
+                        param,
+                        loaded_weight,
+                        name_mapped,
+                        shard_id=shard_id,
+                        expert_id=expert_id,
+                    )
+                    name = name_mapped
+                    break
                 else:
                     if is_expert_weight:
-                        # We've checked that this is an expert weight
-                        # However it's not mapped locally to this rank
-                        # So we simply skip it
                         continue
                     # Skip loading extra bias for GPTQ models.
                     if name.endswith(".bias") and name not in params_dict:
@@ -607,7 +597,15 @@ class Qwen3_5MoeForCausalLM(Qwen3_5ForCausalLMBase, QwenNextMixtureOfExperts):
         self.set_moe_parameters()
 
     def get_expert_mapping(self) -> list[tuple[str, str, int, str]]:
-        return self.model.get_expert_mapping()
+        return RoutedExperts.build_expert_params_mapping(
+            ckpt_gate_proj_name="gate_proj",
+            ckpt_down_proj_name="down_proj",
+            ckpt_up_proj_name="up_proj",
+            num_experts=getattr(self.config, "num_experts", 0),
+            num_redundant_experts=0,
+            routed_experts_prefix="routed_experts",
+            include_fused=True,
+        )
 
 
 ########################################################

--- a/vllm_kunlun/models/qwen3_dflash.py
+++ b/vllm_kunlun/models/qwen3_dflash.py
@@ -1,0 +1,93 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from collections.abc import Iterable
+
+import torch
+from torch import nn
+from vllm.config import VllmConfig
+from vllm.distributed import get_pp_group
+from vllm.model_executor.layers.logits_processor import LogitsProcessor
+from vllm.model_executor.layers.vocab_parallel_embedding import ParallelLMHead
+from vllm.model_executor.models.qwen3 import Qwen3ForCausalLM, Qwen3Model
+from vllm.model_executor.models.utils import (
+    AutoWeightsLoader,
+    PPMissingLayer,
+    maybe_prefix,
+)
+
+
+class DFlashQwen3Model(Qwen3Model):
+    """Qwen3 draft model shell for DFlash.
+
+    The initial Kunlun backport reuses the stable Qwen3 model implementation and
+    exposes the DFlash-specific API surface expected by the proposer.
+    """
+
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
+        super().__init__(vllm_config=vllm_config, prefix=prefix)
+        dflash_config = getattr(self.config, "dflash_config", None)
+        self.use_aux_hidden_state = (
+            dflash_config.get("use_aux_hidden_state", True)
+            if dflash_config is not None
+            else True
+        )
+
+    def precompute_and_store_context_kv(
+        self,
+        hidden_states: torch.Tensor,
+        positions: torch.Tensor,
+        slot_mapping: torch.Tensor,
+    ) -> None:
+        # Upstream DFlash pre-inserts cross-attention context K/V here. In this
+        # 0.15.1 backport the proposer runs on the EAGLE-style path, so no extra
+        # pre-insertion is required yet.
+        del hidden_states, positions, slot_mapping
+
+
+class DFlashQwen3ForCausalLM(Qwen3ForCausalLM):
+    packed_modules_mapping = Qwen3ForCausalLM.packed_modules_mapping
+
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
+        nn.Module.__init__(self)
+        assert vllm_config.speculative_config is not None
+        config = vllm_config.speculative_config.draft_model_config.hf_config
+        quant_config = vllm_config.quant_config
+        if getattr(config, "draft_vocab_size", None) is None:
+            config.draft_vocab_size = getattr(config, "vocab_size", None)
+        self.config = config
+        self.quant_config = quant_config
+        self.model = DFlashQwen3Model(
+            vllm_config=vllm_config, prefix=maybe_prefix(prefix, "model")
+        )
+        if get_pp_group().is_last_rank:
+            if getattr(config, "tie_word_embeddings", False):
+                self.lm_head = self.model.embed_tokens
+            else:
+                self.lm_head = ParallelLMHead(
+                    config.vocab_size,
+                    config.hidden_size,
+                    quant_config=quant_config,
+                    prefix=maybe_prefix(prefix, "lm_head"),
+                )
+        else:
+            self.lm_head = PPMissingLayer()
+        self.logits_processor = LogitsProcessor(config.vocab_size)
+        self.make_empty_intermediate_tensors = (
+            self.model.make_empty_intermediate_tensors
+        )
+
+    def compute_logits(
+        self,
+        hidden_states: torch.Tensor,
+        logits_processor_arg=None,
+    ) -> torch.Tensor | None:
+        del logits_processor_arg
+        return self.logits_processor(self.lm_head, hidden_states)
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        loader = AutoWeightsLoader(
+            self,
+            skip_prefixes=(["lm_head."] if self.config.tie_word_embeddings else None),
+        )
+        return loader.load_weights(weights)

--- a/vllm_kunlun/ops/_custom_ops_back.py
+++ b/vllm_kunlun/ops/_custom_ops_back.py
@@ -1,0 +1,2896 @@
+from typing import Optional  # noqa: E402
+from typing import List, Tuple
+
+import torch  # noqa: E402
+from torch.library import custom_op, impl, register_fake  # noqa: E402
+
+
+@custom_op("_moe_C::topk_softmax", mutates_args=())
+def topk_softmax(
+    topk_weights: torch.Tensor,
+    topk_ids: torch.Tensor,
+    token_expert_indices: torch.Tensor,
+    gating_output: torch.Tensor,
+    renormalize: bool = False,
+    e_score_correction_bias: torch.Tensor | None = None,
+) -> None:
+    pass
+
+
+@custom_op("_C::rms_norm", mutates_args=())
+def rms_norm(
+    result: torch.Tensor,
+    input: torch.Tensor,
+    residual: torch.Tensor,
+    weight: torch.Tensor,
+    scale: torch.Tensor,
+    epsilon: float,
+) -> None:
+    pass
+
+
+@custom_op("_C::fused_add_rms_norm", mutates_args=())
+def fused_add_rms_norm(
+    result: torch.Tensor,
+    input: torch.Tensor,
+    residual: torch.Tensor,
+    weight: torch.Tensor,
+    scale: torch.Tensor,
+    epsilon: float,
+) -> None:
+    pass
+
+
+@custom_op("_C::static_scaled_fp8_quant", mutates_args=())
+def static_scaled_fp8_quant(
+    result: torch.Tensor, input: torch.Tensor, scale: torch.Tensor
+) -> None:
+    pass
+
+
+@impl("_C::static_scaled_fp8_quant", "CUDA")
+def static_scaled_fp8_quant_xpu(
+    result: torch.Tensor, input: torch.Tensor, scale: torch.Tensor
+) -> None:
+    pass
+
+
+@custom_op("_C::dynamic_scaled_fp8_quant", mutates_args=())
+def dynamic_scaled_fp8_quant(
+    result: torch.Tensor, input: torch.Tensor, scale: torch.Tensor
+) -> None:
+    pass
+
+
+@impl("_C::dynamic_scaled_fp8_quant", "CUDA")
+def dynamic_scaled_fp8_quant_xpu(
+    result: torch.Tensor, input: torch.Tensor, scale: torch.Tensor
+) -> None:
+    pass
+
+
+@custom_op("_C::dynamic_per_token_scaled_fp8_quant", mutates_args=())
+def dynamic_per_token_scaled_fp8_quant(
+    result: torch.Tensor,
+    input: torch.Tensor,
+    scale: torch.Tensor,
+    scale_ub: Optional[torch.Tensor],
+) -> None:
+    pass
+
+
+@impl("_C::dynamic_per_token_scaled_fp8_quant", "CUDA")
+def dynamic_per_token_scaled_fp8_quant_xpu(
+    result: torch.Tensor,
+    input: torch.Tensor,
+    scale: torch.Tensor,
+    scale_ub: Optional[torch.Tensor],
+) -> None:
+    pass
+
+
+@custom_op("_C::rms_norm_static_fp8_quant", mutates_args=())
+def rms_norm_static_fp8_quant(
+    result: torch.Tensor,
+    input: torch.Tensor,
+    weight: torch.Tensor,
+    scale: torch.Tensor,
+    epsilon: float,
+) -> None:
+    pass
+
+
+@impl("_C::rms_norm_static_fp8_quant", "CUDA")
+def rms_norm_static_fp8_quant_xpu(
+    result: torch.Tensor,
+    input: torch.Tensor,
+    weight: torch.Tensor,
+    scale: torch.Tensor,
+    epsilon: float,
+) -> None:
+    pass
+
+
+@custom_op("_C::rms_norm_per_block_quant", mutates_args=())
+def rms_norm_per_block_quant(
+    input: torch.Tensor,
+    weight: torch.Tensor,
+    epsilon: float,
+    quant_dtype: torch.dtype,
+    group_size: List[int],
+    scale_ub: torch.Tensor | None = None,
+    residual: torch.Tensor | None = None,
+    is_scale_transposed: bool = False,
+) -> None:
+    pass
+
+
+@impl("_C::rms_norm_per_block_quant", "CUDA")
+def rms_norm_per_block_quant_xpu(
+    input: torch.Tensor,
+    weight: torch.Tensor,
+    epsilon: float,
+    quant_dtype: torch.dtype,
+    group_size: List[int],
+    scale_ub: torch.Tensor | None = None,
+    residual: torch.Tensor | None = None,
+    is_scale_transposed: bool = False,
+) -> None:
+    pass
+
+
+@custom_op("_C::fused_qk_norm_rope", mutates_args=())
+def fused_qk_norm_rope(
+    qkv: torch.Tensor,
+    num_heads_q: int,
+    num_heads_k: int,
+    num_heads_v: int,
+    head_dim: int,
+    eps: float,
+    q_weight: torch.Tensor,
+    k_weight: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    is_neox: bool,
+    position_ids: torch.Tensor,
+) -> None:
+    pass
+
+
+@impl("_C::fused_qk_norm_rope", "CUDA")
+def fused_qk_norm_rope_xpu(
+    qkv: torch.Tensor,
+    num_heads_q: int,
+    num_heads_k: int,
+    num_heads_v: int,
+    head_dim: int,
+    eps: float,
+    q_weight: torch.Tensor,
+    k_weight: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    is_neox: bool,
+    position_ids: torch.Tensor,
+) -> None:
+    pass
+
+
+@custom_op("_C::fused_add_rms_norm_static_fp8_quant", mutates_args=())
+def fused_add_rms_norm_static_fp8_quant(
+    result: torch.Tensor,
+    input: torch.Tensor,
+    residual: torch.Tensor,
+    weight: torch.Tensor,
+    scale: torch.Tensor,
+    epsilon: float,
+) -> None:
+    pass
+
+
+@impl("_C::fused_add_rms_norm_static_fp8_quant", "CUDA")
+def fused_add_rms_norm_static_fp8_quant_xpu(
+    result: torch.Tensor,
+    input: torch.Tensor,
+    residual: torch.Tensor,
+    weight: torch.Tensor,
+    scale: torch.Tensor,
+    epsilon: float,
+) -> None:
+    pass
+
+
+@custom_op("_C::rms_norm_dynamic_per_token_quant", mutates_args=())
+def rms_norm_dynamic_per_token_quant(
+    result: torch.Tensor,
+    input: torch.Tensor,
+    weight: torch.Tensor,
+    scale: torch.Tensor,
+    epsilon: float,
+    scale_ub: Optional[torch.Tensor],
+    residual: Optional[torch.Tensor],
+) -> None:
+    pass
+
+
+@impl("_C::rms_norm_dynamic_per_token_quant", "CUDA")
+def rms_norm_dynamic_per_token_quant_xpu(
+    result: torch.Tensor,
+    input: torch.Tensor,
+    weight: torch.Tensor,
+    scale: torch.Tensor,
+    epsilon: float,
+    scale_ub: Optional[torch.Tensor],
+    residual: Optional[torch.Tensor],
+) -> None:
+    pass
+
+
+@custom_op("_C::silu_and_mul_quant", mutates_args=())
+def silu_and_mul_quant(
+    result: torch.Tensor,
+    input: torch.Tensor,
+    residual: torch.Tensor,
+    weight: torch.Tensor,
+    scale: torch.Tensor,
+    epsilon: float,
+) -> None:
+    pass
+
+
+@impl("_C::silu_and_mul_quant", "CUDA")
+def silu_and_mul_quant_xpu(
+    result: torch.Tensor,
+    input: torch.Tensor,
+    residual: torch.Tensor,
+    weight: torch.Tensor,
+    scale: torch.Tensor,
+    epsilon: float,
+) -> None:
+    pass
+
+
+import kunlun_ops  # noqa: E402
+import torch  # noqa: E402
+from torch.library import custom_op, impl  # noqa: E402
+
+
+@custom_op("_C::add_rmsnorm", mutates_args=())
+def add_rmsnorm(
+    x: torch.Tensor,
+    y: torch.Tensor,
+    weight: torch.Tensor,
+    output: torch.Tensor,
+    eps: float = 1e-5,
+    interweaved: bool = False,
+    store_output_before_norm: bool = True,
+    bias: torch.Tensor = None,
+    smooth: torch.Tensor = None,
+    residual_output: torch.Tensor = None,
+    output_max: torch.Tensor = None,
+) -> None:
+    kunlun_ops.add_rmsnorm(
+        x,
+        y,
+        residual_output=residual_output,
+        weight=weight,
+        eps=eps,
+        output=output,
+    )
+
+
+@impl("_C::add_rmsnorm", "CUDA")
+def add_rmsnorm_cuda(
+    x: torch.Tensor,
+    y: torch.Tensor,
+    weight: torch.Tensor,
+    output: torch.Tensor,
+    eps: float = 1e-5,
+    interweaved: bool = False,
+    store_output_before_norm: bool = True,
+    bias: torch.Tensor = None,
+    smooth: torch.Tensor = None,
+    residual_output: torch.Tensor = None,
+    output_max: torch.Tensor = None,
+) -> None:
+    kunlun_ops.add_rmsnorm(
+        x,
+        y,
+        residual_output=residual_output,
+        weight=weight,
+        eps=eps,
+        output=output,
+    )
+
+
+@custom_op("_C::rmsnorm", mutates_args=())
+def rmsnorm(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    output: torch.Tensor,
+    eps: float = 1e-5,
+    interweave: bool = False,
+    store_output_before_norm: bool = True,
+    bias: torch.Tensor = None,
+    residual_output: torch.Tensor = None,
+    output_max: torch.Tensor = None,
+) -> None:
+    kunlun_ops.rmsnorm(
+        x,
+        weight,
+        output,
+        eps,
+    )
+
+
+@impl("_C::rmsnorm", "CUDA")
+def rmsnorm_cuda(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    output: torch.Tensor,
+    eps: float = 1e-5,
+    interweave: bool = False,
+    store_output_before_norm: bool = True,
+    bias: torch.Tensor = None,
+    residual_output: torch.Tensor = None,
+    output_max: torch.Tensor = None,
+) -> None:
+    kunlun_ops.rmsnorm(
+        x,
+        weight,
+        output,
+        eps,
+    )
+
+
+import torch  # noqa: E402
+
+
+def _fake_rmsnorm(
+    x,
+    weight,
+    output,
+    eps=1e-5,
+    interweave=False,
+    store_output_before_norm=True,
+    bias=None,
+    residual_output=None,
+    output_max=None,
+):
+    # 设置 shape/dtype，但不返回值
+    output.fake_shape = x.shape
+    output.fake_dtype = x.dtype
+    return None
+
+
+rmsnorm.register_fake(_fake_rmsnorm)
+
+
+def _fake_add_rmsnorm(
+    x,
+    y,
+    weight,
+    output,
+    eps=1e-5,
+    interweaved=False,
+    store_output_before_norm=True,
+    bias=None,
+    smooth=None,
+    residual_output=None,
+    output_max=None,
+):
+    output.fake_shape = x.shape
+    output.fake_dtype = x.dtype
+    return None
+
+
+add_rmsnorm.register_fake(_fake_add_rmsnorm)
+
+
+@custom_op("_C::gemma_add_rmsnorm", mutates_args=())
+def gemma_add_rmsnorm(
+    x: torch.Tensor,
+    y: torch.Tensor,
+    weight: torch.Tensor,
+    output: torch.Tensor,
+    eps: float = 1e-5,
+    enable_pdl: bool = False,
+    interweaved: bool = False,
+    store_output_before_norm: bool = True,
+    bias: torch.Tensor = None,
+    smooth: torch.Tensor = None,
+    residual_output: torch.Tensor = None,
+    force_sdnn: bool = False,
+) -> None:
+    # print("gemma_add_rmsnorm wrapper")
+    kunlun_ops.gemma_add_rmsnorm(
+        x,
+        y,
+        weight=weight,
+        output=output,
+        eps=eps,
+        enable_pdl=enable_pdl,
+        interweaved=interweaved,
+        store_output_before_norm=store_output_before_norm,
+        bias=bias,
+        smooth=smooth,
+        residual_output=residual_output,
+        force_sdnn=force_sdnn,
+    )
+
+
+@impl("_C::gemma_add_rmsnorm", "CUDA")
+def gemma_add_rmsnorm_cuda(
+    x: torch.Tensor,
+    y: torch.Tensor,
+    weight: torch.Tensor,
+    output: torch.Tensor,
+    eps: float = 1e-5,
+    enable_pdl: bool = False,
+    interweaved: bool = False,
+    store_output_before_norm: bool = True,
+    bias: torch.Tensor = None,
+    smooth: torch.Tensor = None,
+    residual_output: torch.Tensor = None,
+    force_sdnn: bool = False,
+) -> None:
+    kunlun_ops.gemma_add_rmsnorm(
+        x,
+        y,
+        weight=weight,
+        output=output,
+        eps=eps,
+        enable_pdl=enable_pdl,
+        interweaved=interweaved,
+        store_output_before_norm=store_output_before_norm,
+        bias=bias,
+        smooth=smooth,
+        residual_output=residual_output,
+        force_sdnn=force_sdnn,
+    )
+
+
+def _fake_gemma_add_rmsnorm(
+    x: torch.Tensor,
+    y: torch.Tensor,
+    weight: torch.Tensor,
+    output: torch.Tensor,
+    eps: float = 1e-5,
+    enable_pdl: bool = False,
+    interweaved: bool = False,
+    store_output_before_norm: bool = True,
+    bias: torch.Tensor = None,
+    smooth: torch.Tensor = None,
+    residual_output: torch.Tensor = None,
+    force_sdnn: bool = False,
+):
+    output.fake_shape = x.shape
+    output.fake_dtype = x.dtype
+    return None
+
+
+gemma_add_rmsnorm.register_fake(_fake_gemma_add_rmsnorm)
+
+
+@custom_op("_C::rms_norm_gated", mutates_args=())
+def rms_norm_gated(
+    x: torch.Tensor,
+    output: torch.Tensor,
+    z: torch.Tensor,
+    weight: torch.Tensor,
+    eps: float,
+    group_size: int | None = None,
+    norm_before_gate: bool = True,
+    is_rms_norm: bool = True,
+    force_sdnn: bool = False,
+) -> None:
+    kunlun_ops.rms_norm_gated(
+        x, output, z, weight, eps, group_size, norm_before_gate, is_rms_norm
+    )
+
+
+@impl("_C::rms_norm_gated", "CUDA")
+def rms_norm_gated_cuda(
+    x: torch.Tensor,
+    output: torch.Tensor,
+    z: torch.Tensor,
+    weight: torch.Tensor,
+    eps: float,
+    group_size: int | None = None,
+    norm_before_gate: bool = True,
+    is_rms_norm: bool = True,
+    force_sdnn: bool = False,
+) -> None:
+    kunlun_ops.rms_norm_gated(
+        x, output, z, weight, eps, group_size, norm_before_gate, is_rms_norm
+    )
+
+
+def _fake_rms_norm_gated(
+    x: torch.Tensor,
+    output: torch.Tensor,
+    z: torch.Tensor,
+    weight: torch.Tensor,
+    eps: float,
+    group_size: int | None = None,
+    norm_before_gate: bool = True,
+    is_rms_norm: bool = True,
+    force_sdnn: bool = False,
+) -> None:
+    output.fake_shape = x.shape
+    output.fake_dtype = x.dtype
+    return None
+
+
+rms_norm_gated.register_fake(_fake_rms_norm_gated)
+
+
+@custom_op("_C::gemma_rmsnorm", mutates_args=())
+def gemma_rmsnorm(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    output: torch.Tensor,
+    eps: float = 1e-5,
+    enable_pdl: bool = False,
+    interweave: bool = False,
+    bias: torch.Tensor = None,
+    force_sdnn: bool = False,
+) -> None:
+    # print("gemma_rmsnorm wrapper")
+    kunlun_ops.gemma_rmsnorm(
+        x, weight, output, eps, enable_pdl, interweave, bias, force_sdnn
+    )
+
+
+@impl("_C::gemma_rmsnorm", "CUDA")
+def gemma_rmsnorm_cuda(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    output: torch.Tensor,
+    eps: float = 1e-5,
+    enable_pdl: bool = False,
+    interweave: bool = False,
+    bias: torch.Tensor = None,
+    force_sdnn: bool = False,
+) -> None:
+    kunlun_ops.gemma_rmsnorm(
+        x, weight, output, eps, enable_pdl, interweave, bias, force_sdnn
+    )
+
+
+def _fake_gemma_rmsnorm(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    output: torch.Tensor,
+    eps: float = 1e-5,
+    enable_pdl: bool = False,
+    interweave: bool = False,
+    bias: torch.Tensor = None,
+    force_sdnn: bool = False,
+):
+    # 设置 shape/dtype，但不返回值
+    output.fake_shape = x.shape
+    output.fake_dtype = x.dtype
+    return None
+
+
+gemma_rmsnorm.register_fake(_fake_gemma_rmsnorm)
+
+
+@custom_op("_C::split_norm_rope_neox", mutates_args=())
+def split_norm_rope_neox(
+    q_emb: torch.Tensor,
+    k_emb: torch.Tensor,
+    v_out: torch.Tensor,
+    qkv: torch.Tensor,
+    rotary_pos_embedding: torch.Tensor,
+    q_norm_weight: torch.Tensor,
+    k_norm_weight: torch.Tensor,
+    positions: torch.Tensor,
+    num_tokens: int,
+    max_seqlen: int,
+    head_num: int,
+    kv_head_num: int,
+    head_dim: int,
+    rotary_dim: int,
+    emb_batch_size: int = 1,
+) -> None:
+    kunlun_ops.split_norm_rope_neox(
+        q_emb,
+        k_emb,
+        v_out,
+        qkv,
+        rotary_pos_embedding,
+        q_norm_weight,
+        k_norm_weight,
+        positions,
+        num_tokens,
+        max_seqlen,
+        head_num,
+        kv_head_num,
+        head_dim,
+        rotary_dim,
+    )
+
+
+@impl("_C::split_norm_rope_neox", "CUDA")
+def split_norm_rope_neox_cuda(
+    q_emb: torch.Tensor,
+    k_emb: torch.Tensor,
+    v_out: torch.Tensor,
+    qkv: torch.Tensor,
+    rotary_pos_embedding: torch.Tensor,
+    q_norm_weight: torch.Tensor,
+    k_norm_weight: torch.Tensor,
+    positions: torch.Tensor,
+    num_tokens: int,
+    max_seqlen: int,
+    head_num: int,
+    kv_head_num: int,
+    head_dim: int,
+    rotary_dim: int,
+    emb_batch_size: int = 1,
+) -> None:
+    kunlun_ops.split_norm_rope_neox(
+        q_emb,
+        k_emb,
+        v_out,
+        qkv,
+        rotary_pos_embedding,
+        q_norm_weight,
+        k_norm_weight,
+        positions,
+        num_tokens,
+        max_seqlen,
+        head_num,
+        kv_head_num,
+        head_dim,
+        rotary_dim,
+    )
+
+
+def _fake_split_norm_rope_neox(
+    q_emb: torch.Tensor,
+    k_emb: torch.Tensor,
+    v_out: torch.Tensor,
+    qkv: torch.Tensor,
+    rotary_pos_embedding: torch.Tensor,
+    q_norm_weight: torch.Tensor,
+    k_norm_weight: torch.Tensor,
+    positions: torch.Tensor,
+    num_tokens: int,
+    max_seqlen: int,
+    head_num: int,
+    kv_head_num: int,
+    head_dim: int,
+    rotary_dim: int,
+    emb_batch_size: int = 1,
+):
+    q_emb.fake_shape = q_emb.shape
+    q_emb.fake_dtype = q_emb.dtype
+    k_emb.fake_shape = k_emb.shape
+    k_emb.fake_dtype = k_emb.dtype
+    v_out.fake_shape = v_out.shape
+    v_out.fake_dtype = v_out.dtype
+    return None
+
+
+split_norm_rope_neox.register_fake(_fake_split_norm_rope_neox)
+
+# register fake op impl here
+# for torch.dynamo
+
+if hasattr(torch.ops.custom_ops, "fc_fusion"):
+
+    @register_fake("custom_ops::fc_fusion")
+    def fc_fusion_fake(
+        self: torch.Tensor,
+        other: torch.Tensor,
+        bias: Optional[torch.Tensor],
+        self_trans: bool,
+        other_trans: bool,
+        *,
+        alpha: float = 1.0,
+        beta: float = 0.0,
+        act: int = 1,
+        multi_stream: bool = False,
+        out: torch.Tensor,
+    ) -> None:
+        pass
+
+
+@custom_op("_C::silu_and_mul", mutates_args=())
+def silu_and_mul(
+    out: torch.Tensor, x: torch.Tensor, axis: int = -1, turn: bool = True
+) -> None:
+    kunlun_ops.swiglu(
+        x=x,
+        y=out,
+    )
+
+
+@impl("_C::silu_and_mul", "CUDA")
+def silu_and_mul_cuda(
+    out: torch.Tensor, x: torch.Tensor, axis: int = -1, turn: bool = True
+) -> None:
+    kunlun_ops.swiglu(
+        x=x,
+        y=out,
+    )
+
+
+def _fake_silu_and_mul(
+    out: torch.Tensor, x: torch.Tensor, axis: int = -1, turn: bool = True
+):
+    return None
+
+
+silu_and_mul.register_fake(_fake_silu_and_mul)
+
+
+@custom_op("_C::swigluoai_and_mul", mutates_args=())
+def swigluoai_and_mul(
+    x: torch.Tensor,
+    alpha: float = 1.702,
+    limit: float = 7.0,
+    axis: int = -1,
+    turn: bool = True,
+) -> torch.Tensor:
+    """PyTorch-native implementation equivalent to forward()."""
+    gate, up = x[..., ::2], x[..., 1::2]
+    gate = gate.clamp(min=None, max=limit)
+    up = up.clamp(min=-limit, max=limit)
+    glu = gate * torch.sigmoid(gate * alpha)
+    gated_output = (up + 1) * glu
+    return gated_output
+
+
+@impl("_C::swigluoai_and_mul", "CUDA")
+def swigluoai_and_mul_cuda(
+    x: torch.Tensor,
+    alpha: float = 1.702,
+    limit: float = 7.0,
+    axis: int = -1,
+    turn: bool = True,
+) -> torch.Tensor:
+    """PyTorch-native implementation equivalent to forward()."""
+    gate, up = x[..., ::2], x[..., 1::2]
+    gate = gate.clamp(min=None, max=limit)
+    up = up.clamp(min=-limit, max=limit)
+    glu = gate * torch.sigmoid(gate * alpha)
+    gated_output = (up + 1) * glu
+    return gated_output
+
+
+def _fake_swigluoai_and_mul(
+    x: torch.Tensor,
+    alpha: float = 1.702,
+    limit: float = 7.0,
+    axis: int = -1,
+    turn: bool = True,
+) -> torch.Tensor:
+    """PyTorch-native implementation equivalent to forward()."""
+    gate, up = x[..., ::2], x[..., 1::2]
+    gate = gate.clamp(min=None, max=limit)
+    up = up.clamp(min=-limit, max=limit)
+    glu = gate * torch.sigmoid(gate * alpha)
+    gated_output = (up + 1) * glu
+    return gated_output
+
+
+swigluoai_and_mul.register_fake(_fake_swigluoai_and_mul)
+
+
+@custom_op("_C::moe_softmax_topk", mutates_args=())
+def moe_softmax_topk(
+    x: torch.Tensor,
+    normed_score: torch.Tensor,
+    topk_index: torch.Tensor,
+    block_statistic: torch.Tensor,
+    axis: int = -1,
+    turn: bool = True,
+) -> None:
+    kunlun_ops.moe_softmax_topk(x, normed_score, topk_index, block_statistic)
+
+
+@impl("_C::moe_softmax_topk", "CUDA")
+def moe_softmax_topk_cuda(
+    x: torch.Tensor,
+    normed_score: torch.Tensor,
+    topk_index: torch.Tensor,
+    block_statistic: torch.Tensor,
+    axis: int = -1,
+    turn: bool = True,
+) -> None:
+    kunlun_ops.moe_softmax_topk(x, normed_score, topk_index, block_statistic)
+
+
+def _fake_moe_softmax_topk(
+    x: torch.Tensor,
+    normed_score: torch.Tensor,
+    topk_index: torch.Tensor,
+    block_statistic: torch.Tensor,
+    axis: int = -1,
+    turn: bool = True,
+) -> None:
+    return None
+
+
+moe_softmax_topk.register_fake(_fake_moe_softmax_topk)
+
+
+@custom_op("_C::moe_ffn_block", mutates_args=())
+def moe_ffn_block(
+    out: torch.Tensor,
+    x: torch.Tensor,
+    expert_num: int,
+    moe_top_k: int,
+    gate_w: torch.Tensor,
+    inter_w: torch.Tensor,
+    output_w: torch.Tensor,
+    renormalize: bool = True,
+    use_grouped_topk: bool = False,
+    expert_group_num: Optional[int] = 0,
+    topk_group: Optional[int] = 0,
+    w1_bias: Optional[torch.Tensor] = None,
+    w2_bias: Optional[torch.Tensor] = None,
+) -> None:
+    kunlun_ops.moe_ffn_block(
+        x=x,
+        gate_w=gate_w,
+        inter_w=inter_w,
+        output_w=output_w,
+        expert_num=expert_num,
+        moe_top_k=moe_top_k,
+        topk_group=topk_group,
+        renormalize=renormalize,
+        use_grouped_topk=use_grouped_topk,
+        expert_group_num=expert_group_num,
+        out=out,
+    )
+
+
+@impl("_C::moe_ffn_block", "CUDA")
+def moe_ffn_block_cuda(
+    out: torch.Tensor,
+    x: torch.Tensor,
+    expert_num: int,
+    moe_top_k: int,
+    gate_w: torch.Tensor,
+    inter_w: torch.Tensor,
+    output_w: torch.Tensor,
+    renormalize: bool = True,
+    use_grouped_topk: bool = False,
+    expert_group_num: Optional[int] = 0,
+    topk_group: Optional[int] = 0,
+    w1_bias: Optional[torch.Tensor] = None,
+    w2_bias: Optional[torch.Tensor] = None,
+) -> None:
+    kunlun_ops.moe_ffn_block(
+        x=x,
+        gate_w=gate_w,
+        inter_w=inter_w,
+        output_w=output_w,
+        expert_num=expert_num,
+        moe_top_k=moe_top_k,
+        topk_group=topk_group,
+        renormalize=renormalize,
+        use_grouped_topk=use_grouped_topk,
+        expert_group_num=expert_group_num,
+        out=out,
+    )
+
+
+def _fake_moe_ffn_block(
+    out: torch.Tensor,
+    x: torch.Tensor,
+    expert_num: int,
+    moe_top_k: int,
+    gate_w: torch.Tensor,
+    inter_w: torch.Tensor,
+    output_w: torch.Tensor,
+    renormalize: bool = True,
+    use_grouped_topk: bool = False,
+    expert_group_num: Optional[int] = 0,
+    topk_group: Optional[int] = 0,
+):
+    return None
+
+
+moe_ffn_block.register_fake(_fake_moe_ffn_block)
+
+
+@custom_op("_C::moe_ffn_per_token_block", mutates_args=())
+def moe_ffn_per_token_block(
+    x: torch.Tensor,
+    inter_weight: torch.Tensor,
+    inter_scale: torch.Tensor,
+    outer_weight: torch.Tensor,
+    outer_scale: torch.Tensor,
+    top_k: int,
+    global_num_experts: int,
+    linear_weights: Optional[torch.Tensor] = None,
+    expert_map: Optional[torch.Tensor] = None,
+    activation: str = "silu",
+    output: Optional[torch.Tensor] = None,
+    use_expert_parallel: bool = False,
+    ep_size: int = 1,
+    ep_rank: int = 0,
+) -> None:
+    kunlun_ops.moe_ffn_per_token_block(
+        x=x,
+        inter_weight=inter_weight,
+        inter_scale=inter_scale,
+        outer_weight=outer_weight,
+        outer_scale=outer_scale,
+        gate_weight=linear_weights,
+        expert_num=global_num_experts,
+        moe_top_k=top_k,
+        act_type=activation,
+        use_expert_parallel=use_expert_parallel,
+        ep_size=ep_size,
+        ep_rank=ep_rank,
+        out=output,
+    )
+
+
+@impl("_C::moe_ffn_per_token_block", "CUDA")
+def moe_ffn_per_token_block_cuda(
+    x: torch.Tensor,
+    inter_weight: torch.Tensor,
+    inter_scale: torch.Tensor,
+    outer_weight: torch.Tensor,
+    outer_scale: torch.Tensor,
+    top_k: int,
+    global_num_experts: int,
+    linear_weights: Optional[torch.Tensor] = None,
+    expert_map: Optional[torch.Tensor] = None,
+    activation: str = "silu",
+    output: Optional[torch.Tensor] = None,
+    use_expert_parallel: bool = False,
+    ep_size: int = 1,
+    ep_rank: int = 0,
+) -> None:
+    kunlun_ops.moe_ffn_per_token_block(
+        x=x,
+        inter_weight=inter_weight,
+        inter_scale=inter_scale,
+        outer_weight=outer_weight,
+        outer_scale=outer_scale,
+        gate_weight=linear_weights,
+        expert_num=global_num_experts,
+        moe_top_k=top_k,
+        act_type=activation,
+        use_expert_parallel=use_expert_parallel,
+        ep_size=ep_size,
+        ep_rank=ep_rank,
+        out=output,
+    )
+
+
+def _fake_moe_ffn_per_token_block(
+    x: torch.Tensor,
+    inter_weight: torch.Tensor,
+    inter_scale: torch.Tensor,
+    outer_weight: torch.Tensor,
+    outer_scale: torch.Tensor,
+    top_k: int,
+    global_num_experts: int,
+    linear_weights: Optional[torch.Tensor] = None,
+    expert_map: Optional[torch.Tensor] = None,
+    activation: str = "silu",
+    output: Optional[torch.Tensor] = None,
+    use_expert_parallel: bool = False,
+    ep_size: int = 1,
+    ep_rank: int = 0,
+) -> None:
+    # Fake implementation can be a no-op or a simple operation
+    if output is not None:
+        output.copy_(x)  # Example: simply copy input to output
+
+
+# Register the fake implementation
+moe_ffn_per_token_block.register_fake(_fake_moe_ffn_per_token_block)
+
+
+@custom_op("_C::rotary_embedding", mutates_args=())
+def rotary_embedding(
+    positions: torch.Tensor,
+    query: torch.Tensor,
+    key: torch.Tensor,
+    head_size: int,
+    cos_sin_cache: torch.Tensor,
+    is_neox: bool,
+) -> None:
+    kunlun_ops.rotary_embedding(
+        positions=positions,
+        query=query,
+        key=key,
+        head_size=head_size,
+        cos_sin_cache=cos_sin_cache,
+        is_neox=is_neox,
+    )
+
+
+@impl("_C::rotary_embedding", "CUDA")
+def rotary_embedding_cuda(
+    positions: torch.Tensor,
+    query: torch.Tensor,
+    key: torch.Tensor,
+    head_size: int,
+    cos_sin_cache: torch.Tensor,
+    is_neox: bool,
+) -> None:
+    kunlun_ops.rotary_embedding(
+        positions=positions,
+        query=query,
+        key=key,
+        head_size=head_size,
+        cos_sin_cache=cos_sin_cache,
+        is_neox=is_neox,
+    )
+
+
+def _fake_rotary_embedding(
+    positions: torch.Tensor,
+    query: torch.Tensor,
+    key: torch.Tensor,
+    head_size: int,
+    cos_sin_cache: torch.Tensor,
+    is_neox: bool,
+) -> None:
+    return None
+
+
+rotary_embedding.register_fake(_fake_rotary_embedding)
+
+
+@custom_op("_C::gemm_I8_I8_bf16_nt", mutates_args=())
+def gemm_I8_I8_bf16_nt(
+    x_q: torch.Tensor,
+    x_scale: torch.Tensor,
+    weight: torch.Tensor,
+    weight_scale: torch.Tensor,
+    out: torch.Tensor,
+) -> None:
+    kunlun_ops.gemm_I8_I8_bf16_nt(
+        lhs=(x_q, x_scale), rhs=(weight, weight_scale), out=out
+    )
+
+
+@impl("_C::gemm_I8_I8_bf16_nt", "CUDA")
+def gemm_I8_I8_bf16_nt_cuda(
+    x_q: torch.Tensor,
+    x_scale: torch.Tensor,
+    weight: torch.Tensor,
+    weight_scale: torch.Tensor,
+    out: torch.Tensor,
+) -> None:
+    kunlun_ops.gemm_I8_I8_bf16_nt(
+        lhs=(x_q, x_scale), rhs=(weight, weight_scale), out=out
+    )
+
+
+def _fake_gemm_I8_I8_bf16_nt(
+    x_q: torch.Tensor,
+    x_scale: torch.Tensor,
+    weight: torch.Tensor,
+    weight_scale: torch.Tensor,
+    out: torch.Tensor,
+) -> None:
+    return None
+
+
+gemm_I8_I8_bf16_nt.register_fake(_fake_gemm_I8_I8_bf16_nt)
+
+
+@custom_op("_C::moe_softmax_topk_norm", mutates_args=())
+def moe_softmax_topk_norm(
+    x: torch.Tensor,
+    normed_score: torch.Tensor,
+    topk_index: torch.Tensor,
+    block_statistic: torch.Tensor,
+    stable: bool = True,
+) -> None:
+    kunlun_ops.moe_softmax_topk_norm(
+        x, normed_score, topk_index, block_statistic, stable
+    )
+
+
+@impl("_C::moe_softmax_topk_norm", "CUDA")
+def moe_softmax_topk_norm_cuda(
+    x: torch.Tensor,
+    normed_score: torch.Tensor,
+    topk_index: torch.Tensor,
+    block_statistic: torch.Tensor,
+    stable: bool = True,
+) -> None:
+    kunlun_ops.moe_softmax_topk_norm(
+        x, normed_score, topk_index, block_statistic, stable
+    )
+
+
+def _fake_moe_softmax_topk_norm(
+    x: torch.Tensor,
+    normed_score: torch.Tensor,
+    topk_index: torch.Tensor,
+    block_statistic: torch.Tensor,
+    stable: bool = True,
+) -> None:
+    return None
+
+
+moe_softmax_topk_norm.register_fake(_fake_moe_softmax_topk_norm)
+
+
+@custom_op("_C::gen_block_statistic", mutates_args=())
+def gen_block_statistic(topk_ids: torch.Tensor, block_statistic: torch.Tensor) -> None:
+    kunlun_ops.gen_block_statistic(topk_ids, block_statistic)
+
+
+@impl("_C::gen_block_statistic", "CUDA")
+def gen_block_statistic_cuda(
+    topk_ids: torch.Tensor, block_statistic: torch.Tensor
+) -> None:
+    kunlun_ops.gen_block_statistic(topk_ids, block_statistic)
+
+
+def fake_gen_block_statistic(
+    topk_ids: torch.Tensor, block_statistic: torch.Tensor
+) -> None:
+    return None
+
+
+gen_block_statistic.register_fake(fake_gen_block_statistic)
+
+
+@custom_op("_C::moe_pre_sorted", mutates_args=())
+def moe_pre_sorted(
+    x: torch.Tensor,
+    topk_index: torch.Tensor,
+    block_statistic: torch.Tensor,
+    moe_expand: torch.Tensor,
+    moe_index: torch.Tensor,
+    expert_m: torch.Tensor,
+    sorted_tokens_num_lod: torch.Tensor,
+    index_have_neg: bool = False,
+) -> None:
+    kunlun_ops.moe_pre_sorted(
+        x,
+        topk_index,
+        block_statistic,
+        moe_expand,
+        moe_index,
+        expert_m,
+        sorted_tokens_num_lod,
+    )
+
+
+@impl("_C::moe_pre_sorted", "CUDA")
+def moe_pre_sorted_cuda(
+    x: torch.Tensor,
+    topk_index: torch.Tensor,
+    block_statistic: torch.Tensor,
+    moe_expand: torch.Tensor,
+    moe_index: torch.Tensor,
+    expert_m: torch.Tensor,
+    sorted_tokens_num_lod: torch.Tensor,
+    index_have_neg: bool = False,
+) -> None:
+    kunlun_ops.moe_pre_sorted(
+        x,
+        topk_index,
+        block_statistic,
+        moe_expand,
+        moe_index,
+        expert_m,
+        sorted_tokens_num_lod,
+    )
+
+
+def fake_moe_pre_sorted(
+    x: torch.Tensor,
+    topk_index: torch.Tensor,
+    block_statistic: torch.Tensor,
+    moe_expand: torch.Tensor,
+    moe_index: torch.Tensor,
+    expert_m: torch.Tensor,
+    sorted_tokens_num_lod: torch.Tensor,
+    index_have_neg: bool = False,
+) -> None:
+    return None
+
+
+moe_pre_sorted.register_fake(fake_moe_pre_sorted)
+
+
+@custom_op("_C::moe_fc", mutates_args=())
+def moe_fc(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    sorted_tokens_num_lod: torch.Tensor,
+    sorted_tokens_idx: torch.Tensor,
+    moe_topk: int,
+    y: torch.Tensor,
+    act: Optional[str] = None,
+    x_perchannel_max: Optional[torch.Tensor] = None,
+    w_perchannel_max: Optional[torch.Tensor] = None,
+    topk_ids: Optional[torch.Tensor] = None,
+    topk_w: Optional[torch.Tensor] = None,
+    bias: Optional[torch.Tensor] = None,
+    tgemm_type: Optional[str] = None,
+    tweight_type: Optional[str] = None,
+    scale_n: Optional[int] = 0,
+    scale_k: Optional[int] = 0,
+    use_pack_int4: Optional[bool] = False,
+    sort_mode: Optional[bool] = True,
+) -> None:
+    kunlun_ops.moe_fc(
+        x=x,
+        weight=weight,
+        sorted_tokens_num_lod=sorted_tokens_num_lod,
+        sorted_tokens_idx=sorted_tokens_idx,
+        moe_topk=moe_topk,
+        y=y,
+        act=act,
+        x_perchannel_max=x_perchannel_max,
+        w_perchannel_max=w_perchannel_max,
+        topk_ids=topk_ids,
+        topk_w=topk_w,
+        bias=bias,
+        tgemm_type=tgemm_type,
+        tweight_type=tweight_type,
+        scale_n=scale_n,
+        scale_k=scale_k,
+        use_pack_int4=use_pack_int4,
+        sort_mode=sort_mode,
+    )
+
+
+@impl("_C::moe_fc", "CUDA")
+def moe_fc_cuda(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    sorted_tokens_num_lod: torch.Tensor,
+    sorted_tokens_idx: torch.Tensor,
+    moe_topk: int,
+    y: torch.Tensor,
+    act: Optional[str] = None,
+    x_perchannel_max: Optional[torch.Tensor] = None,
+    w_perchannel_max: Optional[torch.Tensor] = None,
+    topk_ids: Optional[torch.Tensor] = None,
+    topk_w: Optional[torch.Tensor] = None,
+    bias: Optional[torch.Tensor] = None,
+    tgemm_type: Optional[str] = None,
+    tweight_type: Optional[str] = None,
+    scale_n: Optional[int] = 0,
+    scale_k: Optional[int] = 0,
+    use_pack_int4: Optional[bool] = False,
+    sort_mode: Optional[bool] = True,
+) -> None:
+    kunlun_ops.moe_fc(
+        x=x,
+        weight=weight,
+        sorted_tokens_num_lod=sorted_tokens_num_lod,
+        sorted_tokens_idx=sorted_tokens_idx,
+        moe_topk=moe_topk,
+        y=y,
+        act=act,
+        x_perchannel_max=x_perchannel_max,
+        w_perchannel_max=w_perchannel_max,
+        topk_ids=topk_ids,
+        topk_w=topk_w,
+        bias=bias,
+        tgemm_type=tgemm_type,
+        tweight_type=tweight_type,
+        scale_n=scale_n,
+        scale_k=scale_k,
+        use_pack_int4=use_pack_int4,
+        sort_mode=sort_mode,
+    )
+
+
+def fake_moe_fc(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    sorted_tokens_num_lod: torch.Tensor,
+    sorted_tokens_idx: torch.Tensor,
+    moe_topk: int,
+    y: torch.Tensor,
+    act: Optional[str] = None,
+    x_perchannel_max: Optional[torch.Tensor] = None,
+    w_perchannel_max: Optional[torch.Tensor] = None,
+    topk_ids: Optional[torch.Tensor] = None,
+    topk_w: Optional[torch.Tensor] = None,
+    bias: Optional[torch.Tensor] = None,
+    tgemm_type: Optional[str] = None,
+    tweight_type: Optional[str] = None,
+    scale_n: Optional[int] = 0,
+    scale_k: Optional[int] = 0,
+    use_pack_int4: Optional[bool] = False,
+    sort_mode: Optional[bool] = True,
+) -> None:
+    return None
+
+
+moe_fc.register_fake(fake_moe_fc)
+
+
+@custom_op("_C::moe_post", mutates_args=())
+def moe_post(
+    x: torch.Tensor,
+    moe_index: torch.Tensor,
+    normed_scale: torch.Tensor,
+    dequant_scale: torch.Tensor,
+    y: torch.Tensor,
+) -> None:
+    kunlun_ops.moe_post(x, moe_index, normed_scale, dequant_scale, y)
+
+
+@impl("_C::moe_post", "CUDA")
+def moe_post_cuda(
+    x: torch.Tensor,
+    moe_index: torch.Tensor,
+    normed_scale: torch.Tensor,
+    dequant_scale: torch.Tensor,
+    y: torch.Tensor,
+) -> None:
+    kunlun_ops.moe_post(x, moe_index, normed_scale, dequant_scale, y)
+
+
+def fake_moe_post(
+    x: torch.Tensor,
+    moe_index: torch.Tensor,
+    normed_scale: torch.Tensor,
+    dequant_scale: torch.Tensor,
+    y: torch.Tensor,
+) -> None:
+    return None
+
+
+moe_post.register_fake(fake_moe_post)
+
+
+@custom_op("_C::moe_sigmoid_group_topk_norm", mutates_args=())
+def moe_sigmoid_group_topk_norm(
+    x: torch.Tensor,
+    topk_index: torch.Tensor,
+    norm_score: torch.Tensor,
+    block_static: torch.Tensor,
+    bias: torch.Tensor,
+    scale: float,
+    n_group: int,
+    topk_group: int,
+) -> None:
+    kunlun_ops.moe_sigmoid_group_topk_norm(
+        x=x,
+        norm_score=norm_score,
+        topk_index=topk_index,
+        block_static=block_static,
+        bias=bias,
+        n_group=n_group,
+        topk_group=topk_group,
+        scale=scale,
+    )
+
+
+@impl("_C::moe_sigmoid_group_topk_norm", "CUDA")
+def moe_sigmoid_group_topk_norm_cuda(
+    x: torch.Tensor,
+    topk_index: torch.Tensor,
+    norm_score: torch.Tensor,
+    block_static: torch.Tensor,
+    bias: torch.Tensor,
+    scale: float,
+    n_group: int,
+    topk_group: int,
+) -> None:
+    kunlun_ops.moe_sigmoid_group_topk_norm(
+        x=x,
+        norm_score=norm_score,
+        topk_index=topk_index,
+        block_static=block_static,
+        bias=bias,
+        n_group=n_group,
+        topk_group=topk_group,
+        scale=scale,
+    )
+
+
+def _fake_moe_sigmoid_group_topk_norm(
+    x: torch.Tensor,
+    topk_index: torch.Tensor,
+    norm_score: torch.Tensor,
+    block_static: torch.Tensor,
+    bias: torch.Tensor,
+    scale: float,
+    n_group: int,
+    topk_group: int,
+) -> None:
+    return None
+
+
+moe_sigmoid_group_topk_norm.register_fake(_fake_moe_sigmoid_group_topk_norm)
+
+
+##################################################
+# --------------- awq_dequantize -----------------
+##################################################
+@custom_op("_C::awq_dequantize", mutates_args=())
+def awq_dequantize(
+    qweight: torch.Tensor,
+    scales: torch.Tensor,
+    zeros: torch.Tensor,
+    quant_type: int = 0,
+    align_type: int = 1,
+) -> torch.Tensor:
+    weight = torch.empty(
+        (qweight.shape[0], qweight.shape[1] * 8),
+        dtype=torch.float16,
+        device=qweight.device,
+    )
+    group_m = int(qweight.shape[0] / scales.shape[0])
+    kunlun_ops.awq_dequantize(
+        qweight=qweight,
+        scales=scales,
+        zeros=zeros,
+        weight=weight,
+        group_m=group_m,
+        quant_type=quant_type,
+        align_type=align_type,
+    )
+    return weight
+
+
+@impl("_C::awq_dequantize", "CUDA")
+def awq_dequantize_cuda(
+    qweight: torch.Tensor,
+    scales: torch.Tensor,
+    zeros: torch.Tensor,
+    quant_type: int = 0,
+    align_type: int = 1,
+) -> torch.Tensor:
+    weight = torch.empty(
+        (qweight.shape[0], qweight.shape[1] * 8),
+        dtype=torch.float16,
+        device=qweight.device,
+    )
+    group_m = int(qweight.shape[0] / scales.shape[0])
+    kunlun_ops.awq_dequantize(
+        qweight=qweight,
+        scales=scales,
+        zeros=zeros,
+        weight=weight,
+        group_m=group_m,
+        quant_type=quant_type,
+        align_type=align_type,
+    )
+    return weight
+
+
+def _fake_awq_dequantize(
+    qweight: torch.Tensor,
+    scales: torch.Tensor,
+    zeros: torch.Tensor,
+    quant_type: int = 0,
+    align_type: int = 1,
+) -> torch.Tensor:
+    weight = torch.empty(
+        (qweight.shape[0], qweight.shape[1] * 8),
+        dtype=torch.float16,
+        device=qweight.device,
+    )
+    return weight
+
+
+awq_dequantize.register_fake(_fake_awq_dequantize)
+
+
+##################################################
+# ------------------ awq_gemm -------------------
+##################################################
+@custom_op("_C::awq_gemm", mutates_args=())
+def awq_gemm(
+    x: torch.Tensor,
+    qweight: torch.Tensor,
+    scale: torch.Tensor,
+    zeros: torch.Tensor,
+    align_type: int = 1,
+) -> torch.Tensor:
+    out = torch.empty(
+        (x.shape[0], qweight.shape[1] * 8), dtype=torch.float16, device=x.device
+    )
+    group_size = int(qweight.shape[0] / scale.shape[0])
+    kunlun_ops.awq_gemm(
+        x=x,
+        w=qweight,
+        scale=scale,
+        zeros=zeros,
+        out=out,
+        align_type=align_type,
+        group_size=group_size,
+    )
+    return out
+
+
+@impl("_C::awq_gemm", "CUDA")
+def awq_gemm_cuda(
+    x: torch.Tensor,
+    qweight: torch.Tensor,
+    scale: torch.Tensor,
+    zeros: torch.Tensor,
+    align_type: int = 1,
+) -> torch.Tensor:
+    out = torch.empty(
+        (x.shape[0], qweight.shape[1] * 8), dtype=torch.float16, device=x.device
+    )
+    group_size = int(qweight.shape[0] / scale.shape[0])
+    kunlun_ops.awq_gemm(
+        x=x,
+        w=qweight,
+        scale=scale,
+        zeros=zeros,
+        out=out,
+        align_type=align_type,
+        group_size=group_size,
+    )
+    return out
+
+
+def _fake_awq_gemm(
+    x: torch.Tensor,
+    qweight: torch.Tensor,
+    scale: torch.Tensor,
+    zeros: torch.Tensor,
+    align_type: int = 1,
+) -> torch.Tensor:
+    out = torch.empty(
+        (x.shape[0], qweight.shape[1] * 8), dtype=torch.float16, device=x.device
+    )
+    return out
+
+
+awq_gemm.register_fake(_fake_awq_gemm)
+
+
+##################################################
+# ---------------- gptq_shuffle ------------------
+##################################################
+@custom_op("_C::gptq_shuffle", mutates_args=())
+def gptq_shuffle(
+    q_weight: torch.Tensor,
+    q_perm: torch.Tensor,
+    bit: int,
+) -> None:
+    kunlun_ops.gptq_shuffle(weight=q_weight, perm=q_perm, bit=bit)
+
+
+@impl("_C::gptq_shuffle", "CUDA")
+def gptq_shuffle_cuda(
+    q_weight: torch.Tensor,
+    q_perm: torch.Tensor,
+    bit: int,
+) -> None:
+    kunlun_ops.gptq_shuffle(weight=q_weight, perm=q_perm, bit=bit)
+
+
+def _fake_gptq_shuffle(
+    q_weight: torch.Tensor,
+    q_perm: torch.Tensor,
+    bit: int,
+) -> None:
+    return None
+
+
+gptq_shuffle.register_fake(_fake_gptq_shuffle)
+
+
+##################################################
+# ------------- concat_and_cache_mla -------------
+##################################################
+@custom_op("_C::concat_and_cache_mla", mutates_args=())
+def concat_and_cache_mla(
+    kv_c: torch.Tensor,  # [num_tokens, kv_lora_rank]
+    k_pe: torch.Tensor,  # [num_tokens, pe_dim]
+    kv_cache: torch.Tensor,  # [num_blocks, block_size, (kv_lora_rank + pe_dim)]
+    slot_mapping: torch.Tensor,  # [num_tokens] or [num_actual_tokens]
+) -> None:
+    kunlun_ops.concat_and_cache_mla(
+        kv_c=kv_c,
+        k_pe=k_pe,
+        slot_mapping=slot_mapping,
+        kv_cache=kv_cache,
+    )
+
+
+@impl("_C::concat_and_cache_mla", "CUDA")
+def concat_and_cache_mla_cuda(
+    kv_c: torch.Tensor,  # [num_tokens, kv_lora_rank]
+    k_pe: torch.Tensor,  # [num_tokens, pe_dim]
+    kv_cache: torch.Tensor,  # [num_blocks, block_size, (kv_lora_rank + pe_dim)]
+    slot_mapping: torch.Tensor,  # [num_tokens] or [num_actual_tokens]
+) -> None:
+    kunlun_ops.concat_and_cache_mla(
+        kv_c=kv_c,
+        k_pe=k_pe,
+        slot_mapping=slot_mapping,
+        kv_cache=kv_cache,
+    )
+
+
+def _fake_concat_and_cache_mla(
+    kv_c: torch.Tensor,  # [num_tokens, kv_lora_rank]
+    k_pe: torch.Tensor,  # [num_tokens, pe_dim]
+    kv_cache: torch.Tensor,  # [num_blocks, block_size, (kv_lora_rank + pe_dim)]
+    slot_mapping: torch.Tensor,  # [num_tokens] or [num_actual_tokens]
+) -> None:
+    return None
+
+
+concat_and_cache_mla.register_fake(_fake_concat_and_cache_mla)
+
+
+######################################################
+# -------------- scaled_int8_quant -------------------
+######################################################
+@custom_op("_C::scaled_int8_quant", mutates_args=())
+def scaled_int8_quant(
+    x: torch.Tensor,
+    scale: torch.Tensor,
+    azp: Optional[torch.Tensor] = None,
+    symmetric: bool = True,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, bool]:
+    static = False
+    x_q = torch.empty_like(x, dtype=torch.int8, device=x.device)
+    if scale is not None:  # static
+        static = True
+        torch.ops.xspeedgate_ops.static_scaled_int8_quant(x_q, x, scale, azp)
+    else:  # dynamic
+        scale = torch.empty(
+            (x.numel() // x.shape[-1], 1), device=x.device, dtype=torch.float32
+        )
+        azp = None if symmetric else torch.empty_like(scale, dtype=torch.int32)
+        if symmetric:
+            # NOTE: For quant2d ops, scale represents max.
+            kunlun_ops.quant2d(x=x.contiguous(), y=x_q, max=scale, force_sdnn=True)
+        else:
+            torch.ops.xspeedgate_ops.dynamic_scaled_int8_quant(
+                x_q, x.contiguous(), scale, azp
+            )
+    return x_q, scale, azp, static
+
+
+@impl("_C::scaled_int8_quant", "CUDA")
+def scaled_int8_quant_cuda(
+    x: torch.Tensor,
+    scale: torch.Tensor,
+    azp: Optional[torch.Tensor] = None,
+    symmetric: bool = True,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, bool]:
+    static = False
+    x_q = torch.empty_like(x, dtype=torch.int8, device=x.device)
+    if scale is not None:  # static
+        static = True
+        torch.ops.xspeedgate_ops.static_scaled_int8_quant(x_q, x, scale, azp)
+    else:  # dynamic
+        scale = torch.empty(
+            (x.numel() // x.shape[-1], 1), device=x.device, dtype=torch.float32
+        )
+        azp = None if symmetric else torch.empty_like(scale, dtype=torch.int32)
+        if symmetric:
+            # NOTE: For quant2d ops, scale represents max.
+            kunlun_ops.quant2d(x=x.contiguous(), y=x_q, max=scale, force_sdnn=True)
+        else:
+            torch.ops.xspeedgate_ops.dynamic_scaled_int8_quant(
+                x_q, x.contiguous(), scale, azp
+            )
+    return x_q, scale, azp, static
+
+
+def _fake_scaled_int8_quant(
+    x: torch.Tensor,
+    scale: torch.Tensor,
+    azp: Optional[torch.Tensor] = None,
+    symmetric: bool = True,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, bool]:
+    x_q = torch.empty_like(x, dtype=torch.int8, device=x.device)
+    scale = torch.empty(
+        (x.numel() // x.shape[-1], 1), device=x.device, dtype=torch.float32
+    )
+    azp = None if symmetric else torch.empty_like(scale, dtype=torch.int32)
+    return x_q, scale, azp, False
+
+
+scaled_int8_quant.register_fake(_fake_scaled_int8_quant)
+
+
+######################################################
+# ---------------- cutlass_scaled_mm -----------------
+######################################################
+@custom_op("_C::cutlass_scaled_mm", mutates_args=())
+def cutlass_scaled_mm(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    scale_a: torch.Tensor,
+    scale_b: torch.Tensor,
+    out_dtype: torch.dtype,
+    bias: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    out = torch.empty((a.shape[0], b.shape[1]), dtype=out_dtype, device=a.device)
+    torch.ops.xspeedgate_ops.cutlass_scaled_mm(
+        out, a.contiguous(), b.contiguous(), scale_a, scale_b, bias
+    )
+    return out
+
+
+@impl("_C::cutlass_scaled_mm", "CUDA")
+def cutlass_scaled_mm_cuda(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    scale_a: torch.Tensor,
+    scale_b: torch.Tensor,
+    out_dtype: torch.dtype,
+    bias: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    out = torch.empty((a.shape[0], b.shape[1]), dtype=out_dtype, device=a.device)
+    torch.ops.xspeedgate_ops.cutlass_scaled_mm(
+        out, a.contiguous(), b.contiguous(), scale_a, scale_b, bias
+    )
+    return out
+
+
+def fake_cutlass_scaled_mm(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    scale_a: torch.Tensor,
+    scale_b: torch.Tensor,
+    out_dtype: torch.dtype,
+    bias: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    return torch.empty((a.shape[0], b.shape[1]), dtype=out_dtype, device=a.device)
+
+
+cutlass_scaled_mm.register_fake(fake_cutlass_scaled_mm)
+
+
+######################################################
+# ------------ cutlass_scaled_mm_azp -----------------
+######################################################
+@custom_op("_C::cutlass_scaled_mm_azp", mutates_args=())
+def cutlass_scaled_mm_azp(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    scale_a: torch.Tensor,
+    scale_b: torch.Tensor,
+    out_dtype: torch.dtype,
+    azp_adj: torch.Tensor,
+    azp: Optional[torch.Tensor] = None,
+    bias: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    out = torch.empty((a.shape[0], b.shape[1]), dtype=out_dtype, device=a.device)
+    torch.ops.xspeedgate_ops.cutlass_scaled_mm_azp(
+        out, a.contiguous(), b.contiguous(), scale_a, scale_b, azp_adj, azp, bias
+    )
+    return out
+
+
+@impl("_C::cutlass_scaled_mm_azp", "CUDA")
+def cutlass_scaled_mm_azp_cuda(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    scale_a: torch.Tensor,
+    scale_b: torch.Tensor,
+    out_dtype: torch.dtype,
+    azp_adj: torch.Tensor,
+    azp: Optional[torch.Tensor] = None,
+    bias: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    out = torch.empty((a.shape[0], b.shape[1]), dtype=out_dtype, device=a.device)
+    torch.ops.xspeedgate_ops.cutlass_scaled_mm_azp(
+        out, a.contiguous(), b.contiguous(), scale_a, scale_b, azp_adj, azp, bias
+    )
+    return out
+
+
+def fake_cutlass_scaled_mm_azp(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    scale_a: torch.Tensor,
+    scale_b: torch.Tensor,
+    out_dtype: torch.dtype,
+    azp_adj: torch.Tensor,
+    azp: Optional[torch.Tensor] = None,
+    bias: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    return torch.empty((a.shape[0], b.shape[1]), dtype=out_dtype, device=a.device)
+
+
+cutlass_scaled_mm_azp.register_fake(fake_cutlass_scaled_mm_azp)
+
+
+##################################################
+# ------------------ matmul ---------------------
+##################################################
+@custom_op("_C::matmul", mutates_args=())
+def matmul(
+    x: torch.Tensor,
+    w: torch.Tensor,
+    out_dtype: torch.dtype,
+    x_trans: bool = False,
+    w_trans: bool = True,
+    alpha: float = 1.0,
+    beta: float = 0.0,
+    bias: torch.Tensor = None,
+    x_max: torch.Tensor = None,
+    w_max: torch.Tensor = None,
+    x_pc_max: torch.Tensor = None,
+    w_pc_max: torch.Tensor = None,
+) -> torch.Tensor:
+    out = torch.empty(
+        (x.shape[0], w.shape[0] if w_trans else w.shape[1]),
+        dtype=out_dtype,
+        device=x.device,
+    )
+    kunlun_ops.matmul(
+        x=x.contiguous(),
+        w=w.contiguous(),
+        out=out,
+        x_trans=x_trans,
+        w_trans=w_trans,
+        alpha=alpha,
+        beta=beta,
+        bias=bias,
+        x_max=x_max,
+        w_max=w_max,
+        x_pc_max=x_pc_max,
+        w_pc_max=w_pc_max,
+    )
+    return out
+
+
+@impl("_C::matmul", "CUDA")
+def matmul_cuda(
+    x: torch.Tensor,
+    w: torch.Tensor,
+    out_dtype: torch.dtype,
+    x_trans: bool = False,
+    w_trans: bool = True,
+    alpha: float = 1.0,
+    beta: float = 0.0,
+    bias: torch.Tensor = None,
+    x_max: torch.Tensor = None,
+    w_max: torch.Tensor = None,
+    x_pc_max: torch.Tensor = None,
+    w_pc_max: torch.Tensor = None,
+) -> torch.Tensor:
+    out = torch.empty(
+        (x.shape[0], w.shape[0] if w_trans else w.shape[1]),
+        dtype=out_dtype,
+        device=x.device,
+    )
+    kunlun_ops.matmul(
+        x=x.contiguous(),
+        w=w.contiguous(),
+        out=out,
+        x_trans=x_trans,
+        w_trans=w_trans,
+        alpha=alpha,
+        beta=beta,
+        bias=bias,
+        x_max=x_max,
+        w_max=w_max,
+        x_pc_max=x_pc_max,
+        w_pc_max=w_pc_max,
+    )
+    return out
+
+
+def _fake_matmul(
+    x: torch.Tensor,
+    w: torch.Tensor,
+    out_dtype: torch.dtype,
+    x_trans: bool = False,
+    w_trans: bool = True,
+    alpha: float = 1.0,
+    beta: float = 0.0,
+    bias: torch.Tensor = None,
+    x_max: torch.Tensor = None,
+    w_max: torch.Tensor = None,
+    x_pc_max: torch.Tensor = None,
+    w_pc_max: torch.Tensor = None,
+) -> torch.Tensor:
+    return torch.empty(
+        (x.shape[0], w.shape[0] if w_trans else w.shape[1]),
+        dtype=out_dtype,
+        device=x.device,
+    )
+
+
+matmul.register_fake(_fake_matmul)
+
+
+##################################################
+# ------------------- quant2d --------------------
+##################################################
+@custom_op("_C::quant2d", mutates_args=())
+def quant2d(
+    x: torch.Tensor,
+    x_q: torch.Tensor,
+    max: torch.Tensor,
+    force_sdnn: bool = False,
+) -> None:
+    kunlun_ops.quant2d(
+        x=x,
+        y=x_q,
+        max=max,
+        force_sdnn=force_sdnn,
+    )
+
+
+@impl("_C::quant2d", "CUDA")
+def quant2d_cuda(
+    x: torch.Tensor,
+    x_q: torch.Tensor,
+    max: torch.Tensor,
+    force_sdnn: bool = False,
+) -> None:
+    kunlun_ops.quant2d(
+        x=x,
+        y=x_q,
+        max=max,
+        force_sdnn=force_sdnn,
+    )
+
+
+def _fake_quant2d(
+    x: torch.Tensor,
+    x_q: torch.Tensor,
+    max: torch.Tensor,
+    force_sdnn: bool = False,
+) -> None:
+    return None
+
+
+quant2d.register_fake(_fake_quant2d)
+
+
+##################################################
+# --------------- penalties -----------------
+##################################################
+@custom_op("_C::apply_repetition_penalties_", mutates_args=())
+def apply_repetition_penalties_(
+    logits: torch.Tensor,
+    prompt_mask: torch.Tensor,
+    output_mask: torch.Tensor,
+    repetition_penalties: torch.Tensor,
+) -> None:
+    repetition_penalties = repetition_penalties.unsqueeze(dim=1).repeat(
+        1, logits.size(1)
+    )
+    # If token appears in prompt or output, apply, otherwise use 1.0 for no-op.
+    penalties = torch.where(prompt_mask | output_mask, repetition_penalties, 1.0)
+    # If logits are positive, divide by penalty, otherwise multiply by penalty.
+    scaling = torch.where(logits > 0, 1.0 / penalties, penalties)
+    logits *= scaling
+
+
+@impl("_C::apply_repetition_penalties_", "CUDA")
+def apply_repetition_penalties_cuda(
+    logits: torch.Tensor,
+    prompt_mask: torch.Tensor,
+    output_mask: torch.Tensor,
+    repetition_penalties: torch.Tensor,
+) -> None:
+    repetition_penalties = repetition_penalties.unsqueeze(dim=1).repeat(
+        1, logits.size(1)
+    )
+    # If token appears in prompt or output, apply, otherwise use 1.0 for no-op.
+    penalties = torch.where(prompt_mask | output_mask, repetition_penalties, 1.0)
+    # If logits are positive, divide by penalty, otherwise multiply by penalty.
+    scaling = torch.where(logits > 0, 1.0 / penalties, penalties)
+    logits *= scaling
+
+
+##################################################
+# --------------- I8_mqa_logits -----------------
+##################################################
+@custom_op("_C::I8_mqa_logits", mutates_args=())
+def I8_mqa_logits(
+    q: torch.Tensor,
+    fused_kv_cache: List[torch.Tensor],
+    weights: torch.Tensor,
+    context_q_lens: List[torch.Tensor],
+    context_k_lens: List[torch.Tensor],
+    logits: torch.Tensor,
+    clean_logits: bool,
+    max_seq_q: Optional[int] = 0,
+    max_seq_k: Optional[int] = 0,
+    is_causal: Optional[bool] = False,
+    use_xfa_boost: Optional[bool] = False,
+) -> None:
+    kunlun_ops.I8_mqa_logits(
+        q=q,
+        fused_kv_cache=fused_kv_cache,
+        weights=weights,
+        context_q_lens=context_q_lens,
+        context_k_lens=context_k_lens,
+        logits=logits,
+        clean_logits=clean_logits,
+        max_seq_q=max_seq_q,
+        max_seq_k=max_seq_k,
+        is_causal=is_causal,
+        use_xfa_boost=use_xfa_boost,
+    )
+    return None
+
+
+@impl("_C::I8_mqa_logits", "CUDA")
+def I8_mqa_logits_cuda(
+    q: torch.Tensor,
+    fused_kv_cache: List[torch.Tensor],
+    weights: torch.Tensor,
+    context_q_lens: List[torch.Tensor],
+    context_k_lens: List[torch.Tensor],
+    logits: torch.Tensor,
+    clean_logits: bool,
+    max_seq_q: Optional[int] = 0,
+    max_seq_k: Optional[int] = 0,
+    is_causal: Optional[bool] = False,
+    use_xfa_boost: Optional[bool] = False,
+) -> None:
+    kunlun_ops.I8_mqa_logits(
+        q=q,
+        fused_kv_cache=fused_kv_cache,
+        weights=weights,
+        context_q_lens=context_q_lens,
+        context_k_lens=context_k_lens,
+        logits=logits,
+        clean_logits=clean_logits,
+        max_seq_q=max_seq_q,
+        max_seq_k=max_seq_k,
+        is_causal=is_causal,
+        use_xfa_boost=use_xfa_boost,
+    )
+    return None
+
+
+def _fake_I8_mqa_logits(
+    q: torch.Tensor,
+    fused_kv_cache: List[torch.Tensor],
+    weights: torch.Tensor,
+    context_q_lens: List[torch.Tensor],
+    context_k_lens: List[torch.Tensor],
+    logits: torch.Tensor,
+    clean_logits: bool,
+    max_seq_q: Optional[int] = 0,
+    max_seq_k: Optional[int] = 0,
+    is_causal: Optional[bool] = False,
+    use_xfa_boost: Optional[bool] = False,
+) -> None:
+    return None
+
+
+I8_mqa_logits.register_fake(_fake_I8_mqa_logits)
+
+
+##################################################
+# ------------- I8_paged_mqa_logits --------------
+##################################################
+@custom_op("_C::I8_paged_mqa_logits", mutates_args=())
+def I8_paged_mqa_logits(
+    q: torch.Tensor,
+    fused_kv_cache: List[torch.Tensor],
+    weights: torch.Tensor,
+    context_lens: List[torch.Tensor],
+    block_table: torch.Tensor,
+    max_context_len: int,
+    clean_logits: bool,
+    out: torch.Tensor,
+    use_xfa_boost: Optional[bool] = False,
+) -> None:
+    kunlun_ops.I8_paged_mqa_logits(
+        q=q,
+        fused_kv_cache=fused_kv_cache,
+        weights=weights,
+        context_lens=context_lens,
+        block_table=block_table,
+        max_context_len=max_context_len,
+        clean_logits=clean_logits,
+        out=out,
+        use_xfa_boost=use_xfa_boost,
+    )
+    return None
+
+
+@impl("_C::I8_paged_mqa_logits", "CUDA")
+def I8_paged_mqa_logits_cuda(
+    q: torch.Tensor,
+    fused_kv_cache: List[torch.Tensor],
+    weights: torch.Tensor,
+    context_lens: List[torch.Tensor],
+    block_table: torch.Tensor,
+    max_context_len: int,
+    clean_logits: bool,
+    out: torch.Tensor,
+    use_xfa_boost: Optional[bool] = False,
+) -> None:
+    kunlun_ops.I8_paged_mqa_logits(
+        q=q,
+        fused_kv_cache=fused_kv_cache,
+        weights=weights,
+        context_lens=context_lens,
+        block_table=block_table,
+        max_context_len=max_context_len,
+        clean_logits=clean_logits,
+        out=out,
+        use_xfa_boost=use_xfa_boost,
+    )
+    return None
+
+
+def _fake_I8_paged_mqa_logits(
+    q: torch.Tensor,
+    fused_kv_cache: List[torch.Tensor],
+    weights: torch.Tensor,
+    context_lens: List[torch.Tensor],
+    block_table: torch.Tensor,
+    max_context_len: int,
+    clean_logits: bool,
+    out: torch.Tensor,
+    use_xfa_boost: Optional[bool] = False,
+) -> None:
+    return None
+
+
+I8_paged_mqa_logits.register_fake(_fake_I8_paged_mqa_logits)
+
+
+##################################################
+# ----------- sparse_prefill_fwd_opt -------------
+##################################################
+@custom_op("_C::sparse_prefill_fwd_opt", mutates_args=())
+def sparse_prefill_fwd_opt(
+    q: torch.Tensor,
+    kv: torch.Tensor,
+    indices: torch.Tensor,
+    out: torch.Tensor,
+    max_logits: torch.Tensor,
+    lse: torch.Tensor,
+    sm_scale: float,
+    qlod_cpu: Optional[torch.Tensor] = None,
+    qlod_xpu: Optional[torch.Tensor] = None,
+    kvlod_cpu: Optional[torch.Tensor] = None,
+    kvlod_xpu: Optional[torch.Tensor] = None,
+    d_v: Optional[int] = -1,
+    is_causal: Optional[bool] = True,
+    use_xfa_boost: Optional[bool] = False,
+) -> None:
+    kunlun_ops.sparse_prefill_fwd_opt(
+        q=q,
+        kv=kv,
+        indices=indices,
+        out=out,
+        max_logits=max_logits,
+        lse=lse,
+        sm_scale=sm_scale,
+        qlod_cpu=qlod_cpu,
+        qlod_xpu=qlod_xpu,
+        kvlod_cpu=kvlod_cpu,
+        kvlod_xpu=kvlod_xpu,
+        d_v=d_v,
+        is_causal=is_causal,
+        use_xfa_boost=use_xfa_boost,
+    )
+    return None
+
+
+@impl("_C::sparse_prefill_fwd_opt", "CUDA")
+def sparse_prefill_fwd_opt_cuda(
+    q: torch.Tensor,
+    kv: torch.Tensor,
+    indices: torch.Tensor,
+    out: torch.Tensor,
+    max_logits: torch.Tensor,
+    lse: torch.Tensor,
+    sm_scale: float,
+    qlod_cpu: Optional[torch.Tensor] = None,
+    qlod_xpu: Optional[torch.Tensor] = None,
+    kvlod_cpu: Optional[torch.Tensor] = None,
+    kvlod_xpu: Optional[torch.Tensor] = None,
+    d_v: Optional[int] = -1,
+    is_causal: Optional[bool] = True,
+    use_xfa_boost: Optional[bool] = False,
+) -> None:
+    kunlun_ops.sparse_prefill_fwd_opt(
+        q=q,
+        kv=kv,
+        indices=indices,
+        out=out,
+        max_logits=max_logits,
+        lse=lse,
+        sm_scale=sm_scale,
+        qlod_cpu=qlod_cpu,
+        qlod_xpu=qlod_xpu,
+        kvlod_cpu=kvlod_cpu,
+        kvlod_xpu=kvlod_xpu,
+        d_v=d_v,
+        is_causal=is_causal,
+        use_xfa_boost=use_xfa_boost,
+    )
+    return None
+
+
+def _fake_sparse_prefill_fwd_opt(
+    q: torch.Tensor,
+    kv: torch.Tensor,
+    indices: torch.Tensor,
+    out: torch.Tensor,
+    max_logits: torch.Tensor,
+    lse: torch.Tensor,
+    sm_scale: float,
+    qlod_cpu: Optional[torch.Tensor] = None,
+    qlod_xpu: Optional[torch.Tensor] = None,
+    kvlod_cpu: Optional[torch.Tensor] = None,
+    kvlod_xpu: Optional[torch.Tensor] = None,
+    d_v: Optional[int] = -1,
+    is_causal: Optional[bool] = True,
+    use_xfa_boost: Optional[bool] = False,
+) -> None:
+    return None
+
+
+sparse_prefill_fwd_opt.register_fake(_fake_sparse_prefill_fwd_opt)
+
+
+##################################################
+# ------------------ fwd_kvcache_mla -------------
+##################################################
+@custom_op("_C::fwd_kvcache_mla", mutates_args=())
+def fwd_kvcache_mla(
+    q_c: torch.Tensor,
+    kv_cache: torch.Tensor,
+    indices: torch.Tensor,
+    kv_lod_cpu: torch.Tensor,
+    out: torch.Tensor,
+    max_logits: torch.Tensor,
+    p_sums: torch.Tensor,
+    softmax_scale: float,
+    max_seq_kv: int,
+    q_r: Optional[torch.Tensor] = None,
+    pe_cache: Optional[torch.Tensor] = None,
+    use_xfa_boost: Optional[bool] = False,
+    kv_lod_xpu: Optional[torch.Tensor] = None,
+) -> None:
+    kunlun_ops.fwd_kvcache_mla(
+        q_c=q_c,
+        kv_cache=kv_cache,
+        indices=indices,
+        kv_lod_cpu=kv_lod_cpu,
+        out=out,
+        max_logits=max_logits,
+        p_sums=p_sums,
+        softmax_scale=softmax_scale,
+        max_seq_kv=max_seq_kv,
+        q_r=q_r,
+        pe_cache=pe_cache,
+        use_xfa_boost=use_xfa_boost,
+        kv_lod_xpu=kv_lod_xpu,
+    )
+    return None
+
+
+@impl("_C::fwd_kvcache_mla", "CUDA")
+def fwd_kvcache_mla_cuda(
+    q_c: torch.Tensor,
+    kv_cache: torch.Tensor,
+    indices: torch.Tensor,
+    kv_lod_cpu: torch.Tensor,
+    out: torch.Tensor,
+    max_logits: torch.Tensor,
+    p_sums: torch.Tensor,
+    softmax_scale: float,
+    max_seq_kv: int,
+    q_r: Optional[torch.Tensor] = None,
+    pe_cache: Optional[torch.Tensor] = None,
+    use_xfa_boost: Optional[bool] = False,
+    kv_lod_xpu: Optional[torch.Tensor] = None,
+) -> None:
+    kunlun_ops.fwd_kvcache_mla(
+        q_c=q_c,
+        kv_cache=kv_cache,
+        indices=indices,
+        kv_lod_cpu=kv_lod_cpu,
+        out=out,
+        max_logits=max_logits,
+        p_sums=p_sums,
+        softmax_scale=softmax_scale,
+        max_seq_kv=max_seq_kv,
+        q_r=q_r,
+        pe_cache=pe_cache,
+        use_xfa_boost=use_xfa_boost,
+        kv_lod_xpu=kv_lod_xpu,
+    )
+    return None
+
+
+def _fake_fwd_kvcache_mla(
+    q_c: torch.Tensor,
+    kv_cache: torch.Tensor,
+    indices: torch.Tensor,
+    kv_lod_cpu: torch.Tensor,
+    out: torch.Tensor,
+    max_logits: torch.Tensor,
+    p_sums: torch.Tensor,
+    softmax_scale: float,
+    max_seq_kv: int,
+    q_r: Optional[torch.Tensor] = None,
+    pe_cache: Optional[torch.Tensor] = None,
+    use_xfa_boost: Optional[bool] = False,
+    kv_lod_xpu: Optional[torch.Tensor] = None,
+) -> None:
+    return None
+
+
+fwd_kvcache_mla.register_fake(_fake_fwd_kvcache_mla)
+
+
+##################################################
+# --------------- dequant_int4 -------------------
+##################################################
+@custom_op("_C::dequant_int4", mutates_args=())
+def dequant_int4(
+    x: torch.Tensor,
+    scale: torch.Tensor,
+    zero: torch.Tensor,
+    y: torch.Tensor,
+    group_m: int,
+    int4_signed: bool = True,
+    use_mode_fast: bool = False,
+) -> None:
+    kunlun_ops.dequant_int4(
+        x=x,
+        scale=scale,
+        zero=zero,
+        y=y,
+        group_m=group_m,
+        int4_signed=int4_signed,
+        use_mode_fast=use_mode_fast,
+    )
+    return None
+
+
+@impl("_C::dequant_int4", "CUDA")
+def dequant_int4_cuda(
+    x: torch.Tensor,
+    scale: torch.Tensor,
+    zero: torch.Tensor,
+    y: torch.Tensor,
+    group_m: int,
+    int4_signed: bool = True,
+    use_mode_fast: bool = False,
+) -> None:
+    kunlun_ops.dequant_int4(
+        x=x,
+        scale=scale,
+        zero=zero,
+        y=y,
+        group_m=group_m,
+        int4_signed=int4_signed,
+        use_mode_fast=use_mode_fast,
+    )
+    return None
+
+
+def _fake_dequant_int4(
+    x: torch.Tensor,
+    scale: torch.Tensor,
+    zero: torch.Tensor,
+    y: torch.Tensor,
+    group_m: int,
+    int4_signed: bool = True,
+    use_mode_fast: bool = False,
+) -> None:
+    return None
+
+
+dequant_int4.register_fake(_fake_dequant_int4)
+
+
+##################################################
+# ------------------ fast_topkv2 -------------
+##################################################
+@custom_op("_C::fast_topkv2", mutates_args=())
+def fast_topkv2(
+    score: torch.Tensor, lengths: torch.Tensor, topk: Optional[int] = 2048
+) -> torch.Tensor:
+    assert topk == 2048, "fast_topkv2 only supports topk = 2048 by now"
+    topk_indices = kunlun_ops.fast_topkv2(score=score, lengths=lengths, topk=topk)
+    return topk_indices
+
+
+@impl("_C::fast_topkv2", "CUDA")
+def fast_topkv2_cuda(
+    score: torch.Tensor, lengths: torch.Tensor, topk: Optional[int] = 2048
+) -> torch.Tensor:
+    assert topk == 2048, "fast_topkv2 only supports topk = 2048 by now"
+    topk_indices = kunlun_ops.fast_topkv2(score=score, lengths=lengths, topk=topk)
+    return topk_indices
+
+
+def _fake_fast_topkv2(
+    score: torch.Tensor, lengths: torch.Tensor, topk: Optional[int] = 2048
+) -> torch.Tensor:
+    assert topk == 2048, "fast_topkv2 only supports topk = 2048 by now"
+    topk_indices = score.new_empty((score.size(0), topk), dtype=torch.int32)
+    return topk_indices
+
+
+fast_topkv2.register_fake(_fake_fast_topkv2)
+
+##################################################
+# ----------------- LoRA ops --------------------
+##################################################
+
+
+##################################################
+# -------------- sgmv_shrink_lora ----------------
+##################################################
+@custom_op("_C::sgmv_shrink_lora", mutates_args=())
+def sgmv_shrink_lora(
+    inputs: torch.Tensor,
+    lora_a_weights: torch.Tensor,
+    output_tensor: torch.Tensor,
+    block_statistic: torch.Tensor,
+    sorted_tokens_num_lod: torch.Tensor,
+    moe_index: torch.Tensor,
+    expert_m: torch.Tensor,
+    b_seq_start_loc: torch.Tensor,
+    seq_len_tensor: torch.Tensor,
+    lora_indices_tensor: torch.Tensor,
+    batches: int,
+    max_seq_length: int,
+    token_nums: int,
+    scaling: float,
+) -> torch.Tensor:
+    # return torch.ops.xspeedgate_ops.sgmv_shrink_cluster(
+    #     inputs, lora_a_weights, seq_len_tensor, lora_indices_tensor, output_tensor, scaling
+    # )
+    return torch.ops.xspeedgate_ops.sgmv_shrink_sdnn(
+        inputs,
+        lora_a_weights,
+        seq_len_tensor,
+        lora_indices_tensor,
+        output_tensor,
+        scaling,
+    )
+
+
+@impl("_C::sgmv_shrink_lora", "CUDA")
+def sgmv_shrink_lora_cuda(
+    inputs: torch.Tensor,
+    lora_a_weights: torch.Tensor,
+    output_tensor: torch.Tensor,
+    block_statistic: torch.Tensor,
+    sorted_tokens_num_lod: torch.Tensor,
+    moe_index: torch.Tensor,
+    expert_m: torch.Tensor,
+    b_seq_start_loc: torch.Tensor,
+    seq_len_tensor: torch.Tensor,
+    lora_indices_tensor: torch.Tensor,
+    batches: int,
+    max_seq_length: int,
+    token_nums: int,
+    scaling: float,
+) -> torch.Tensor:
+    # return torch.ops.xspeedgate_ops.sgmv_shrink_cluster(
+    #     inputs, lora_a_weights, seq_len_tensor, lora_indices_tensor, output_tensor, scaling
+    # )
+    return torch.ops.xspeedgate_ops.sgmv_shrink_sdnn(
+        inputs,
+        lora_a_weights,
+        seq_len_tensor,
+        lora_indices_tensor,
+        output_tensor,
+        scaling,
+    )
+
+
+def _fake_sgmv_shrink_lora(
+    inputs: torch.Tensor,
+    lora_a_weights: torch.Tensor,
+    output_tensor: torch.Tensor,
+    block_statistic: torch.Tensor,
+    sorted_tokens_num_lod: torch.Tensor,
+    moe_index: torch.Tensor,
+    expert_m: torch.Tensor,
+    b_seq_start_loc: torch.Tensor,
+    seq_len_tensor: torch.Tensor,
+    lora_indices_tensor: torch.Tensor,
+    batches: int,
+    max_seq_length: int,
+    token_nums: int,
+    scaling: float,
+) -> torch.Tensor:
+    return output_tensor
+
+
+sgmv_shrink_lora.register_fake(_fake_sgmv_shrink_lora)
+
+
+##################################################
+# -------------- sgmv_expand_lora ----------------
+##################################################
+@custom_op("_C::sgmv_expand_lora", mutates_args=())
+def sgmv_expand_lora(
+    inputs: torch.Tensor,
+    lora_b_weights: torch.Tensor,
+    output_tensor: torch.Tensor,
+    block_statistic: torch.Tensor,
+    sorted_tokens_num_lod: torch.Tensor,
+    moe_index: torch.Tensor,
+    b_seq_start_loc: torch.Tensor,
+    seq_len_tensor: torch.Tensor,
+    lora_indices_tensor: torch.Tensor,
+    batches: int,
+    max_seq_length: int,
+    token_nums: int,
+    add_inputs: bool = False,
+) -> torch.Tensor:
+    # return torch.ops.xspeedgate_ops.sgmv_expand_cluster(
+    #     inputs, lora_b_weights, seq_len_tensor, lora_indices_tensor, output_tensor, 0
+    # )
+    return torch.ops.xspeedgate_ops.sgmv_expand_sdnn(
+        inputs, lora_b_weights, seq_len_tensor, lora_indices_tensor, output_tensor, 0
+    )
+
+
+@impl("_C::sgmv_expand_lora", "CUDA")
+def sgmv_expand_lora_cuda(
+    inputs: torch.Tensor,
+    lora_b_weights: torch.Tensor,
+    output_tensor: torch.Tensor,
+    block_statistic: torch.Tensor,
+    sorted_tokens_num_lod: torch.Tensor,
+    moe_index: torch.Tensor,
+    b_seq_start_loc: torch.Tensor,
+    seq_len_tensor: torch.Tensor,
+    lora_indices_tensor: torch.Tensor,
+    batches: int,
+    max_seq_length: int,
+    token_nums: int,
+    add_inputs: bool = False,
+) -> torch.Tensor:
+    # return torch.ops.xspeedgate_ops.sgmv_expand_cluster(
+    #     inputs, lora_b_weights, seq_len_tensor, lora_indices_tensor, output_tensor, 0
+    # )
+    return torch.ops.xspeedgate_ops.sgmv_expand_sdnn(
+        inputs, lora_b_weights, seq_len_tensor, lora_indices_tensor, output_tensor, 0
+    )
+
+
+def _fake_sgmv_expand_lora(
+    inputs: torch.Tensor,
+    lora_b_weights: torch.Tensor,
+    output_tensor: torch.Tensor,
+    block_statistic: torch.Tensor,
+    sorted_tokens_num_lod: torch.Tensor,
+    moe_index: torch.Tensor,
+    b_seq_start_loc: torch.Tensor,
+    seq_len_tensor: torch.Tensor,
+    lora_indices_tensor: torch.Tensor,
+    batches: int,
+    max_seq_length: int,
+    token_nums: int,
+    add_inputs: bool = False,
+) -> torch.Tensor:
+    return output_tensor
+
+
+sgmv_expand_lora.register_fake(_fake_sgmv_expand_lora)
+
+
+##################################################
+# ----------- sgmv_expand_slice_lora -------------
+##################################################
+@custom_op("_C::sgmv_expand_slice_lora", mutates_args=())
+def sgmv_expand_slice_lora(
+    inputs: torch.Tensor,
+    lora_b_weights: torch.Tensor,
+    output_tensor: torch.Tensor,
+    block_statistic: torch.Tensor,
+    sorted_tokens_num_lod: torch.Tensor,
+    moe_index: torch.Tensor,
+    normed_scale: torch.Tensor,
+    b_seq_start_loc: torch.Tensor,
+    seq_len_tensor: torch.Tensor,
+    lora_indices_tensor: torch.Tensor,
+    batches: int,
+    max_seq_length: int,
+    token_nums: int,
+    slice_offset: int,
+    slice_size: int,
+    add_inputs: bool = False,
+) -> torch.Tensor:
+    return torch.ops.xspeedgate_ops.sgmv_expand_cluster(
+        inputs,
+        lora_b_weights,
+        seq_len_tensor,
+        lora_indices_tensor,
+        output_tensor,
+        slice_offset,
+    )
+
+
+@impl("_C::sgmv_expand_slice_lora", "CUDA")
+def sgmv_expand_slice_lora_cuda(
+    inputs: torch.Tensor,
+    lora_b_weights: torch.Tensor,
+    output_tensor: torch.Tensor,
+    block_statistic: torch.Tensor,
+    sorted_tokens_num_lod: torch.Tensor,
+    moe_index: torch.Tensor,
+    normed_scale: torch.Tensor,
+    b_seq_start_loc: torch.Tensor,
+    seq_len_tensor: torch.Tensor,
+    lora_indices_tensor: torch.Tensor,
+    batches: int,
+    max_seq_length: int,
+    token_nums: int,
+    slice_offset: int,
+    slice_size: int,
+    add_inputs: bool = False,
+) -> torch.Tensor:
+    return torch.ops.xspeedgate_ops.sgmv_expand_cluster(
+        inputs,
+        lora_b_weights,
+        seq_len_tensor,
+        lora_indices_tensor,
+        output_tensor,
+        slice_offset,
+    )
+
+
+def _fake_sgmv_expand_slice_lora(
+    inputs: torch.Tensor,
+    lora_b_weights: torch.Tensor,
+    output_tensor: torch.Tensor,
+    block_statistic: torch.Tensor,
+    sorted_tokens_num_lod: torch.Tensor,
+    moe_index: torch.Tensor,
+    normed_scale: torch.Tensor,
+    b_seq_start_loc: torch.Tensor,
+    seq_len_tensor: torch.Tensor,
+    lora_indices_tensor: torch.Tensor,
+    batches: int,
+    max_seq_length: int,
+    token_nums: int,
+    slice_offset: int,
+    slice_size: int,
+    add_inputs: bool = False,
+) -> torch.Tensor:
+    return output_tensor
+
+
+sgmv_expand_slice_lora.register_fake(_fake_sgmv_expand_slice_lora)
+
+
+##################################################
+# -------------- bgmv_shrink_lora ----------------
+##################################################
+@custom_op("_C::bgmv_shrink_lora", mutates_args=())
+def bgmv_shrink_lora(
+    inputs: torch.Tensor,
+    lora_a_weights: torch.Tensor,
+    output_tensor: torch.Tensor,
+    block_statistic: torch.Tensor,
+    sorted_tokens_num_lod: torch.Tensor,
+    moe_index: torch.Tensor,
+    expert_m: torch.Tensor,
+    lora_indices_tensor: torch.Tensor,
+    scaling: float = 1.0,
+) -> torch.Tensor:
+    return torch.ops.xspeedgate_ops.bgmv_shrink_cluster(
+        inputs, lora_a_weights, lora_indices_tensor, output_tensor, scaling
+    )
+
+
+@impl("_C::bgmv_shrink_lora", "CUDA")
+def bgmv_shrink_lora_cuda(
+    inputs: torch.Tensor,
+    lora_a_weights: torch.Tensor,
+    output_tensor: torch.Tensor,
+    block_statistic: torch.Tensor,
+    sorted_tokens_num_lod: torch.Tensor,
+    moe_index: torch.Tensor,
+    expert_m: torch.Tensor,
+    lora_indices_tensor: torch.Tensor,
+    scaling: float = 1.0,
+) -> torch.Tensor:
+    return torch.ops.xspeedgate_ops.bgmv_shrink_cluster(
+        inputs, lora_a_weights, lora_indices_tensor, output_tensor, scaling
+    )
+
+
+def _fake_bgmv_shrink_lora(
+    inputs: torch.Tensor,
+    lora_a_weights: torch.Tensor,
+    output_tensor: torch.Tensor,
+    block_statistic: torch.Tensor,
+    sorted_tokens_num_lod: torch.Tensor,
+    moe_index: torch.Tensor,
+    expert_m: torch.Tensor,
+    lora_indices_tensor: torch.Tensor,
+    scaling: float = 1.0,
+) -> torch.Tensor:
+    return output_tensor
+
+
+bgmv_shrink_lora.register_fake(_fake_bgmv_shrink_lora)
+
+
+##################################################
+# -------------- bgmv_expand_lora ----------------
+##################################################
+@custom_op("_C::bgmv_expand_lora", mutates_args=())
+def bgmv_expand_lora(
+    inputs: torch.Tensor,
+    lora_b_weights: torch.Tensor,
+    output_tensor: torch.Tensor,
+    block_statistic: torch.Tensor,
+    sorted_tokens_num_lod: torch.Tensor,
+    moe_index: torch.Tensor,
+    lora_indices_tensor: torch.Tensor,
+    add_inputs: bool = True,
+) -> torch.Tensor:
+    return torch.ops.xspeedgate_ops.bgmv_expand_cluster(
+        inputs, lora_b_weights, lora_indices_tensor, output_tensor, 0
+    )
+
+
+@impl("_C::bgmv_expand_lora", "CUDA")
+def bgmv_expand_lora_cuda(
+    inputs: torch.Tensor,
+    lora_b_weights: torch.Tensor,
+    output_tensor: torch.Tensor,
+    block_statistic: torch.Tensor,
+    sorted_tokens_num_lod: torch.Tensor,
+    moe_index: torch.Tensor,
+    lora_indices_tensor: torch.Tensor,
+    add_inputs: bool = True,
+) -> torch.Tensor:
+    return torch.ops.xspeedgate_ops.bgmv_expand_cluster(
+        inputs, lora_b_weights, lora_indices_tensor, output_tensor, 0
+    )
+
+
+def _fake_bgmv_expand_lora(
+    inputs: torch.Tensor,
+    lora_b_weights: torch.Tensor,
+    output_tensor: torch.Tensor,
+    block_statistic: torch.Tensor,
+    sorted_tokens_num_lod: torch.Tensor,
+    moe_index: torch.Tensor,
+    lora_indices_tensor: torch.Tensor,
+    add_inputs: bool = True,
+) -> torch.Tensor:
+    return output_tensor
+
+
+bgmv_expand_lora.register_fake(_fake_bgmv_expand_lora)
+
+
+##################################################
+# ----------- bgmv_expand_slice_lora -------------
+##################################################
+@custom_op("_C::bgmv_expand_slice_lora", mutates_args=())
+def bgmv_expand_slice_lora(
+    inputs: torch.Tensor,
+    lora_b_weights: torch.Tensor,
+    output_tensor: torch.Tensor,
+    block_statistic: torch.Tensor,
+    sorted_tokens_num_lod: torch.Tensor,
+    moe_index: torch.Tensor,
+    normed_scale: torch.Tensor,
+    lora_indices_tensor: torch.Tensor,
+    slice_offset: int,
+    slice_size: int,
+    add_inputs: bool = True,
+) -> torch.Tensor:
+    return torch.ops.xspeedgate_ops.bgmv_expand_cluster(
+        inputs, lora_b_weights, lora_indices_tensor, output_tensor, slice_offset
+    )
+
+
+@impl("_C::bgmv_expand_slice_lora", "CUDA")
+def bgmv_expand_slice_lora_cuda(
+    inputs: torch.Tensor,
+    lora_b_weights: torch.Tensor,
+    output_tensor: torch.Tensor,
+    block_statistic: torch.Tensor,
+    sorted_tokens_num_lod: torch.Tensor,
+    moe_index: torch.Tensor,
+    normed_scale: torch.Tensor,
+    lora_indices_tensor: torch.Tensor,
+    slice_offset: int,
+    slice_size: int,
+    add_inputs: bool = True,
+) -> torch.Tensor:
+    return torch.ops.xspeedgate_ops.bgmv_expand_cluster(
+        inputs, lora_b_weights, lora_indices_tensor, output_tensor, slice_offset
+    )
+
+
+def _fake_bgmv_expand_slice_lora(
+    inputs: torch.Tensor,
+    lora_b_weights: torch.Tensor,
+    output_tensor: torch.Tensor,
+    block_statistic: torch.Tensor,
+    sorted_tokens_num_lod: torch.Tensor,
+    moe_index: torch.Tensor,
+    normed_scale: torch.Tensor,
+    lora_indices_tensor: torch.Tensor,
+    slice_offset: int,
+    slice_size: int,
+    add_inputs: bool = True,
+) -> torch.Tensor:
+    return output_tensor
+
+
+bgmv_expand_slice_lora.register_fake(_fake_bgmv_expand_slice_lora)
+
+
+##################################################
+# ----------- lora_matmul_inplace ----------------
+##################################################
+@custom_op("_C::lora_matmul_inplace", mutates_args=())
+def lora_matmul_inplace(
+    x: torch.Tensor,
+    w: torch.Tensor,
+    output_tensor: torch.Tensor,
+    x_trans: bool = False,
+    w_trans: bool = True,
+    alpha: float = 1.0,
+    beta: float = 1.0,
+) -> None:
+    kunlun_ops.matmul(
+        x=x.contiguous(),
+        w=w.contiguous(),
+        out=output_tensor,
+        x_trans=x_trans,
+        w_trans=w_trans,
+        alpha=alpha,
+        beta=beta,
+    )
+
+
+@impl("_C::lora_matmul_inplace", "CUDA")
+def lora_matmul_inplace_cuda(
+    x: torch.Tensor,
+    w: torch.Tensor,
+    output_tensor: torch.Tensor,
+    x_trans: bool = False,
+    w_trans: bool = True,
+    alpha: float = 1.0,
+    beta: float = 1.0,
+) -> None:
+    kunlun_ops.matmul(
+        x=x.contiguous(),
+        w=w.contiguous(),
+        out=output_tensor,
+        x_trans=x_trans,
+        w_trans=w_trans,
+        alpha=alpha,
+        beta=beta,
+    )
+
+
+def _fake_lora_matmul_inplace(
+    x: torch.Tensor,
+    w: torch.Tensor,
+    output_tensor: torch.Tensor,
+    x_trans: bool = False,
+    w_trans: bool = True,
+    alpha: float = 1.0,
+    beta: float = 1.0,
+) -> None:
+    return None
+
+
+lora_matmul_inplace.register_fake(_fake_lora_matmul_inplace)

--- a/vllm_kunlun/ops/_kunlun_ops.py
+++ b/vllm_kunlun/ops/_kunlun_ops.py
@@ -416,7 +416,7 @@ class KunlunOps:
                 normed_score=normed_score,
                 topk_index=topk_ids,
                 block_statistic=None,
-                stable=False,
+                stable=True,
             )
         elif scoring_func == "sigmoid":
             torch.ops._C.moe_sigmoid_group_topk_norm(
@@ -578,6 +578,8 @@ class KunlunOps:
                 sorted_tokens_idx=sorted_tokens_idx,
                 moe_topk=moe_top_k,
                 y=y,
+                topk_ids=topk_ids,
+                act=None,
             )
             # Reuse `workspace_a` for `out1` after `moe_expand` is no longer
             # needed.
@@ -599,6 +601,8 @@ class KunlunOps:
                 sorted_tokens_idx=sorted_tokens_idx,
                 moe_topk=moe_top_k,
                 y=out,
+                topk_ids=topk_ids,
+                act=None,
             )
 
             output = torch.empty(

--- a/vllm_kunlun/ops/native_ops.py
+++ b/vllm_kunlun/ops/native_ops.py
@@ -1,0 +1,277 @@
+"""
+Pure PyTorch native implementations for:
+  1. causal_conv1d_update (decode)
+  2. causal_conv1d_fn (prefill)
+  3. chunk_gated_delta_rule (prefill SSM)
+  4. fused_recurrent_gated_delta_rule (decode SSM)
+
+Purpose: bypass ALL XPU kernels to isolate state corruption bug.
+"""
+
+import torch
+import torch.nn.functional as F
+
+
+def _l2norm(x: torch.Tensor, eps: float = 1e-6) -> torch.Tensor:
+    """Match XPU l2norm_fwd: normalize along last dim with eps=1e-6."""
+    # XPU l2norm uses eps=1e-6, F.normalize default is 1e-12
+    return F.normalize(x.float(), p=2, dim=-1, eps=eps).to(x.dtype)
+
+
+# ============================================================
+# 1. causal_conv1d_update — decode 路径 conv1d
+# ============================================================
+def native_causal_conv1d_update(
+    x: torch.Tensor,  # [N, D] (after unsqueeze→[N,1,D])
+    conv_state: torch.Tensor,  # [num_slots, W-1, D]
+    weight: torch.Tensor,  # [D, W]
+    bias: torch.Tensor,  # [D]
+    activation: str = "silu",
+    conv_state_indices: torch.Tensor = None,  # [N]
+    **kwargs,  # absorb extra params
+):
+    """Single-token conv1d update per sequence."""
+    if x.dim() == 3:
+        x_2d = x.squeeze(1)  # [N, D]
+    else:
+        x_2d = x  # [N, D]
+
+    N, D = x_2d.shape
+    out = torch.empty_like(x_2d)
+
+    for i in range(N):
+        if conv_state_indices is not None:
+            si = conv_state_indices[i].item()
+        else:
+            si = i
+
+        # state: [W-1, D], new token: [D]
+        state = conv_state[si]  # [W-1, D]
+        token = x_2d[i]  # [D]
+
+        # full window: [W, D]
+        full = torch.cat([state, token.unsqueeze(0)], dim=0)  # [W, D]
+
+        # depthwise conv: output[d] = sum_w(full[w,d] * weight[d,w]) + bias[d]
+        o = (full.float().T * weight.float()).sum(dim=1)  # [D]
+        if bias is not None:
+            o = o + bias.float()
+
+        if activation in ("silu", "swish"):
+            o = o * torch.sigmoid(o)
+
+        out[i] = o.to(x_2d.dtype)
+
+        # update state: shift left, append new token
+        conv_state[si] = torch.cat([state[1:], token.unsqueeze(0)], dim=0)
+
+    return out
+
+
+# ============================================================
+# 2. causal_conv1d_fn — prefill 路径 conv1d
+# ============================================================
+def native_causal_conv1d_fn(
+    x: torch.Tensor,  # [total_tokens, D]
+    weight: torch.Tensor,  # [D, W]
+    bias: torch.Tensor,  # [D]
+    activation: str = "silu",
+    conv_states: torch.Tensor = None,  # [num_slots, W-1, D]
+    has_initial_state: torch.Tensor = None,  # [N]
+    cache_indices: torch.Tensor = None,  # [N]
+    query_start_loc: torch.Tensor = None,  # [N+1]
+    **kwargs,  # absorb _cpu, metadata, etc.
+):
+    """Multi-token causal conv1d for prefill."""
+    D = x.shape[-1]
+    W = weight.shape[1]
+    N = len(query_start_loc) - 1
+    out = torch.empty_like(x)
+
+    for seq_idx in range(N):
+        si = cache_indices[seq_idx].item() if cache_indices is not None else seq_idx
+        t_start = query_start_loc[seq_idx].item()
+        t_end = query_start_loc[seq_idx + 1].item()
+
+        # initial conv state
+        if has_initial_state is not None and has_initial_state[seq_idx]:
+            state = conv_states[si].clone()  # [W-1, D]
+        else:
+            state = torch.zeros(W - 1, D, dtype=x.dtype, device=x.device)
+
+        for t in range(t_start, t_end):
+            token = x[t]  # [D]
+            full = torch.cat([state, token.unsqueeze(0)], dim=0)  # [W, D]
+            o = (full.float().T * weight.float()).sum(dim=1)
+            if bias is not None:
+                o = o + bias.float()
+            if activation in ("silu", "swish"):
+                o = o * torch.sigmoid(o)
+            out[t] = o.to(x.dtype)
+            state = torch.cat([state[1:], token.unsqueeze(0)], dim=0)
+
+        # write back final conv state
+        if conv_states is not None:
+            conv_states[si] = state
+
+    return out
+
+
+# ============================================================
+# 3. chunk_gated_delta_rule — prefill SSM
+# ============================================================
+def native_chunk_gated_delta_rule(
+    q: torch.Tensor,  # [1, T, H, K]
+    k: torch.Tensor,  # [1, T, H, K]
+    v: torch.Tensor,  # [1, T, HV, V]
+    g: torch.Tensor,  # [1, T, HV]
+    beta: torch.Tensor,  # [1, T, HV]
+    scale: float = None,
+    initial_state: torch.Tensor = None,  # [N, HV, K, V] standard layout
+    output_final_state: bool = False,
+    cu_seqlens: torch.Tensor = None,  # [N+1]
+    use_qk_l2norm_in_kernel: bool = False,
+    **kwargs,
+):
+    """Pure torch gated delta rule recurrence for prefill (standard layout)."""
+    B, T, H, K = q.shape
+    _, _, HV, V = v.shape
+    GVA = HV // H
+
+    if scale is None:
+        scale = K**-0.5
+
+    if use_qk_l2norm_in_kernel:
+        q = _l2norm(q)
+        k = _l2norm(k)
+
+    if cu_seqlens is not None:
+        N = len(cu_seqlens) - 1
+    else:
+        N = B
+
+    output = torch.zeros(B, T, HV, V, dtype=v.dtype, device=v.device)
+    final_states = []
+
+    for seq_idx in range(N):
+        if cu_seqlens is not None:
+            t_start = cu_seqlens[seq_idx].item()
+            t_end = cu_seqlens[seq_idx + 1].item()
+        else:
+            t_start, t_end = 0, T
+
+        # initial_state: [N, HV, K, V] standard layout
+        state = (
+            initial_state[seq_idx].float()
+            if initial_state is not None
+            else torch.zeros(HV, K, V, dtype=torch.float32, device=v.device)
+        )
+
+        for t in range(t_start, t_end):
+            k_t = k[0, t].float()  # [H, K]
+            q_t = q[0, t].float()  # [H, K]
+            v_t = v[0, t].float()  # [HV, V]
+            g_t = g[0, t].float()  # [HV]
+            b_t = beta[0, t].float()  # [HV]
+
+            # expand key heads → value heads
+            k_exp = k_t.repeat_interleave(GVA, dim=0)  # [HV, K]
+            q_exp = q_t.repeat_interleave(GVA, dim=0)  # [HV, K]
+
+            decay = torch.exp(g_t).unsqueeze(-1).unsqueeze(-1)  # [HV, 1, 1]
+
+            # outer(k, v): [HV, K, 1] * [HV, 1, V] = [HV, K, V]
+            outer = k_exp.unsqueeze(-1) * v_t.unsqueeze(-2)
+
+            # S = decay * S + beta * outer(k, v)
+            state = decay * state + b_t.unsqueeze(-1).unsqueeze(-1) * outer
+
+            # o = scale * q^T @ S: [HV, 1, K] @ [HV, K, V] = [HV, 1, V] → [HV, V]
+            o_t = torch.bmm(q_exp.unsqueeze(1), state).squeeze(1)
+            output[0, t] = (scale * o_t).to(output.dtype)
+
+        if output_final_state:
+            final_states.append(state.to(initial_state.dtype))
+
+    final_state = (
+        torch.stack(final_states) if output_final_state and final_states else None
+    )
+    return output, final_state
+
+
+# ============================================================
+# 4. fused_recurrent_gated_delta_rule — decode SSM
+# ============================================================
+def native_fused_recurrent_gated_delta_rule(
+    q: torch.Tensor,  # [1, N, H, K]
+    k: torch.Tensor,  # [1, N, H, K]
+    v: torch.Tensor,  # [1, N, HV, V]
+    g: torch.Tensor,  # [1, N, HV]
+    beta: torch.Tensor,  # [1, N, HV]
+    scale: float = None,
+    initial_state: torch.Tensor = None,  # [num_slots, HV, V, K] TRANSPOSED layout
+    inplace_final_state: bool = True,
+    cu_seqlens: torch.Tensor = None,
+    ssm_state_indices: torch.Tensor = None,
+    use_qk_l2norm_in_kernel: bool = False,
+    **kwargs,
+):
+    """Pure torch gated delta rule for decode (transposed state layout [HV, V, K])."""
+    B, T, H, K = q.shape
+    _, _, HV, V = v.shape
+    GVA = HV // H
+
+    if scale is None:
+        scale = K**-0.5
+
+    if use_qk_l2norm_in_kernel:
+        q = _l2norm(q)
+        k = _l2norm(k)
+
+    if cu_seqlens is not None:
+        N = len(cu_seqlens) - 1
+    else:
+        N = T
+
+    output = torch.zeros(B, T, HV, V, dtype=v.dtype, device=v.device)
+
+    for seq_idx in range(N):
+        if ssm_state_indices is not None:
+            si = ssm_state_indices[seq_idx].item()
+        else:
+            si = seq_idx
+
+        if cu_seqlens is not None:
+            t_start = cu_seqlens[seq_idx].item()
+            t_end = cu_seqlens[seq_idx + 1].item()
+        else:
+            t_start, t_end = seq_idx, seq_idx + 1
+
+        # state: [HV, V, K] transposed layout
+        state = initial_state[si].float()
+
+        for t in range(t_start, t_end):
+            k_t = k[0, t].float()
+            q_t = q[0, t].float()
+            v_t = v[0, t].float()
+            g_t = g[0, t].float()
+            b_t = beta[0, t].float()
+
+            k_exp = k_t.repeat_interleave(GVA, dim=0)  # [HV, K]
+            q_exp = q_t.repeat_interleave(GVA, dim=0)  # [HV, K]
+
+            decay = torch.exp(g_t).unsqueeze(-1).unsqueeze(-1)  # [HV, 1, 1]
+
+            # transposed layout: outer(v, k) = [HV, V, 1] * [HV, 1, K] = [HV, V, K]
+            outer = v_t.unsqueeze(-1) * k_exp.unsqueeze(-2)
+
+            state = decay * state + b_t.unsqueeze(-1).unsqueeze(-1) * outer
+
+            # o = scale * S @ q: [HV, V, K] @ [HV, K, 1] = [HV, V]
+            o_t = torch.bmm(state, q_exp.unsqueeze(-1)).squeeze(-1)
+            output[0, t] = (scale * o_t).to(output.dtype)
+
+        if inplace_final_state:
+            initial_state[si] = state.to(initial_state.dtype)
+
+    return output, initial_state if inplace_final_state else None

--- a/vllm_kunlun/ops/rotary_embedding.py
+++ b/vllm_kunlun/ops/rotary_embedding.py
@@ -1,0 +1,256 @@
+#
+# Copyright (c) 2025 Baidu, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-kunlun project.
+#
+"""
+Kunlun-optimized Rotary Embedding implementations using vLLM's CustomOp.register_oot mechanism.
+
+Design:
+- Uses @CustomOp.register_oot to register Kunlun-optimized RotaryEmbedding classes
+- These classes automatically replace the default implementations when instantiated
+- Since KunlunPlatform uses _enum=PlatformEnum.OOT, dispatch_forward() selects
+  forward_oot, so we implement forward_oot
+
+OOT Mechanism:
+- When code calls RotaryEmbedding(...), vLLM's CustomOp.__new__ checks op_registry_oot
+- If "RotaryEmbedding" is found in OOT registry, it returns KunlunRotaryEmbedding instance instead
+- This is the official vLLM way to replace operators without modifying source code
+"""
+
+import logging
+from typing import Optional, Tuple
+
+import torch
+import xspeedgate_ops  # noqa
+from vllm.model_executor.custom_op import CustomOp
+from vllm.model_executor.layers.rotary_embedding import (
+    DeepseekScalingRotaryEmbedding,
+    MRotaryEmbedding,
+    RotaryEmbedding,
+)
+
+logger = logging.getLogger("vllm_kunlun.ops.rotary_embedding")
+
+# Track if OOT classes have logged (for logging once per type)
+_oot_rotary_init_logged = False
+_oot_mrotary_init_logged = False
+_oot_deepseek_rotary_init_logged = False
+
+
+# =============================================================================
+# OOT-registered Kunlun RotaryEmbedding classes
+# =============================================================================
+
+
+@CustomOp.register_oot(name="RotaryEmbedding")
+class KunlunRotaryEmbedding(RotaryEmbedding):
+    """
+    Kunlun-optimized RotaryEmbedding registered via OOT mechanism.
+
+    This class replaces the default RotaryEmbedding when instantiated through
+    vLLM's CustomOp registry. When code calls RotaryEmbedding(...), vLLM's
+    CustomOp.__new__ checks op_registry_oot and returns KunlunRotaryEmbedding instance.
+    """
+
+    def __init__(self, *args, **kwargs):
+        global _oot_rotary_init_logged
+        super().__init__(*args, **kwargs)
+        if not _oot_rotary_init_logged:
+            logger.info(
+                "[KunlunOOT] KunlunRotaryEmbedding.__init__ called (OOT instantiation)"
+            )
+            _oot_rotary_init_logged = True
+
+    def forward_oot(
+        self,
+        positions: torch.Tensor,
+        query: torch.Tensor,
+        key: Optional[torch.Tensor] = None,
+        offsets: Optional[torch.Tensor] = None,
+    ) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
+        """Kunlun-optimized forward_oot using Kunlun RoPE kernels."""
+        from vllm_kunlun.ops._kunlun_ops import KunlunOps as ops
+
+        if (
+            self.cos_sin_cache.device != query.device
+            or self.cos_sin_cache.dtype != query.dtype
+        ):
+            self.cos_sin_cache = self.cos_sin_cache.to(query.device, dtype=query.dtype)
+
+        # ops.rotary_embedding()/batched_rotary_embedding()
+        # are in-place operations that update the query and key tensors.
+        if offsets is not None:
+            batched_rotary = getattr(ops, "batched_rotary_embedding", None)
+            if batched_rotary is not None:
+                batched_rotary(
+                    positions,
+                    query,
+                    key,
+                    self.head_size,
+                    self.cos_sin_cache,
+                    self.is_neox_style,
+                    self.rotary_dim,
+                    offsets,
+                )
+            else:
+                # Fallback to the base implementation when Kunlun does not
+                # provide a batched_rotary_embedding kernel.
+                return super().forward_native(
+                    positions,
+                    query,
+                    key,
+                    offsets=offsets,
+                )
+        else:
+            query, key = ops.rotary_embedding(
+                positions,
+                query,
+                key,
+                self.head_size,
+                self.cos_sin_cache,
+                self.is_neox_style,
+            )
+        return query, key
+
+
+@CustomOp.register_oot(name="MRotaryEmbedding")
+class KunlunMRotaryEmbedding(MRotaryEmbedding):
+    """
+    Kunlun-optimized MRotaryEmbedding (Multi-modal RoPE) registered via OOT mechanism.
+    """
+
+    def __init__(self, *args, **kwargs):
+        global _oot_mrotary_init_logged
+        super().__init__(*args, **kwargs)
+        if not _oot_mrotary_init_logged:
+            logger.info(
+                "[KunlunOOT] KunlunMRotaryEmbedding.__init__ called (OOT instantiation)"
+            )
+            _oot_mrotary_init_logged = True
+
+    def forward_oot(
+        self,
+        positions: torch.Tensor,
+        query: torch.Tensor,
+        key: Optional[torch.Tensor] = None,
+    ) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
+        """Kunlun-optimized forward_oot for MRotaryEmbedding."""
+        assert positions.ndim == 2
+        assert key is not None
+
+        query, key = torch.ops.xspeedgate_ops.mrotary_embedding_fwd_v0(
+            query,
+            key,
+            positions.to(dtype=torch.int32),
+            self.cos_sin_cache,
+            self.mrope_interleaved,
+            self.is_neox_style,
+            self.head_size,
+            self.rotary_dim,
+            self.mrope_section[0],
+            self.mrope_section[1],
+            self.mrope_section[2],
+        )
+
+        return query, key
+
+
+@CustomOp.register_oot(name="DeepseekScalingRotaryEmbedding")
+class KunlunDeepseekScalingRotaryEmbedding(DeepseekScalingRotaryEmbedding):
+    """
+    Kunlun-optimized DeepseekScalingRotaryEmbedding registered via OOT mechanism.
+    """
+
+    def __init__(self, *args, **kwargs):
+        global _oot_deepseek_rotary_init_logged
+        super().__init__(*args, **kwargs)
+        if not _oot_deepseek_rotary_init_logged:
+            logger.info(
+                "[KunlunOOT] KunlunDeepseekScalingRotaryEmbedding.__init__ called (OOT instantiation)"
+            )
+            _oot_deepseek_rotary_init_logged = True
+
+    def forward_oot(
+        self,
+        positions: torch.Tensor,
+        query: torch.Tensor,
+        key: Optional[torch.Tensor] = None,
+        offsets: Optional[torch.Tensor] = None,
+    ) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
+        """Kunlun-optimized forward_oot for DeepseekScalingRotaryEmbedding."""
+        return torch.ops.xspeedgate_ops.flashinfer_rotary_embedding(
+            positions=positions,
+            rotary_dim=self.rotary_dim,
+            head_size=self.head_size,
+            cos_sin_cache=self.cos_sin_cache,
+            is_neox_style=self.is_neox_style,
+            query=query,
+            key=key,
+            offsets=offsets,
+        )
+
+
+# =============================================================================
+# Utility functions (kept for compatibility)
+# =============================================================================
+
+
+def Split_Norm_Rope(
+    qkv: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    q_norm_weight: torch.Tensor,
+    k_norm_weight: torch.Tensor,
+    positions: torch.Tensor,
+    max_position_embeddings: int,
+    q_head_num: int,
+    kv_head_num: int,
+    head_dim: int,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Fused Split + Norm + RoPE operation."""
+    num_tokens = qkv.shape[0]
+    rotary_dim = head_dim
+    q_emb_out = torch.empty(
+        (num_tokens, q_head_num * head_dim), dtype=qkv.dtype, device=qkv.device
+    )
+    k_emb_out = torch.empty(
+        (num_tokens, kv_head_num * head_dim), dtype=qkv.dtype, device=qkv.device
+    )
+    v_out = torch.empty(
+        (num_tokens, kv_head_num * head_dim), dtype=qkv.dtype, device=qkv.device
+    )
+    torch.ops._C.split_norm_rope_neox(
+        q_emb_out,
+        k_emb_out,
+        v_out,
+        qkv,
+        cos_sin_cache,
+        q_norm_weight,
+        k_norm_weight,
+        positions,
+        num_tokens,
+        max_position_embeddings,
+        q_head_num,
+        kv_head_num,
+        head_dim,
+        rotary_dim,
+    )
+    return q_emb_out, k_emb_out, v_out
+
+
+# Log that OOT registration is complete
+logger.info(
+    "[KunlunOOT] Registered KunlunRotaryEmbedding, KunlunMRotaryEmbedding, "
+    "KunlunDeepseekScalingRotaryEmbedding via CustomOp.register_oot"
+)

--- a/vllm_kunlun/ops/vocab_parallel_embedding.py
+++ b/vllm_kunlun/ops/vocab_parallel_embedding.py
@@ -107,7 +107,7 @@ class KunlunVocabParallelEmbedding(VocabParallelEmbedding):
             masked_input = input_
 
         # Get the embeddings
-        output_parallel = self.quant_method.embedding(self, masked_input)
+        output_parallel = self.quant_method.embedding(self, masked_input.long())
 
         # Mask the output embedding
         if self.tp_size > 1:

--- a/vllm_kunlun/patches/patch_torch251.py
+++ b/vllm_kunlun/patches/patch_torch251.py
@@ -1,0 +1,707 @@
+"""
+vLLM Compatibility Patch Script for PyTorch 2.5.1
+==================================================
+
+Why are these patches necessary?
+--------------------------------
+vLLM (v0.15.x) was developed and tested against newer versions of PyTorch
+(2.7+), which introduced several API changes that are NOT available in
+PyTorch 2.5.1. Running vLLM on PyTorch 2.5.1 without these patches will
+result in AttributeError or TypeError exceptions at runtime.
+
+Specifically, the following incompatibilities exist:
+
+1. `torch._functorch.config.bundled_autograd_cache` — This configuration
+   option was introduced in PyTorch 2.7+. It does not exist in PyTorch
+   2.5.1, so any code referencing it (either as a direct attribute or via
+   `torch._functorch.config.patch(...)`) will raise an AttributeError.
+
+2. `patched_inline_call(self_: Any)` signature — The inline call hook
+   signature changed between PyTorch versions. In PyTorch 2.5.1, it
+   expects `(parent, func, args, kwargs)` rather than `(self_: Any)`.
+
+3. `torch.Size(...)` constructor — In certain compilation contexts under
+   PyTorch 2.5.1, `torch.Size()` does not work correctly during tracing.
+   Using `torch.empty().size` is a compatible workaround.
+
+4. `list[int]` type hint — Python 3.10 supports `list[int]` in type
+   annotations, but certain runtime introspection paths (especially
+   within torch.compile / FX tracing) may fail to resolve built-in
+   generic aliases. Using `typing.List[int]` avoids this.
+
+When should these patches be removed?
+--------------------------------------
+These patches are TEMPORARY workarounds for PyTorch 2.5.1 compatibility.
+They should be REMOVED once the environment is upgraded to PyTorch 2.9+,
+where all referenced APIs are stable and available. Keeping these patches
+on PyTorch 2.9+ may cause unexpected behavior.
+
+Usage:
+------
+    python patch_torch251.py           # Apply all patches
+    python patch_torch251.py --dry-run # Preview changes without modifying files
+    python patch_torch251.py --revert  # Restore all files from .bak backups
+"""
+
+import os
+import shutil
+import site
+import sys
+
+# ============================================================
+# Base path for the target Python environment
+# ============================================================
+# Determine the site-packages directory dynamically to keep this
+# script portable across different Python installations.
+_site_packages_list = []
+try:
+    _site_packages_list = site.getsitepackages()
+except Exception:
+    _site_packages_list = []
+if _site_packages_list:
+    # Prefer the first returned site-packages directory.
+    SITE_PACKAGES = _site_packages_list[0]
+else:
+    # Fallback: use the current environment prefix.
+    SITE_PACKAGES = sys.prefix
+
+# ============================================================
+# Patch definitions
+# Each patch contains:
+#   - file:      target file path (relative to SITE_PACKAGES)
+#   - desc:      human-readable description
+#   - lines:     original line numbers (for reference only)
+#   - old:       the exact code to find and replace
+#   - new:       the replacement code
+#   - count:     (optional) number of occurrences to replace.
+#                Defaults to 1. Use 0 to replace ALL occurrences.
+#
+# IMPORTANT: When multiple patches target the same file, the
+# import/header patches should come BEFORE the body patches to
+# ensure correct dependency order.
+# ============================================================
+PATCHES = [
+    # ----------------------------------------------------------
+    # Patch 1: decorators.py — Fix inline call signature
+    # ----------------------------------------------------------
+    #     {
+    #         "file": "vllm/compilation/decorators.py",
+    #         "desc": (
+    #             "Fix patched_inline_call signature. "
+    #             "PyTorch 2.5.1 uses (parent, func, args, kwargs) instead of "
+    #             "(self_: Any). The self_.f_code attribute does not exist in "
+    #             "2.5.1; use func.get_code() instead."
+    #         ),
+    #         "lines": "505-508",
+    #         "old": """\
+    #         def patched_inline_call(self_: Any) -> Any:
+    #             code = self_.f_code
+    #             self.compilation_config.traced_files.add(code.co_filename)
+    #             return inline_call(self_)""",
+    #         "new": """\
+    #         def patched_inline_call(parent, func, args, kwargs):
+    #             # [PyTorch 2.5.1 compat] Use func.get_code() instead of
+    #             # self_.f_code, which is not available in this version.
+    #             code = func.get_code()
+    #             # Note: vLLM 0.15.x uses self.compilation_config directly
+    #             # (not self.vllm_config.compilation_config)
+    #             self.compilation_config.traced_files.add(code.co_filename)
+    #             # Pass all four arguments as expected by PyTorch 2.5.1
+    #             return inline_call(parent, func, args, kwargs)""",
+    #     },
+    #     # ----------------------------------------------------------
+    #     # Patch 2: layer.py — Fix torch.Size during tracing
+    #     # ----------------------------------------------------------
+    #     {
+    #         "file": "vllm/attention/layer.py",
+    #         "desc": (
+    #             "Replace torch.Size() with torch.empty().size. "
+    #             "In PyTorch 2.5.1, torch.Size() does not work correctly "
+    #             "during torch.compile tracing. torch.empty().size produces "
+    #             "a compatible result."
+    #         ),
+    #         "lines": "378-380",
+    #         "old": """\
+    #                 output_shape = torch.Size(
+    #                     (num_tokens, self.num_heads * self.head_size_v)
+    #                 )""",
+    #         "new": """\
+    #                 output_shape = torch.empty(
+    #                     (num_tokens, self.num_heads * self.head_size_v)
+    #                 ).size()""",
+    #     },
+    #     # ----------------------------------------------------------
+    #     # Patch 3: piecewise_backend.py — Remove bundled_autograd_cache
+    #     #          context manager (serialize path)
+    #     # ----------------------------------------------------------
+    #     {
+    #         "file": "vllm/compilation/piecewise_backend.py",
+    #         "desc": (
+    #             "Remove bundled_autograd_cache context manager around "
+    #             "serialization. torch._functorch.config.bundled_autograd_cache "
+    #             "does not exist in PyTorch 2.5.1."
+    #         ),
+    #         "lines": "180-185",
+    #         "old": """\
+    #             with torch._functorch.config.patch("bundled_autograd_cache", True):
+    #                 entry = fn.serialize()
+    #                 f = io.BytesIO()
+    #                 StandaloneCompiledArtifactsPickler(f).dump(entry)
+    #                 result = f.getvalue()""",
+    #         "new": """\
+    #             entry = fn.serialize()
+    #             f = io.BytesIO()
+    #             StandaloneCompiledArtifactsPickler(f).dump(entry)
+    #             result = f.getvalue()""",
+    #     },
+    #     # ----------------------------------------------------------
+    #     # Patch 4: piecewise_backend.py — Remove bundled_autograd_cache
+    #     #          context manager (compile path)
+    #     # ----------------------------------------------------------
+    #     {
+    #         "file": "vllm/compilation/piecewise_backend.py",
+    #         "desc": (
+    #             "Remove bundled_autograd_cache context manager around "
+    #             "compilation. Same reason as above — the config option is "
+    #             "unavailable in PyTorch 2.5.1."
+    #         ),
+    #         "lines": "243-254",
+    #         "old": """\
+    #                 with (
+    #                     torch._functorch.config.patch("bundled_autograd_cache", True),
+    #                 ):
+    #                     range_entry.runnable = self.vllm_backend.compiler_manager.compile(
+    #                         self.graph,
+    #                         args_list,
+    #                         self.vllm_backend.inductor_config,
+    #                         self.compilation_config,
+    #                         compile_range=range_entry.compile_range,
+    #                         graph_index=self.piecewise_compile_index,
+    #                         num_graphs=self.total_piecewise_compiles,
+    #                     )""",
+    #         "new": """\
+    #                 range_entry.runnable = self.vllm_backend.compiler_manager.compile(
+    #                     self.graph,
+    #                     args_list,
+    #                     self.vllm_backend.inductor_config,
+    #                     self.compilation_config,
+    #                     compile_range=range_entry.compile_range,
+    #                     graph_index=self.piecewise_compile_index,
+    #                     num_graphs=self.total_piecewise_compiles,
+    #                 )""",
+    #     },
+    #     # ----------------------------------------------------------
+    #     # Patch 5: compiler_interface.py — Comment out unavailable config
+    #     # ----------------------------------------------------------
+    #     {
+    #         "file": "vllm/compilation/compiler_interface.py",
+    #         "desc": (
+    #             "Comment out bundled_autograd_cache assignment. "
+    #             "This attribute does not exist in torch._functorch.config "
+    #             "on PyTorch 2.5.1 and will raise AttributeError."
+    #         ),
+    #         "lines": "654-656",
+    #         "old": """\
+    # def set_functorch_config() -> None:
+    #     if not envs.VLLM_USE_MEGA_AOT_ARTIFACT:
+    #         torch._functorch.config.bundled_autograd_cache = False""",
+    #         "new": """\
+    # def set_functorch_config() -> None:
+    #     if not envs.VLLM_USE_MEGA_AOT_ARTIFACT:
+    #         # [PyTorch 2.5.1 compat] bundled_autograd_cache is not available.
+    #         # TODO: Restore this line after upgrading to PyTorch 2.9+
+    #         # torch._functorch.config.bundled_autograd_cache = False
+    #         pass""",
+    #     },
+    #     # ----------------------------------------------------------
+    #     # Patch 6: parallel_state.py — Add List to typing imports
+    #     #          (must be applied BEFORE Patch 7)
+    #     # ----------------------------------------------------------
+    #     {
+    #         "file": "vllm/distributed/parallel_state.py",
+    #         "desc": (
+    #             "Add List to the typing import. Required by Patch 7 which "
+    #             "changes list[int] to List[int]. Without this import, "
+    #             "List would be undefined."
+    #         ),
+    #         "lines": "36",
+    #         "old": "from typing import Any, Optional",
+    #         "new": "from typing import Any, List, Optional",
+    #     },
+    #     # ----------------------------------------------------------
+    #     # Patch 7: parallel_state.py — Use List[int] instead of list[int]
+    #     # ----------------------------------------------------------
+    #     {
+    #         "file": "vllm/distributed/parallel_state.py",
+    #         "desc": (
+    #             "Replace built-in generic `list[int]` with `List[int]` from "
+    #             "typing. While Python 3.10 supports `list[int]` in annotations, "
+    #             "certain runtime introspection paths used by torch.compile / "
+    #             "FX tracing may fail to resolve it. Using `typing.List[int]` "
+    #             "is the safe, backward-compatible form."
+    #         ),
+    #         "lines": "173, 225",
+    #         # Replace ALL occurrences in the file
+    #         "count": 0,
+    #         "old": "    output_shape: list[int],",
+    #         "new": "    output_shape: List[int],",
+    #     },
+    # ----------------------------------------------------------
+    # Patch 8: vllm/transformers_utils/config.py - add qwen3_5
+    # ----------------------------------------------------------
+    {
+        "file": "vllm/transformers_utils/config.py",
+        "desc": ("support qwen3_5 in vllm0.15.1"),
+        "lines": "101",
+        "old": """\
+_CONFIG_REGISTRY: dict[str, type[PretrainedConfig]] = LazyConfigDict(
+    afmoe="AfmoeConfig",
+    bagel="BagelConfig",
+    chatglm="ChatGLMConfig",
+    deepseek_vl_v2="DeepseekVLV2Config",
+    deepseek_v32="DeepseekV3Config",
+    flex_olmo="FlexOlmoConfig",
+    hunyuan_vl="HunYuanVLConfig",
+    isaac="IsaacConfig",
+    kimi_linear="KimiLinearConfig",
+    kimi_vl="KimiVLConfig",
+    kimi_k25="KimiK25Config",
+    RefinedWeb="RWConfig",  # For tiiuae/falcon-40b(-instruct)
+    RefinedWebModel="RWConfig",  # For tiiuae/falcon-7b(-instruct)
+    jais="JAISConfig",
+    mlp_speculator="MLPSpeculatorConfig",
+    medusa="MedusaConfig",
+    midashenglm="MiDashengLMConfig",
+    eagle="EAGLEConfig",
+    speculators="SpeculatorsConfig",
+    nemotron="NemotronConfig",
+    olmo3="Olmo3Config",
+    ovis="OvisConfig",
+    ultravox="UltravoxConfig",
+    step3_vl="Step3VLConfig",
+    step3_text="Step3TextConfig",
+    step3p5="Step3p5Config",
+    qwen3_asr="Qwen3ASRConfig",
+    qwen3_next="Qwen3NextConfig",
+    lfm2_moe="Lfm2MoeConfig",
+    tarsier2="Tarsier2Config",
+)""",
+        "new": """\
+_CONFIG_REGISTRY: dict[str, type[PretrainedConfig]] = LazyConfigDict(
+    afmoe="AfmoeConfig",
+    bagel="BagelConfig",
+    chatglm="ChatGLMConfig",
+    deepseek_vl_v2="DeepseekVLV2Config",
+    deepseek_v32="DeepseekV3Config",
+    flex_olmo="FlexOlmoConfig",
+    hunyuan_vl="HunYuanVLConfig",
+    isaac="IsaacConfig",
+    kimi_linear="KimiLinearConfig",
+    kimi_vl="KimiVLConfig",
+    kimi_k25="KimiK25Config",
+    RefinedWeb="RWConfig",  # For tiiuae/falcon-40b(-instruct)
+    RefinedWebModel="RWConfig",  # For tiiuae/falcon-7b(-instruct)
+    jais="JAISConfig",
+    mlp_speculator="MLPSpeculatorConfig",
+    medusa="MedusaConfig",
+    midashenglm="MiDashengLMConfig",
+    eagle="EAGLEConfig",
+    speculators="SpeculatorsConfig",
+    nemotron="NemotronConfig",
+    olmo3="Olmo3Config",
+    ovis="OvisConfig",
+    ultravox="UltravoxConfig",
+    step3_vl="Step3VLConfig",
+    step3_text="Step3TextConfig",
+    step3p5="Step3p5Config",
+    qwen3_asr="Qwen3ASRConfig",
+    qwen3_next="Qwen3NextConfig",
+    qwen3_5="Qwen3_5Config",
+    qwen3_5_moe="Qwen3_5MoeConfig",
+    lfm2_moe="Lfm2MoeConfig",
+    tarsier2="Tarsier2Config",
+)""",
+    },
+    # ----------------------------------------------------------
+    # Patch 9: vllm/transformers_utils/configs/__init__.py
+    #                       add qwen3_5
+    # ----------------------------------------------------------
+    {
+        "file": "vllm/transformers_utils/configs/__init__.py",
+        "desc": ("support qwen3_5 in vllm0.15.1"),
+        "lines": "55",
+        "old": """\
+_CLASS_TO_MODULE: dict[str, str] = {
+    "AfmoeConfig": "vllm.transformers_utils.configs.afmoe",
+    "BagelConfig": "vllm.transformers_utils.configs.bagel",
+    "ChatGLMConfig": "vllm.transformers_utils.configs.chatglm",
+    "DeepseekVLV2Config": "vllm.transformers_utils.configs.deepseek_vl2",
+    "DotsOCRConfig": "vllm.transformers_utils.configs.dotsocr",
+    "EAGLEConfig": "vllm.transformers_utils.configs.eagle",
+    "FlexOlmoConfig": "vllm.transformers_utils.configs.flex_olmo",
+    "HunYuanVLConfig": "vllm.transformers_utils.configs.hunyuan_vl",
+    "HunYuanVLTextConfig": "vllm.transformers_utils.configs.hunyuan_vl",
+    "HunYuanVLVisionConfig": "vllm.transformers_utils.configs.hunyuan_vl",
+    "IsaacConfig": "vllm.transformers_utils.configs.isaac",
+    # RWConfig is for the original tiiuae/falcon-40b(-instruct) and
+    # tiiuae/falcon-7b(-instruct) models. Newer Falcon models will use the
+    # `FalconConfig` class from the official HuggingFace transformers library.
+    "RWConfig": "vllm.transformers_utils.configs.falcon",
+    "JAISConfig": "vllm.transformers_utils.configs.jais",
+    "Lfm2MoeConfig": "vllm.transformers_utils.configs.lfm2_moe",
+    "MedusaConfig": "vllm.transformers_utils.configs.medusa",
+    "MiDashengLMConfig": "vllm.transformers_utils.configs.midashenglm",
+    "MLPSpeculatorConfig": "vllm.transformers_utils.configs.mlp_speculator",
+    "MoonViTConfig": "vllm.transformers_utils.configs.moonvit",
+    "KimiLinearConfig": "vllm.transformers_utils.configs.kimi_linear",
+    "KimiVLConfig": "vllm.transformers_utils.configs.kimi_vl",
+    "KimiK25Config": "vllm.transformers_utils.configs.kimi_k25",
+    "NemotronConfig": "vllm.transformers_utils.configs.nemotron",
+    "NemotronHConfig": "vllm.transformers_utils.configs.nemotron_h",
+    "Olmo3Config": "vllm.transformers_utils.configs.olmo3",
+    "OvisConfig": "vllm.transformers_utils.configs.ovis",
+    "PixelShuffleSiglip2VisionConfig": "vllm.transformers_utils.configs.isaac",
+    "RadioConfig": "vllm.transformers_utils.configs.radio",
+    "SpeculatorsConfig": "vllm.transformers_utils.configs.speculators.base",
+    "UltravoxConfig": "vllm.transformers_utils.configs.ultravox",
+    "Step3VLConfig": "vllm.transformers_utils.configs.step3_vl",
+    "Step3VisionEncoderConfig": "vllm.transformers_utils.configs.step3_vl",
+    "Step3TextConfig": "vllm.transformers_utils.configs.step3_vl",
+    "Step3p5Config": "vllm.transformers_utils.configs.step3p5",
+    "Qwen3ASRConfig": "vllm.transformers_utils.configs.qwen3_asr",
+    "Qwen3NextConfig": "vllm.transformers_utils.configs.qwen3_next",
+    "Tarsier2Config": "vllm.transformers_utils.configs.tarsier2",
+    # Special case: DeepseekV3Config is from HuggingFace Transformers
+    "DeepseekV3Config": "transformers",
+}""",
+        "new": """\
+_CLASS_TO_MODULE: dict[str, str] = {
+    "AfmoeConfig": "vllm.transformers_utils.configs.afmoe",
+    "BagelConfig": "vllm.transformers_utils.configs.bagel",
+    "ChatGLMConfig": "vllm.transformers_utils.configs.chatglm",
+    "DeepseekVLV2Config": "vllm.transformers_utils.configs.deepseek_vl2",
+    "DotsOCRConfig": "vllm.transformers_utils.configs.dotsocr",
+    "EAGLEConfig": "vllm.transformers_utils.configs.eagle",
+    "FlexOlmoConfig": "vllm.transformers_utils.configs.flex_olmo",
+    "HunYuanVLConfig": "vllm.transformers_utils.configs.hunyuan_vl",
+    "HunYuanVLTextConfig": "vllm.transformers_utils.configs.hunyuan_vl",
+    "HunYuanVLVisionConfig": "vllm.transformers_utils.configs.hunyuan_vl",
+    "IsaacConfig": "vllm.transformers_utils.configs.isaac",
+    # RWConfig is for the original tiiuae/falcon-40b(-instruct) and
+    # tiiuae/falcon-7b(-instruct) models. Newer Falcon models will use the
+    # `FalconConfig` class from the official HuggingFace transformers library.
+    "RWConfig": "vllm.transformers_utils.configs.falcon",
+    "JAISConfig": "vllm.transformers_utils.configs.jais",
+    "Lfm2MoeConfig": "vllm.transformers_utils.configs.lfm2_moe",
+    "MedusaConfig": "vllm.transformers_utils.configs.medusa",
+    "MiDashengLMConfig": "vllm.transformers_utils.configs.midashenglm",
+    "MLPSpeculatorConfig": "vllm.transformers_utils.configs.mlp_speculator",
+    "MoonViTConfig": "vllm.transformers_utils.configs.moonvit",
+    "KimiLinearConfig": "vllm.transformers_utils.configs.kimi_linear",
+    "KimiVLConfig": "vllm.transformers_utils.configs.kimi_vl",
+    "KimiK25Config": "vllm.transformers_utils.configs.kimi_k25",
+    "NemotronConfig": "vllm.transformers_utils.configs.nemotron",
+    "NemotronHConfig": "vllm.transformers_utils.configs.nemotron_h",
+    "Olmo3Config": "vllm.transformers_utils.configs.olmo3",
+    "OvisConfig": "vllm.transformers_utils.configs.ovis",
+    "PixelShuffleSiglip2VisionConfig": "vllm.transformers_utils.configs.isaac",
+    "RadioConfig": "vllm.transformers_utils.configs.radio",
+    "SpeculatorsConfig": "vllm.transformers_utils.configs.speculators.base",
+    "UltravoxConfig": "vllm.transformers_utils.configs.ultravox",
+    "Step3VLConfig": "vllm.transformers_utils.configs.step3_vl",
+    "Step3VisionEncoderConfig": "vllm.transformers_utils.configs.step3_vl",
+    "Step3TextConfig": "vllm.transformers_utils.configs.step3_vl",
+    "Step3p5Config": "vllm.transformers_utils.configs.step3p5",
+    "Qwen3ASRConfig": "vllm.transformers_utils.configs.qwen3_asr",
+    "Qwen3NextConfig": "vllm.transformers_utils.configs.qwen3_next",
+    "Qwen3_5Config": "vllm_kunlun.transformers_utils.configs.qwen3_5",
+    "Qwen3_5TextConfig": "vllm_kunlun.transformers_utils.configs.qwen3_5",
+    "Qwen3_5MoeConfig": "vllm_kunlun.transformers_utils.configs.qwen3_5_moe",
+    "Qwen3_5MoeTextConfig": "vllm_kunlun.transformers_utils.configs.qwen3_5_moe",
+    "Tarsier2Config": "vllm.transformers_utils.configs.tarsier2",
+    # Special case: DeepseekV3Config is from HuggingFace Transformers
+    "DeepseekV3Config": "transformers",
+}""",
+    },
+    {
+        "file": "vllm/transformers_utils/configs/__init__.py",
+        "desc": ("support qwen3_5 in vllm0.15.1"),
+        "lines": "97",
+        "old": """\
+__all__ = [
+    "AfmoeConfig",
+    "BagelConfig",
+    "ChatGLMConfig",
+    "DeepseekVLV2Config",
+    "DeepseekV3Config",
+    "DotsOCRConfig",
+    "EAGLEConfig",
+    "FlexOlmoConfig",
+    "HunYuanVLConfig",
+    "HunYuanVLTextConfig",
+    "HunYuanVLVisionConfig",
+    "IsaacConfig",
+    "RWConfig",
+    "JAISConfig",
+    "Lfm2MoeConfig",
+    "MedusaConfig",
+    "MiDashengLMConfig",
+    "MLPSpeculatorConfig",
+    "MoonViTConfig",
+    "KimiLinearConfig",
+    "KimiVLConfig",
+    "KimiK25Config",
+    "NemotronConfig",
+    "NemotronHConfig",
+    "Olmo3Config",
+    "OvisConfig",
+    "PixelShuffleSiglip2VisionConfig",
+    "RadioConfig",
+    "SpeculatorsConfig",
+    "UltravoxConfig",
+    "Step3VLConfig",
+    "Step3VisionEncoderConfig",
+    "Step3TextConfig",
+    "Step3p5Config",
+    "Qwen3ASRConfig",
+    "Qwen3NextConfig",
+    "Tarsier2Config",
+]""",
+        "new": """\
+__all__ = [
+    "AfmoeConfig",
+    "BagelConfig",
+    "ChatGLMConfig",
+    "DeepseekVLV2Config",
+    "DeepseekV3Config",
+    "DotsOCRConfig",
+    "EAGLEConfig",
+    "FlexOlmoConfig",
+    "HunYuanVLConfig",
+    "HunYuanVLTextConfig",
+    "HunYuanVLVisionConfig",
+    "IsaacConfig",
+    "RWConfig",
+    "JAISConfig",
+    "Lfm2MoeConfig",
+    "MedusaConfig",
+    "MiDashengLMConfig",
+    "MLPSpeculatorConfig",
+    "MoonViTConfig",
+    "KimiLinearConfig",
+    "KimiVLConfig",
+    "KimiK25Config",
+    "NemotronConfig",
+    "NemotronHConfig",
+    "Olmo3Config",
+    "OvisConfig",
+    "PixelShuffleSiglip2VisionConfig",
+    "RadioConfig",
+    "SpeculatorsConfig",
+    "UltravoxConfig",
+    "Step3VLConfig",
+    "Step3VisionEncoderConfig",
+    "Step3TextConfig",
+    "Step3p5Config",
+    "Qwen3ASRConfig",
+    "Qwen3NextConfig",
+    "Qwen3_5Config",
+    "Qwen3_5TextConfig",
+    "Qwen3_5MoeConfig",
+    "Qwen3_5MoeTextConfig",
+    "Tarsier2Config",
+]""",
+    },
+    # ----------------------------------------------------------
+    # Patch 10: utils.py — Add backend="torch_native" to
+    #           apply_token_bitmask_inplace call
+    # ----------------------------------------------------------
+    {
+        "file": "vllm/v1/structured_output/utils.py",
+        "desc": (
+            "Add backend='torch_native' parameter to "
+            "xgr.apply_token_bitmask_inplace call. Without this parameter, "
+            "the default backend may not be compatible with the Kunlun "
+            "platform on PyTorch 2.5.1."
+        ),
+        "lines": "119",
+        "old": (
+            "xgr.apply_token_bitmask_inplace(logits, grammar_bitmask, "
+            "indices=index_tensor)"
+        ),
+        "new": (
+            "xgr.apply_token_bitmask_inplace(logits, grammar_bitmask, "
+            'indices=index_tensor, backend="torch_native")'
+        ),
+    },
+    # # ----------------------------------------------------------
+    # # Patch 11: block_table.py — update slot_mapping dtype
+    # #           from int64 to int32
+    # # ----------------------------------------------------------
+    # {
+    #     "file": "vllm/v1/worker/block_table.py",
+    #     "desc": (
+    #         "Update slot_mapping dtype from int64 to int32. This is required "
+    #         "for compatibility with the Kunlun platform on PyTorch 2.5.1."
+    #     ),
+    #     "lines": "73",
+    #     "old": """\
+    #     self.slot_mapping = self._make_buffer(
+    #         self.max_num_batched_tokens, dtype=torch.int64
+    #     )""",
+    #     "new": """\
+    #     self.slot_mapping = self._make_buffer(
+    #         self.max_num_batched_tokens, dtype=torch.int32
+    #     )""",
+    # },
+]
+
+
+# ============================================================
+# Core logic
+# ============================================================
+
+
+def get_full_path(relative_path: str) -> str:
+    """Construct the full file path from SITE_PACKAGES."""
+    return os.path.join(SITE_PACKAGES, relative_path)
+
+
+def apply_patch(patch: dict, dry_run: bool = False) -> str:
+    """
+    Apply a single patch.
+    Returns: 'success', 'skipped', or 'failed'
+    """
+    file_path = get_full_path(patch["file"])
+    desc = patch["desc"]
+    # How many occurrences to replace: default 1, use 0 for all
+    count = patch.get("count", 1)
+
+    print(
+        f"\n{'[DRY RUN] ' if dry_run else ''}"
+        f"Patch: {patch['file']} (lines {patch['lines']})"
+    )
+    print(f"  Description: {desc}")
+
+    # 1. Read the file
+    try:
+        with open(file_path, "r", encoding="utf-8") as f:
+            content = f.read()
+    except FileNotFoundError:
+        print(f"  FAIL: File not found: {file_path}")
+        return "failed"
+
+    # 2. Check if already patched (idempotent)
+    if patch["new"] in content and patch["old"] not in content:
+        print("  SKIP: Already patched.")
+        return "skipped"
+
+    # 3. Verify the original code exists
+    if patch["old"] not in content:
+        print(
+            "  FAIL: Original code not found. The file may have been "
+            "modified or the vLLM version may differ."
+        )
+        return "failed"
+
+    # Count how many occurrences will be replaced
+    num_occurrences = content.count(patch["old"])
+    replacements = num_occurrences if count == 0 else min(count, num_occurrences)
+    print(
+        f"  Found {num_occurrences} occurrence(s), "
+        f"will replace {'all' if count == 0 else replacements}."
+    )
+
+    if dry_run:
+        print("  OK: Would apply patch.")
+        return "success"
+
+    # 4. Backup (only once per file, never overwrite existing .bak)
+    backup_path = file_path + ".bak"
+    if not os.path.exists(backup_path):
+        shutil.copy2(file_path, backup_path)
+        print(f"  Backup created: {backup_path}")
+    else:
+        print(f"  Backup already exists, not overwriting: {backup_path}")
+
+    # 5. Replace and write back
+    if count == 0:
+        # Replace ALL occurrences
+        new_content = content.replace(patch["old"], patch["new"])
+    else:
+        new_content = content.replace(patch["old"], patch["new"], count)
+
+    with open(file_path, "w", encoding="utf-8") as f:
+        f.write(new_content)
+
+    print(f"  SUCCESS: Patch applied ({replacements} replacement(s)).")
+    return "success"
+
+
+def revert_all():
+    """Restore all patched files from their .bak backups."""
+    print("=" * 64)
+    print("  Reverting all patches from .bak backups")
+    print("=" * 64)
+
+    seen = set()
+    for patch in PATCHES:
+        file_path = get_full_path(patch["file"])
+        if file_path in seen:
+            continue
+        seen.add(file_path)
+
+        backup_path = file_path + ".bak"
+        if os.path.exists(backup_path):
+            shutil.copy2(backup_path, file_path)
+            print(f"  Restored: {file_path}")
+        else:
+            print(f"  No backup found for: {file_path}")
+
+    print("\nRevert complete.")
+
+
+def main():
+    dry_run = "--dry-run" in sys.argv
+    revert = "--revert" in sys.argv
+
+    if revert:
+        revert_all()
+        return
+
+    print("=" * 64)
+    print("  vLLM Compatibility Patch for PyTorch 2.5.1")
+    print(f"  Total patches: {len(PATCHES)}")
+    if dry_run:
+        print("  Mode: DRY RUN (no files will be modified)")
+    print("")
+    print("  NOTE: These patches are TEMPORARY. Remove them after")
+    print("        upgrading to PyTorch 2.9+.")
+    print("=" * 64)
+
+    results = {"success": 0, "skipped": 0, "failed": 0}
+
+    for patch in PATCHES:
+        result = apply_patch(patch, dry_run=dry_run)
+        results[result] += 1
+
+    print("\n" + "=" * 64)
+    print(
+        f"  Results: "
+        f"{results['success']} applied  |  "
+        f"{results['skipped']} skipped  |  "
+        f"{results['failed']} failed  |  "
+        f"{len(PATCHES)} total"
+    )
+    if not dry_run and results["success"] > 0:
+        print("  Original files backed up as .bak")
+        print("  To revert: python patch_torch251.py --revert")
+    print("=" * 64)
+
+    # Exit with non-zero code if any patch failed
+    if results["failed"] > 0:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/vllm_kunlun/platforms/kunlun.py
+++ b/vllm_kunlun/platforms/kunlun.py
@@ -26,6 +26,7 @@ class KunlunPlatform(Platform):
     dist_backend: str = "nccl"
     ray_device_key: str = "GPU"
     device_name: str = "cuda"
+    dispatch_key: str = "CUDA"
 
     @property
     def device_type(self):

--- a/vllm_kunlun/quantization/__init__.py
+++ b/vllm_kunlun/quantization/__init__.py
@@ -111,8 +111,18 @@ def get_quantization_config(quantization: str) -> type[QuantizationConfig]:
         raise ValueError(f"Invalid quantization method: {quantization}")
 
     # lazy import to avoid triggering `torch.compile` too early
-    from vllm.model_executor.layers.quantization.awq import AWQConfig
-    from vllm.model_executor.layers.quantization.awq_marlin import AWQMarlinConfig
+    from vllm.model_executor.layers.quantization.auto_awq import (
+        AutoAWQConfig as AWQConfig,
+    )
+    from vllm.model_executor.layers.quantization.auto_awq import (
+        AutoAWQConfig as AWQMarlinConfig,
+    )
+
+    # gptq_bitblas, gptq_marlin, gptq_marlin_24 merged into auto_gptq in 0.25.x
+    from vllm.model_executor.layers.quantization.auto_gptq import AutoGPTQConfig
+    from vllm.model_executor.layers.quantization.auto_gptq import (
+        AutoGPTQConfig as GPTQConfig,
+    )
     from vllm.model_executor.layers.quantization.bitblas import BitBLASConfig
     from vllm.model_executor.layers.quantization.bitsandbytes import BitsAndBytesConfig
     from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tensors import (
@@ -125,12 +135,10 @@ def get_quantization_config(quantization: str) -> type[QuantizationConfig]:
 
     # from vllm.model_executor.layers.quantization.fp_quant import FPQuantConfig
     from vllm.model_executor.layers.quantization.gguf import GGUFConfig
-    from vllm.model_executor.layers.quantization.gptq import GPTQConfig
-    from vllm.model_executor.layers.quantization.gptq_bitblas import GPTQBitBLASConfig
-    from vllm.model_executor.layers.quantization.gptq_marlin import GPTQMarlinConfig
-    from vllm.model_executor.layers.quantization.gptq_marlin_24 import (
-        GPTQMarlin24Config,
-    )
+
+    GPTQBitBLASConfig = AutoGPTQConfig
+    GPTQMarlinConfig = AutoGPTQConfig
+    GPTQMarlin24Config = AutoGPTQConfig
     from vllm.model_executor.layers.quantization.inc import INCConfig
     from vllm.model_executor.layers.quantization.ipex_quant import IPEXConfig
     from vllm.model_executor.layers.quantization.modelopt import (

--- a/vllm_kunlun/quantization/awq.py
+++ b/vllm_kunlun/quantization/awq.py
@@ -23,7 +23,10 @@ from vllm.logger import init_logger
 from vllm.model_executor.layers.fused_moe.layer import FusedMoE
 from vllm.model_executor.layers.linear import LinearBase, UnquantizedLinearMethod
 from vllm.model_executor.layers.quantization import register_quantization_config
-from vllm.model_executor.layers.quantization.awq import AWQConfig, AWQLinearMethod
+from vllm.model_executor.layers.quantization.auto_awq import AutoAWQConfig as AWQConfig
+from vllm.model_executor.layers.quantization.auto_awq import (
+    AutoAWQLinearMethod as AWQLinearMethod,
+)
 from vllm.model_executor.layers.quantization.moe_wna16 import MoeWNA16Config
 from vllm.model_executor.layers.quantization.utils.quant_utils import is_layer_skipped
 

--- a/vllm_kunlun/quantization/gptq.py
+++ b/vllm_kunlun/quantization/gptq.py
@@ -17,6 +17,7 @@
 # This file is a part of the vllm-kunlun project.
 
 
+import enum
 from typing import Optional, Union
 
 import torch
@@ -24,12 +25,13 @@ from torch.nn.parameter import Parameter
 from vllm.logger import init_logger
 from vllm.model_executor.layers.fused_moe.layer import FusedMoE
 from vllm.model_executor.layers.quantization import register_quantization_config
-from vllm.model_executor.layers.quantization.base_config import QuantizeMethodBase
-from vllm.model_executor.layers.quantization.gptq import (
-    ExllamaState,
-    GPTQConfig,
-    GPTQLinearMethod,
+from vllm.model_executor.layers.quantization.auto_gptq import (
+    AutoGPTQConfig as GPTQConfig,
 )
+from vllm.model_executor.layers.quantization.auto_gptq import (
+    AutoGPTQLinearMethod as GPTQLinearMethod,
+)
+from vllm.model_executor.layers.quantization.base_config import QuantizeMethodBase
 from vllm.model_executor.layers.quantization.utils.gptq_utils import (
     get_linear_quant_method,
 )
@@ -37,6 +39,12 @@ from vllm.model_executor.layers.quantization.utils.gptq_utils import (
 from vllm_kunlun.quantization.utils import _remove_quantization_method
 
 logger = init_logger(__name__)
+
+
+# ExllamaState was removed in vllm 0.25.x, define a compat stub
+class ExllamaState(enum.Enum):
+    UNINITIALIZED = 0
+    READY = 1
 
 
 # reove the original gptq quantization method

--- a/vllm_kunlun/quantization/gptq.py
+++ b/vllm_kunlun/quantization/gptq.py
@@ -47,7 +47,7 @@ class ExllamaState(enum.Enum):
     READY = 1
 
 
-# reove the original gptq quantization method
+# remove the original gptq quantization method
 _remove_quantization_method("gptq")
 
 

--- a/vllm_kunlun/tests/test_prefill_attention_prefix_cache.py
+++ b/vllm_kunlun/tests/test_prefill_attention_prefix_cache.py
@@ -1,0 +1,469 @@
+#!/usr/bin/env python3
+"""Standalone diagnostic for kunlun_ops.prefill_attention(is_prefix_cache=True).
+
+The script builds a tiny paged KV cache with deterministic values, runs the
+Kunlun prefix-cache prefill op, compares it with a PyTorch reference attention,
+and reports whether changing unwritten tail slots changes the output.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import sys
+from dataclasses import asdict, dataclass
+
+import torch
+
+try:
+    import cocopod  # noqa: F401
+    import kunlun_ops
+except Exception as exc:  # pragma: no cover - diagnostic script
+    print(f"[ERROR] failed to import kunlun_ops: {exc}", file=sys.stderr)
+    raise
+
+
+@dataclass
+class CaseResult:
+    name: str
+    layout: str
+    block_table_scale: int
+    batch_size: int
+    q_lens: list[int]
+    kv_lens: list[int]
+    block_size: int
+    num_heads: int
+    num_kv_heads: int
+    head_size: int
+    dtype: str
+    key_cache_contiguous: bool
+    value_cache_contiguous: bool
+    max_abs_err_clean: float
+    max_rel_err_clean: float
+    max_abs_err_dirty: float
+    max_rel_err_dirty: float
+    max_dirty_delta: float
+    dirty_changes_output: bool
+    clean_pass: bool
+    dirty_pass: bool
+
+
+def get_device() -> torch.device:
+    if hasattr(torch, "xpu") and torch.xpu.is_available():
+        return torch.device("xpu")
+    if torch.cuda.is_available():
+        return torch.device("cuda")
+    raise RuntimeError("No XPU/CUDA device is available for kunlun_ops")
+
+
+def make_lod(
+    lengths: list[int], device: torch.device
+) -> tuple[torch.Tensor, torch.Tensor]:
+    lod_cpu = torch.zeros(len(lengths) + 1, dtype=torch.int32, device="cpu")
+    lod_cpu[1:] = torch.tensor(lengths, dtype=torch.int32).cumsum(dim=0)
+    return lod_cpu, lod_cpu.to(device)
+
+
+def expand_kv_heads(x: torch.Tensor, num_heads: int) -> torch.Tensor:
+    if x.shape[1] == num_heads:
+        return x
+    assert num_heads % x.shape[1] == 0
+    return x.repeat_interleave(num_heads // x.shape[1], dim=1)
+
+
+def reference_attention(
+    q_flat: torch.Tensor,
+    k_tokens: list[torch.Tensor],
+    v_tokens: list[torch.Tensor],
+    q_lens: list[int],
+    scale: float,
+) -> torch.Tensor:
+    outputs = []
+    q_offset = 0
+    for q_len, k_req, v_req in zip(q_lens, k_tokens, v_tokens):
+        q_req = q_flat[q_offset : q_offset + q_len].float()
+        k_req = expand_kv_heads(k_req.float(), q_req.shape[1])
+        v_req = expand_kv_heads(v_req.float(), q_req.shape[1])
+        scores = torch.einsum("qhd,khd->hqk", q_req, k_req) * scale
+        # Query tokens are assumed to be the last q_len tokens of the full KV
+        # sequence. Causal mask only hides future query positions inside tail.
+        kv_len = k_req.shape[0]
+        q_positions = torch.arange(kv_len - q_len, kv_len, device=q_req.device)
+        k_positions = torch.arange(kv_len, device=q_req.device)
+        mask = k_positions[None, :] <= q_positions[:, None]
+        scores = scores.masked_fill(~mask.unsqueeze(0), float("-inf"))
+        probs = torch.softmax(scores, dim=-1)
+        out_req = torch.einsum("hqk,khd->qhd", probs, v_req)
+        outputs.append(out_req)
+        q_offset += q_len
+    return torch.cat(outputs, dim=0).to(q_flat.dtype)
+
+
+def make_cache_view(
+    num_blocks: int,
+    block_size: int,
+    num_kv_heads: int,
+    head_size: int,
+    dtype: torch.dtype,
+    device: torch.device,
+    layout: str,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None]:
+    if layout == "contiguous":
+        key_cache = torch.zeros(
+            (num_blocks, num_kv_heads, block_size, head_size),
+            dtype=dtype,
+            device=device,
+        )
+        value_cache = torch.zeros_like(key_cache)
+        return key_cache, value_cache, None
+
+    if layout == "hybrid":
+        # Simulate vLLM hybrid attention+mamba layout rewrite:
+        # the logical attention KV cache is viewed as (2, num_blocks, ...), but
+        # _update_hybrid_attention_mamba_layout changes its stride so key blocks
+        # are at even physical pages and value blocks are at odd physical pages.
+        raw_kv_cache = torch.zeros(
+            (2, num_blocks, block_size, num_kv_heads, head_size),
+            dtype=dtype,
+            device=device,
+        )
+        hidden_size = block_size * num_kv_heads * head_size
+        raw_kv_cache.as_strided_(
+            size=raw_kv_cache.shape,
+            stride=(
+                hidden_size,
+                2 * hidden_size,
+                num_kv_heads * head_size,
+                head_size,
+                1,
+            ),
+        )
+        key_cache = raw_kv_cache[0].permute(0, 2, 1, 3)
+        value_cache = raw_kv_cache[1].permute(0, 2, 1, 3)
+        return key_cache, value_cache, raw_kv_cache
+
+    raise ValueError(f"unknown layout: {layout}")
+
+
+def build_cache(
+    q_lens: list[int],
+    kv_lens: list[int],
+    block_size: int,
+    num_kv_heads: int,
+    head_size: int,
+    dtype: torch.dtype,
+    device: torch.device,
+    dirty_tail_value: float | None,
+    layout: str,
+    block_table_scale: int,
+) -> tuple[
+    torch.Tensor, torch.Tensor, torch.Tensor, list[torch.Tensor], list[torch.Tensor]
+]:
+    logical_blocks = sum(math.ceil(kv_len / block_size) for kv_len in kv_lens) + 4
+    storage_blocks = logical_blocks * max(block_table_scale, 1) + 4
+    key_cache, value_cache, raw_kv_cache = make_cache_view(
+        storage_blocks, block_size, num_kv_heads, head_size, dtype, device, layout
+    )
+    block_tables = torch.full(
+        (len(kv_lens), max(math.ceil(kv_len / block_size) for kv_len in kv_lens)),
+        -1,
+        dtype=torch.int32,
+        device=device,
+    )
+
+    if dirty_tail_value is not None:
+        key_cache.fill_(dirty_tail_value)
+        value_cache.fill_(-dirty_tail_value)
+        if raw_kv_cache is not None:
+            raw_kv_cache.fill_(dirty_tail_value)
+
+    k_tokens_per_req: list[torch.Tensor] = []
+    v_tokens_per_req: list[torch.Tensor] = []
+    next_logical_block = 0
+    for req_idx, kv_len in enumerate(kv_lens):
+        num_blocks = math.ceil(kv_len / block_size)
+        logical_block_ids = torch.arange(
+            next_logical_block, next_logical_block + num_blocks, dtype=torch.int32
+        )
+        physical_block_ids = logical_block_ids * block_table_scale
+        block_tables[req_idx, :num_blocks] = physical_block_ids.to(device)
+        generator = torch.Generator(device=device)
+        generator.manual_seed(1000 + req_idx)
+        k_req = torch.randn(
+            (kv_len, num_kv_heads, head_size),
+            generator=generator,
+            dtype=dtype,
+            device=device,
+        )
+        v_req = torch.randn(
+            (kv_len, num_kv_heads, head_size),
+            generator=generator,
+            dtype=dtype,
+            device=device,
+        )
+        for token_idx in range(kv_len):
+            logical_block_id = next_logical_block + token_idx // block_size
+            physical_block_id = logical_block_id * block_table_scale
+            block_offset = token_idx % block_size
+            key_cache[physical_block_id, :, block_offset, :] = k_req[token_idx]
+            value_cache[physical_block_id, :, block_offset, :] = v_req[token_idx]
+        k_tokens_per_req.append(k_req)
+        v_tokens_per_req.append(v_req)
+        next_logical_block += num_blocks
+
+    return key_cache, value_cache, block_tables, k_tokens_per_req, v_tokens_per_req
+
+
+def run_case(
+    name: str,
+    q_lens: list[int],
+    kv_lens: list[int],
+    block_size: int,
+    num_heads: int,
+    num_kv_heads: int,
+    head_size: int,
+    dtype: torch.dtype,
+    device: torch.device,
+    atol: float,
+    rtol: float,
+    layout: str,
+    block_table_scale: int,
+) -> CaseResult:
+    assert len(q_lens) == len(kv_lens)
+    assert all(0 < q_len <= kv_len for q_len, kv_len in zip(q_lens, kv_lens))
+
+    generator = torch.Generator(device=device)
+    generator.manual_seed(20240519)
+    q = torch.randn(
+        (sum(q_lens), num_heads, head_size),
+        generator=generator,
+        dtype=dtype,
+        device=device,
+    )
+    out_clean = torch.empty_like(q)
+    out_dirty = torch.empty_like(q)
+
+    qlod_cpu, qlod_xpu = make_lod(q_lens, device)
+    kvlod_cpu, kvlod_xpu = make_lod(kv_lens, device)
+
+    key_cache, value_cache, block_tables, k_tokens, v_tokens = build_cache(
+        q_lens,
+        kv_lens,
+        block_size,
+        num_kv_heads,
+        head_size,
+        dtype,
+        device,
+        None,
+        layout,
+        block_table_scale,
+    )
+    kunlun_ops.prefill_attention(
+        q=q,
+        k=key_cache,
+        v=value_cache,
+        out=out_clean,
+        is_causal=True,
+        is_prefix_cache=True,
+        block_table=block_tables,
+        context_qlen_lod_cpu=qlod_cpu,
+        context_qlen_lod_xpu=qlod_xpu,
+        context_kvlen_lod_cpu=kvlod_cpu,
+        context_kvlen_lod_xpu=kvlod_xpu,
+        alibi_slopes=None,
+        softmax_lse=None,
+        swa_left=-1,
+        swa_right=-1,
+        sink=None,
+    )
+
+    key_cache_dirty, value_cache_dirty, block_tables_dirty, _, _ = build_cache(
+        q_lens,
+        kv_lens,
+        block_size,
+        num_kv_heads,
+        head_size,
+        dtype,
+        device,
+        37.0,
+        layout,
+        block_table_scale,
+    )
+    kunlun_ops.prefill_attention(
+        q=q,
+        k=key_cache_dirty,
+        v=value_cache_dirty,
+        out=out_dirty,
+        is_causal=True,
+        is_prefix_cache=True,
+        block_table=block_tables_dirty,
+        context_qlen_lod_cpu=qlod_cpu,
+        context_qlen_lod_xpu=qlod_xpu,
+        context_kvlen_lod_cpu=kvlod_cpu,
+        context_kvlen_lod_xpu=kvlod_xpu,
+        alibi_slopes=None,
+        softmax_lse=None,
+        swa_left=-1,
+        swa_right=-1,
+        sink=None,
+    )
+
+    ref = reference_attention(
+        q, k_tokens, v_tokens, q_lens, scale=1.0 / math.sqrt(head_size)
+    )
+    clean_diff = (out_clean.float() - ref.float()).abs()
+    dirty_diff = (out_dirty.float() - ref.float()).abs()
+    dirty_delta = (out_dirty.float() - out_clean.float()).abs()
+    ref_abs = ref.float().abs().clamp_min(1e-6)
+
+    max_abs_err_clean = clean_diff.max().item()
+    max_rel_err_clean = (clean_diff / ref_abs).max().item()
+    max_abs_err_dirty = dirty_diff.max().item()
+    max_rel_err_dirty = (dirty_diff / ref_abs).max().item()
+    max_dirty_delta = dirty_delta.max().item()
+
+    return CaseResult(
+        name=name,
+        layout=layout,
+        block_table_scale=block_table_scale,
+        batch_size=len(q_lens),
+        q_lens=q_lens,
+        kv_lens=kv_lens,
+        block_size=block_size,
+        num_heads=num_heads,
+        num_kv_heads=num_kv_heads,
+        head_size=head_size,
+        dtype=str(dtype),
+        key_cache_contiguous=key_cache.is_contiguous(),
+        value_cache_contiguous=value_cache.is_contiguous(),
+        max_abs_err_clean=max_abs_err_clean,
+        max_rel_err_clean=max_rel_err_clean,
+        max_abs_err_dirty=max_abs_err_dirty,
+        max_rel_err_dirty=max_rel_err_dirty,
+        max_dirty_delta=max_dirty_delta,
+        dirty_changes_output=max_dirty_delta > atol,
+        clean_pass=max_abs_err_clean <= atol or max_rel_err_clean <= rtol,
+        dirty_pass=max_abs_err_dirty <= atol or max_rel_err_dirty <= rtol,
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--block-size", type=int, default=16)
+    parser.add_argument("--num-heads", type=int, default=8)
+    parser.add_argument("--num-kv-heads", type=int, default=2)
+    parser.add_argument("--head-size", type=int, default=128)
+    parser.add_argument(
+        "--dtype", choices=("float16", "bfloat16", "float32"), default="float16"
+    )
+    parser.add_argument("--atol", type=float, default=5e-2)
+    parser.add_argument("--rtol", type=float, default=5e-2)
+    parser.add_argument("--json", default="")
+    parser.add_argument(
+        "--layouts",
+        default="contiguous,hybrid",
+        help="comma-separated layouts: contiguous,hybrid",
+    )
+    args = parser.parse_args()
+
+    device = get_device()
+    dtype = getattr(torch, args.dtype)
+    cases = [
+        ("single_partial_tail", [3], [19]),
+        ("single_exact_block", [4], [32]),
+        ("multi_mixed_partial", [3, 5, 1], [19, 37, 48]),
+        ("apc_like_short_query", [1, 1, 2], [33, 49, 65]),
+    ]
+    layout_scales = []
+    requested_layouts = {
+        layout.strip() for layout in args.layouts.split(",") if layout.strip()
+    }
+    if "contiguous" in requested_layouts:
+        layout_scales.append(("contiguous", 1))
+    if "hybrid" in requested_layouts:
+        # Mirrors kunlun_attn.py non-contiguous path: block_tables * 2.
+        layout_scales.append(("hybrid", 2))
+
+    results = []
+    print("# kunlun_ops.prefill_attention prefix-cache diagnostic")
+    print(f"device={device} dtype={dtype} block_size={args.block_size}")
+    print(
+        f"heads={args.num_heads} kv_heads={args.num_kv_heads} head_size={args.head_size}"
+    )
+    for layout, block_table_scale in layout_scales:
+        for case in cases:
+            result = run_case(
+                case[0],
+                case[1],
+                case[2],
+                args.block_size,
+                args.num_heads,
+                args.num_kv_heads,
+                args.head_size,
+                dtype,
+                device,
+                args.atol,
+                args.rtol,
+                layout,
+                block_table_scale,
+            )
+            results.append(result)
+            status = (
+                "PASS"
+                if result.clean_pass
+                and result.dirty_pass
+                and not result.dirty_changes_output
+                else "FAIL"
+            )
+            print(
+                f"[{status}] {result.layout}/{result.name}: "
+                f"scale={result.block_table_scale} "
+                f"kc_contig={result.key_cache_contiguous} "
+                f"vc_contig={result.value_cache_contiguous} "
+                f"clean_abs={result.max_abs_err_clean:.6g} "
+                f"clean_rel={result.max_rel_err_clean:.6g} "
+                f"dirty_abs={result.max_abs_err_dirty:.6g} "
+                f"dirty_rel={result.max_rel_err_dirty:.6g} "
+                f"dirty_delta={result.max_dirty_delta:.6g} "
+                f"q_lens={result.q_lens} kv_lens={result.kv_lens}"
+            )
+
+    report = {
+        "device": str(device),
+        "dtype": str(dtype),
+        "block_size": args.block_size,
+        "num_heads": args.num_heads,
+        "num_kv_heads": args.num_kv_heads,
+        "head_size": args.head_size,
+        "atol": args.atol,
+        "rtol": args.rtol,
+        "layout_scales": layout_scales,
+        "results": [asdict(result) for result in results],
+    }
+    if args.json:
+        with open(args.json, "w", encoding="utf-8") as f:
+            json.dump(report, f, indent=2, ensure_ascii=False)
+        print(f"wrote json report: {args.json}")
+
+    failed = [
+        r
+        for r in results
+        if not (r.clean_pass and r.dirty_pass and not r.dirty_changes_output)
+    ]
+    if failed:
+        print(
+            "\nFinding: prefix-cache output differs from reference or depends on dirty tail slots."
+        )
+        return 1
+    print(
+        "\nFinding: prefix-cache output matches reference and is insensitive to dirty tail slots."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    if os.environ.get("CUDA_VISIBLE_DEVICES") == "":
+        print("[WARN] CUDA_VISIBLE_DEVICES is empty", file=sys.stderr)
+    raise SystemExit(main())

--- a/vllm_kunlun/v1/attention/backends/gdn_attn.py
+++ b/vllm_kunlun/v1/attention/backends/gdn_attn.py
@@ -207,12 +207,9 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
                 )
 
         if spec_sequence_masks is None:
-            (
-                num_decodes,
-                num_prefills,
-                num_decode_tokens,
-                num_prefill_tokens,
-            ) = split_decodes_and_prefills(m, decode_threshold=1)
+            num_decodes, num_prefills, num_decode_tokens, num_prefill_tokens = (
+                split_decodes_and_prefills(m, decode_threshold=1)
+            )
             num_spec_decode_tokens = 0
             spec_token_indx = None
             spec_token_masks = None
@@ -358,13 +355,11 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
             if spec_sequence_masks_cpu is not None:
                 has_initial_state = has_initial_state[~spec_sequence_masks_cpu]
                 assert non_spec_query_start_loc_cpu is not None
-            (
-                nums_dict,
-                batch_ptr,
-                token_chunk_offset_ptr,
-            ) = compute_causal_conv1d_metadata(
-                non_spec_query_start_loc_cpu,
-                device=query_start_loc.device,
+            nums_dict, batch_ptr, token_chunk_offset_ptr = (
+                compute_causal_conv1d_metadata(
+                    non_spec_query_start_loc_cpu,
+                    device=query_start_loc.device,
+                )
             )
         else:
             has_initial_state = None
@@ -456,9 +451,7 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
             num_actual_tokens=m.num_actual_tokens,
             has_initial_state=has_initial_state,
             has_initial_state_cpu=(
-                has_initial_state.to("cpu", non_blocking=True)
-                if has_initial_state is not None
-                else None
+                has_initial_state.cpu() if has_initial_state is not None else None
             ),
             chunk_indices=chunk_indices,
             chunk_offsets=chunk_offsets,
@@ -468,7 +461,7 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
             spec_state_indices_tensor=spec_state_indices_tensor,
             non_spec_state_indices_tensor=non_spec_state_indices_tensor,
             non_spec_state_indices_tensor_cpu=(
-                non_spec_state_indices_tensor.to("cpu", non_blocking=True)
+                non_spec_state_indices_tensor.cpu()
                 if non_spec_state_indices_tensor is not None
                 else None
             ),

--- a/vllm_kunlun/v1/attention/backends/kunlun_attn.py
+++ b/vllm_kunlun/v1/attention/backends/kunlun_attn.py
@@ -32,6 +32,7 @@ import kunlun_ops
 import numpy as np
 import torch
 from vllm.config import VllmConfig
+from vllm.logger import init_logger
 from vllm.v1.attention.backend import (
     AttentionBackend,
     AttentionCGSupport,
@@ -54,6 +55,8 @@ import inspect
 from vllm.utils.math_utils import cdiv
 from vllm.v1.attention.backends.fa_utils import get_flash_attn_version
 from vllm.v1.kv_cache_interface import AttentionSpec
+
+logger = init_logger(__name__)
 
 
 class KunlunAttentionBackend(AttentionBackend):
@@ -689,6 +692,26 @@ class KunlunAttentionMetadataBuilder:
 class KunlunAttentionImpl(AttentionImpl[KunlunMetadata]):
     """KunlunAttentionImpl"""
 
+    @staticmethod
+    def _get_block_table_scale(key_cache: torch.Tensor) -> int:
+        contiguous_block_stride = (
+            key_cache.shape[1] * key_cache.shape[2] * key_cache.shape[3]
+        )
+        actual_block_stride = key_cache.stride(0)
+        if actual_block_stride == contiguous_block_stride:
+            return 1
+        if actual_block_stride % contiguous_block_stride != 0:
+            logger.warning(
+                "[KunlunAttention] unexpected KV cache block stride: "
+                "actual=%s contiguous=%s shape=%s stride=%s",
+                actual_block_stride,
+                contiguous_block_stride,
+                tuple(key_cache.shape),
+                tuple(key_cache.stride()),
+            )
+            return 1
+        return actual_block_stride // contiguous_block_stride
+
     def __init__(
         self,
         num_heads: int,
@@ -794,7 +817,6 @@ class KunlunAttentionImpl(AttentionImpl[KunlunMetadata]):
                     # and value tensors are not cached. This happens during
                     # the initial memory
                     value = value.contiguous()
-                    key = key.contiguous()
                     kunlun_ops.reshape_and_cache_flash(
                         key[: attn_metadata.num_actual_tokens],
                         value[: attn_metadata.num_actual_tokens],
@@ -822,23 +844,18 @@ class KunlunAttentionImpl(AttentionImpl[KunlunMetadata]):
             #   score = Q @ K^T * (1/sqrt(d)) * alpha
             # We want: score = Q @ K^T * self.scale
             # So: alpha = self.scale * sqrt(d) = self.scale / (1/sqrt(d))
-            import math
+            # import math
 
-            _prefill_alpha = self.scale * math.sqrt(self.head_size)
+            # _prefill_alpha = self.scale * math.sqrt(self.head_size)
 
-            # For hybrid Attention (Qwen3-Next.)
-            if key_cache.is_contiguous():
-                tmp_block_tables = prefill_meta.block_tables
-            else:
-                # For hybrid Attention (Qwen3-Next)
-                tmp_block_tables = prefill_meta.block_tables * 2
+            # For hybrid/packed attention, Kunlun kernels assume contiguous
+            # block stride. Scale logical block ids to match the actual
+            # packed KV-cache block stride (e.g. 2 * attn_pack_size).
+            block_table_scale = self._get_block_table_scale(key_cache)
+            tmp_block_tables = prefill_meta.block_tables * block_table_scale
 
             # Prefix cache or KV sharing layers (must read K/V from cache)
-            is_kv_sharing = self.kv_sharing_target_layer_name is not None
-            if (
-                is_kv_sharing
-                or prefill_meta.query_start_loc_host[-1] != prefill_meta.kv_lod_cpu[-1]
-            ):
+            if prefill_meta.query_start_loc_host[-1] != prefill_meta.kv_lod_cpu[-1]:
                 kunlun_ops.prefill_attention(
                     q=prefill_query,
                     k=key_cache,  # Key Cache [block_num, head, block_size, dim]
@@ -846,7 +863,6 @@ class KunlunAttentionImpl(AttentionImpl[KunlunMetadata]):
                     out=output[num_decode_tokens : attn_metadata.num_actual_tokens],
                     is_causal=True,
                     is_prefix_cache=True,
-                    alpha=_prefill_alpha,
                     block_table=tmp_block_tables,
                     context_qlen_lod_cpu=prefill_meta.query_start_loc_host,
                     context_qlen_lod_xpu=prefill_meta.query_start_loc,
@@ -869,7 +885,6 @@ class KunlunAttentionImpl(AttentionImpl[KunlunMetadata]):
                     v=prefill_value,
                     out=output[num_decode_tokens : attn_metadata.num_actual_tokens],
                     is_causal=True,
-                    alpha=_prefill_alpha,
                     context_qlen_lod_cpu=prefill_meta.query_start_loc_host,
                     context_qlen_lod_xpu=prefill_meta.query_start_loc,
                     alibi_slopes=self.alibi_slopes,
@@ -889,13 +904,11 @@ class KunlunAttentionImpl(AttentionImpl[KunlunMetadata]):
             ), "Encoder-only models should not have decode metadata."
             decode_query = query[:num_decode_tokens]
 
-            # For hybrid Attention (Qwen3-Next
-            if key_cache.is_contiguous():
-                tmp_block_tables = decode_meta.block_tables
-            else:
-                tmp_block_tables = (
-                    decode_meta.block_tables * 2
-                )  # only test in Qwen3-Next
+            # For hybrid/packed attention, Kunlun kernels assume contiguous
+            # block stride. Scale logical block ids to match the actual
+            # packed KV-cache block stride (e.g. 2 * attn_pack_size).
+            block_table_scale = self._get_block_table_scale(key_cache)
+            tmp_block_tables = decode_meta.block_tables * block_table_scale
 
             has_max_window_size = getattr(self, "_spec_attn_has_max_window_size", None)
             if has_max_window_size is None:

--- a/vllm_kunlun/v1/sample/ops/topk_topp_sampler.py
+++ b/vllm_kunlun/v1/sample/ops/topk_topp_sampler.py
@@ -12,6 +12,11 @@ from vllm.logger import init_logger
 logger = init_logger(__name__)
 
 
+def flashinfer_sampler_supported() -> bool:
+    """FlashInfer is not supported on Kunlun XPU, always return False."""
+    return False
+
+
 class TopKTopPSampler(nn.Module):
     """
     Module that performs optional top-k and top-p filtering followed by
@@ -20,9 +25,10 @@ class TopKTopPSampler(nn.Module):
     Implementations may update the logits tensor in-place.
     """
 
-    def __init__(self, logprobs_mode):
+    def __init__(self, logprobs_mode, use_fp64_gumbel: bool = False):
         super().__init__()
         self.logprobs_mode = logprobs_mode
+        self.use_fp64_gumbel = use_fp64_gumbel
         logger.info_once("Using FlashInfer for top-p & top-k sampling.")
         self.forward = self.forward_kunlun
         self.apply_top_k_top_p = apply_top_k_top_p
@@ -213,3 +219,35 @@ def flashinfer_sample(
         )
 
     return next_token_ids.view(-1)
+
+
+def empty_exponential_noise_like(
+    probs: torch.Tensor,
+    use_fp64_gumbel: bool = False,
+) -> torch.Tensor:
+    """Return a tensor of exponential noise with the same shape as probs.
+
+    Used by vllm.v1.spec_decode.llm_base_proposer for speculative decoding.
+    """
+    if use_fp64_gumbel:
+        noise = torch.empty_like(probs, dtype=torch.float64)
+    else:
+        noise = torch.empty_like(probs)
+    noise.exponential_()
+    return noise
+
+
+def sample_with_exponential_noise(
+    probs: torch.Tensor,
+    q: torch.Tensor,
+) -> torch.Tensor:
+    """Sample from probs using exponential noise q (Gumbel-max trick).
+
+    Used by vllm.v1.spec_decode.llm_base_proposer for speculative decoding.
+    """
+    if q.dtype == probs.dtype:
+        scores = probs.div_(q)
+    else:
+        scores = q.reciprocal_()
+        scores.mul_(probs)
+    return scores.argmax(dim=-1).view(-1)

--- a/vllm_kunlun/v1/sample/rejection_sampler.py
+++ b/vllm_kunlun/v1/sample/rejection_sampler.py
@@ -1,21 +1,34 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-from typing import Optional
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import replace
+from typing import TYPE_CHECKING, Optional
 
 import torch
 import torch.nn as nn
 from vllm.logger import init_logger
+from vllm.v1.outputs import LogprobsLists, LogprobsTensors, SamplerOutput
+from vllm.v1.sample.logits_processor.builtin import MinTokensLogitsProcessor
 from vllm.v1.sample.metadata import SamplingMetadata
+from vllm.v1.sample.ops.bad_words import apply_bad_words_with_drafts
+from vllm.v1.sample.ops.penalties import apply_all_penalties
 from vllm.v1.sample.ops.topk_topp_sampler import apply_top_k_top_p
+from vllm.v1.sample.sampler import Sampler
 from vllm.v1.spec_decode.metadata import SpecDecodeMetadata
+from vllm.v1.spec_decode.utils import unconditional_to_conditional_rates
+
+if TYPE_CHECKING:
+    from vllm.config.speculative import SpeculativeConfig
 
 logger = init_logger(__name__)
 
 PLACEHOLDER_TOKEN_ID = -1
-GREEDY_TEMPERATURE = -1
+GREEDY_TEMPERATURE = 0
 # Maximum number of speculative draft tokens allowed per request in a single
 # step. This value is chosen to be large enough to handle typical use cases.
-MAX_SPEC_LEN = 32
+MAX_SPEC_LEN = 128
 
 
 class RejectionSampler(nn.Module):
@@ -41,17 +54,42 @@ class RejectionSampler(nn.Module):
         output tokens = accepted tokens + recovered tokens + bonus tokens
     """
 
+    def __init__(
+        self,
+        sampler: Sampler,
+        spec_config: SpeculativeConfig | None = None,
+        device: torch.device | None = None,
+    ):
+        super().__init__()
+        self.sampler = sampler
+        logprobs_mode = self.sampler.logprobs_mode
+        self.is_processed_logprobs_mode = logprobs_mode.startswith("processed")
+        self.is_logits_logprobs_mode = logprobs_mode.endswith("logits")
+
+        self.synthetic_conditional_rates: torch.Tensor | None = None
+        if (
+            spec_config is not None
+            and spec_config.rejection_sample_method == "synthetic"
+        ):
+            assert spec_config.synthetic_acceptance_rates is not None
+            self.synthetic_conditional_rates = torch.tensor(
+                unconditional_to_conditional_rates(
+                    spec_config.synthetic_acceptance_rates
+                ),
+                dtype=torch.float32,
+                device=device,
+            )
+        self.synthetic_mode = self.synthetic_conditional_rates is not None
+
     def forward(
         self,
         metadata: SpecDecodeMetadata,
         # [num_tokens, vocab_size]
         draft_probs: Optional[torch.Tensor],
-        # [num_tokens, vocab_size]
-        target_logits: torch.Tensor,
-        # [batch_size, 1]
-        bonus_token_ids: torch.Tensor,
+        # [num_tokens + batch_size, vocab_size]
+        logits: torch.Tensor,
         sampling_metadata: SamplingMetadata,
-    ) -> torch.Tensor:
+    ) -> SamplerOutput:
         """
         Args:
             metadata:
@@ -60,31 +98,48 @@ class RejectionSampler(nn.Module):
                 Probability distribution for the draft tokens. Shape is
                 [num_tokens, vocab_size]. Can be None if probabilities are
                 not provided, which is the case for ngram spec decode.
-            target_logits (torch.Tensor):
+            logits (torch.Tensor):
                 Target model's logits probability distribution.
-                Shape is [num_tokens, vocab_size]. Here, probabilities from
-                different requests are flattened into a single tensor because
-                this is the shape of the output logits.
-                NOTE: `target_logits` can be updated in place to save memory.
-            bonus_token_ids_tensor (torch.Tensor):
-                A tensor containing bonus tokens. Shape is [batch_size, 1].
-                Bonus tokens are added to the end of the sequence if all
-                proposed tokens are accepted. We generate the bonus tokens
-                outside of the rejection sampler with the default sampling
-                strategy. It allows for more flexibility in the sampling
-                process such as top_p, top_k sampling.
+                Shape is [num_tokens + batch_size, vocab_size]. Here,
+                probabilities from different requests are flattened into a
+                single tensor because this is the shape of the output logits.
+                NOTE: `logits` can be updated in place to save memory.
             sampling_metadata (vllm.v1.sample.metadata.SamplingMetadata):
                 Additional metadata needed for sampling, such as temperature,
                 top-k/top-p parameters, or other relevant information.
         Returns:
-            output_token_ids (torch.Tensor):
-                A tensor containing the final output token IDs.
+            SamplerOutput:
+                Contains the final output token IDs and their logprobs if
+                requested.
         """
         assert metadata.max_spec_len <= MAX_SPEC_LEN
-        # [num_tokens, vocab_size]
-        # NOTE(woosuk): `target_logits` can be updated in place inside the
-        # `compute_probs` function.
 
+        bonus_logits_indices = metadata.bonus_logits_indices
+        target_logits_indices = metadata.target_logits_indices
+
+        assert logits is not None
+        bonus_logits = logits[bonus_logits_indices]
+        bonus_sampler_output = self.sampler(
+            logits=bonus_logits,
+            sampling_metadata=replace(
+                sampling_metadata,
+                max_num_logprobs=-1,
+            ),
+            predict_bonus_token=True,
+            logprobs_mode_override=(
+                "processed_logits" if self.is_processed_logprobs_mode else "raw_logits"
+            ),
+        )
+        bonus_token_ids = bonus_sampler_output.sampled_token_ids
+
+        raw_target_logits = logits[target_logits_indices]
+        raw_target_logits = raw_target_logits.to(torch.float32)
+        target_logits = raw_target_logits
+        if not self.is_processed_logprobs_mode:
+            target_logits = target_logits.clone()
+        target_logits = self.apply_logits_processors(
+            target_logits, sampling_metadata, metadata
+        )
         target_probs = compute_probs(
             target_logits,
             metadata.cu_num_draft_tokens,
@@ -100,14 +155,76 @@ class RejectionSampler(nn.Module):
             target_probs,
             bonus_token_ids,
             sampling_metadata,
+            synthetic_mode=self.synthetic_mode,
+            synthetic_conditional_rates=self.synthetic_conditional_rates,
         )
-        return output_token_ids
+
+        logprobs_tensors = None
+        if sampling_metadata.max_num_logprobs is not None:
+            logprobs_tensors = self._get_logprobs_tensors(
+                sampling_metadata.max_num_logprobs,
+                metadata,
+                logits,
+                target_logits if self.is_processed_logprobs_mode else raw_target_logits,
+                bonus_sampler_output.logprobs_tensors.logprobs,
+                output_token_ids,
+            )
+
+        return SamplerOutput(
+            sampled_token_ids=output_token_ids,
+            logprobs_tensors=logprobs_tensors,
+        )
+
+    def _get_logprobs_tensors(
+        self,
+        max_num_logprobs: int,
+        metadata: SpecDecodeMetadata,
+        logits: torch.Tensor,
+        target_logits: torch.Tensor,
+        bonus_logits: torch.Tensor,
+        sampled_token_ids: torch.Tensor,
+    ) -> LogprobsTensors:
+        cu_num_sampled_tokens = torch.zeros_like(metadata.cu_num_sampled_tokens)
+        cu_num_sampled_tokens[1:] = metadata.cu_num_sampled_tokens[:-1]
+
+        bonus_logits_indices = metadata.bonus_logits_indices
+        target_logits_indices = metadata.target_logits_indices
+        final_logits = torch.zeros_like(logits, dtype=torch.float32)
+        final_logits[target_logits_indices] = target_logits.to(torch.float32)
+        final_logits[bonus_logits_indices] = bonus_logits.to(torch.float32)
+
+        logit_start_indices = cu_num_sampled_tokens
+        offsets = torch.arange(
+            sampled_token_ids.shape[-1],
+            device=logit_start_indices.device,
+            dtype=logit_start_indices.dtype,
+        )
+        accepted_logit_indices = (
+            logit_start_indices.unsqueeze(1) + offsets.unsqueeze(0)
+        ).flatten()
+        accepted_logit_indices.clamp_(max=final_logits.shape[0] - 1)
+        accepted_tokens = sampled_token_ids.clone().flatten()
+        accepted_tokens[accepted_tokens == PLACEHOLDER_TOKEN_ID] = 0
+
+        accepted_logits = final_logits[accepted_logit_indices]
+        accepted_logprobs = (
+            accepted_logits
+            if self.is_logits_logprobs_mode
+            else self.sampler.compute_logprobs(accepted_logits)
+        )
+        return self.sampler.gather_logprobs(
+            accepted_logprobs,
+            max_num_logprobs,
+            accepted_tokens.to(torch.int64),
+        )
 
     @staticmethod
     def parse_output(
         output_token_ids: torch.Tensor,
         vocab_size: int,
-    ) -> list[list[int]]:
+        discard_req_indices: Sequence[int] = (),
+        logprobs_tensors: LogprobsTensors | None = None,
+    ) -> tuple[list[list[int]], LogprobsLists | None]:
         """Parse the output of the rejection sampler.
 
         Args:
@@ -116,19 +233,132 @@ class RejectionSampler(nn.Module):
                 replaced with `PLACEHOLDER_TOKEN_ID` by the rejection sampler
                 and will be filtered out in this function.
             vocab_size: The size of the vocabulary.
+            discard_req_indices: Optional row indices to discard tokens in.
+            logprobs_tensors: Optional logprobs tensors to filter.
 
         Returns:
-            A list of lists of token IDs.
+            A list of lists of token IDs and optional logprobs.
         """
         output_token_ids_np = output_token_ids.cpu().numpy()
-        # Create mask for valid tokens.
         valid_mask = (output_token_ids_np != PLACEHOLDER_TOKEN_ID) & (
             output_token_ids_np < vocab_size
         )
+        output_logprobs = None
+        if logprobs_tensors is not None:
+            cu_num_tokens = [0] + valid_mask.sum(axis=1).cumsum().tolist()
+            filtered_tensors = logprobs_tensors.filter(valid_mask.flatten())
+            output_logprobs = filtered_tensors.tolists(cu_num_tokens)
+
+        if len(discard_req_indices) > 0:
+            valid_mask[discard_req_indices] = False
         outputs = [
             row[valid_mask[i]].tolist() for i, row in enumerate(output_token_ids_np)
         ]
-        return outputs
+        return outputs, output_logprobs
+
+    def apply_logits_processors(
+        self,
+        logits: torch.Tensor,
+        sampling_metadata: SamplingMetadata,
+        metadata: SpecDecodeMetadata,
+    ) -> torch.Tensor:
+        has_penalties = not sampling_metadata.no_penalties
+        any_penalties_or_bad_words = (
+            sampling_metadata.bad_words_token_ids or has_penalties
+        )
+        holder = sampling_metadata.thinking_budget_state_holder
+        needs_thinking = holder is not None and holder.has_tracked_requests()
+
+        output_token_ids = sampling_metadata.output_token_ids
+        if any_penalties_or_bad_words or needs_thinking:
+            output_token_ids = self._combine_outputs_with_spec_tokens(
+                output_token_ids,
+                sampling_metadata.spec_token_ids,
+            )
+
+        repeat_indices: torch.Tensor | None = None
+        need_repeat_indices = (
+            sampling_metadata.allowed_token_ids_mask is not None
+            or has_penalties
+            or needs_thinking
+        )
+        if need_repeat_indices:
+            num_requests = len(metadata.num_draft_tokens)
+            num_draft_tokens = torch.tensor(metadata.num_draft_tokens, device="cpu")
+            original_indices = torch.arange(num_requests, device="cpu")
+            repeat_indices_cpu = original_indices.repeat_interleave(num_draft_tokens)
+            repeat_indices = repeat_indices_cpu.to(
+                device=logits.device, non_blocking=True
+            )
+            logits = self.apply_penalties(
+                logits, sampling_metadata, metadata, repeat_indices, output_token_ids
+            )
+
+            if sampling_metadata.allowed_token_ids_mask is not None:
+                token_mask = sampling_metadata.allowed_token_ids_mask[repeat_indices]
+                logits.masked_fill_(token_mask, float("-inf"))
+
+        if bad_words_token_ids := sampling_metadata.bad_words_token_ids:
+            apply_bad_words_with_drafts(
+                logits, bad_words_token_ids, output_token_ids, metadata.num_draft_tokens
+            )
+
+        for processor in sampling_metadata.logitsprocs.non_argmax_invariant:
+            if isinstance(processor, MinTokensLogitsProcessor):
+                logits = processor.apply_with_spec_decode(
+                    logits, metadata.num_draft_tokens
+                )
+        if holder is not None and holder.has_tracked_requests():
+            logits = holder.apply_to_logits(
+                logits,
+                predict_bonus_token=False,
+                spec_token_ids=sampling_metadata.spec_token_ids,
+            )
+        return logits
+
+    @staticmethod
+    def apply_penalties(
+        logits: torch.Tensor,
+        sampling_metadata: SamplingMetadata,
+        metadata: SpecDecodeMetadata,
+        repeat_indices: torch.Tensor,
+        output_token_ids: list[list[int]],
+    ) -> torch.Tensor:
+        if sampling_metadata.no_penalties:
+            return logits
+
+        assert sampling_metadata.prompt_token_ids is not None
+        prompt_token_ids = sampling_metadata.prompt_token_ids[repeat_indices]
+        presence_penalties = sampling_metadata.presence_penalties[repeat_indices]
+        frequency_penalties = sampling_metadata.frequency_penalties[repeat_indices]
+        repetition_penalties = sampling_metadata.repetition_penalties[repeat_indices]
+
+        logits = apply_all_penalties(
+            logits,
+            prompt_token_ids,
+            presence_penalties,
+            frequency_penalties,
+            repetition_penalties,
+            output_token_ids,
+        )
+        return logits
+
+    @staticmethod
+    def _combine_outputs_with_spec_tokens(
+        output_token_ids: list[list[int]],
+        spec_token_ids: list[list[int]] | None = None,
+    ) -> list[list[int]]:
+        if spec_token_ids is None:
+            return output_token_ids
+
+        result = []
+        for out, spec in zip(output_token_ids, spec_token_ids):
+            if len(spec) == 0:
+                continue
+            result.append(out)
+            for i in range(len(spec) - 1):
+                result.append([*result[-1], spec[i]])
+        return result
 
 
 def rejection_sample(
@@ -146,6 +376,8 @@ def rejection_sample(
     # [batch_size, 1]
     bonus_token_ids: torch.Tensor,
     sampling_metadata: SamplingMetadata,
+    synthetic_mode: bool = False,
+    synthetic_conditional_rates: torch.Tensor | None = None,
 ) -> torch.Tensor:
     assert draft_token_ids.ndim == 1
     assert draft_probs is None or draft_probs.ndim == 2
@@ -174,6 +406,15 @@ def rejection_sample(
         is_greedy = None
     else:
         is_greedy = sampling_metadata.temperature == GREEDY_TEMPERATURE
+    uniform_probs: torch.Tensor | None = None
+    if synthetic_mode or not sampling_metadata.all_greedy:
+        uniform_probs = generate_uniform_probs(
+            num_tokens,
+            num_draft_tokens,
+            sampling_metadata.generators,
+            device,
+        )
+
     if not sampling_metadata.all_random:
         # Rejection sampling for greedy sampling requests.
         target_argmax = target_probs.argmax(dim=-1)
@@ -181,6 +422,7 @@ def rejection_sample(
             min(num_draft_tokens) == 1
             and max(num_draft_tokens) == 1
             and sampling_metadata.all_greedy
+            and not synthetic_mode
         ):
             rejection_greedy_sample_spec_len_1_pytorch(
                 output_token_ids,
@@ -198,18 +440,14 @@ def rejection_sample(
                 num_draft_tokens,
                 max_spec_len,
                 is_greedy,
+                uniform_probs,
+                synthetic_conditional_rates,
+                synthetic_mode,
             )
         if sampling_metadata.all_greedy:
             return output_token_ids
 
-    # Generate uniform probabilities for rejection sampling.
-    # [num_tokens]
-    uniform_probs = generate_uniform_probs(
-        num_tokens,
-        num_draft_tokens,
-        sampling_metadata.generators,
-        device,
-    )
+    assert uniform_probs is not None
 
     # Sample recovered tokens for each position.
     # [num_tokens]
@@ -236,8 +474,9 @@ def rejection_sample(
         is_greedy,
         max_spec_len,
         vocab_size,
+        synthetic_conditional_rates,
         IS_NGRAM=draft_probs is None,
-        # num_warps=1,
+        SYNTHETIC_MODE=synthetic_mode,
     )
     return output_token_ids
 
@@ -462,6 +701,9 @@ def rejection_greedy_sample_pytorch(
     draft_tokens_per_req,  # [batch_size], list
     max_spec_len,
     is_greedy=None,  # [batch_size] or None
+    uniform_probs=None,  # [num_tokens] or None
+    synthetic_conditional_rates=None,  # [num_speculative_tokens] or None
+    synthetic_mode=False,
 ):
     batch_size = output_token_ids.size(0)
     num_tokens = draft_token_ids.size(0)
@@ -480,7 +722,20 @@ def rejection_greedy_sample_pytorch(
     )
 
     # Find the first mismatch position of each request.
-    mismatch_global = draft_token_ids != target_argmax
+    if synthetic_mode:
+        assert uniform_probs is not None
+        assert synthetic_conditional_rates is not None
+        accepted = torch.empty(num_tokens, dtype=torch.bool, device=device)
+        for req_idx, draft_count in enumerate(draft_tokens_per_req.tolist()):
+            start_idx = start_indices[req_idx]
+            end_idx = start_idx + draft_count
+            if draft_count > 0:
+                rates = synthetic_conditional_rates[:draft_count]
+                accepted[start_idx:end_idx] = uniform_probs[start_idx:end_idx] < rates
+        target_argmax = torch.where(accepted, draft_token_ids, target_argmax)
+        mismatch_global = ~accepted
+    else:
+        mismatch_global = draft_token_ids != target_argmax
     if max_spec_len == 0:
         first_mismatch_pos_per_req = torch.zeros(
             batch_size, dtype=torch.long, device=device
@@ -533,7 +788,9 @@ def rejection_random_sample_pytorch(
     is_greedy,  # [batch_size]
     max_spec_len,
     vocab_size,
+    synthetic_conditional_rates=None,  # [num_speculative_tokens] or None
     IS_NGRAM=False,
+    SYNTHETIC_MODE=False,
 ):
     batch_size = output_token_ids.shape[0]
 

--- a/vllm_kunlun/v1/sample/spec_decode/dflash.py
+++ b/vllm_kunlun/v1/sample/spec_decode/dflash.py
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from __future__ import annotations
+
+import torch
+from vllm.v1.spec_decode.eagle import EagleProposer
+
+
+class DFlashProposer(EagleProposer):
+    """Minimal DFlash proposer backport for vLLM 0.15.1.
+
+    This keeps the DFlash method on the EAGLE-style speculative decoding path
+    while avoiding the upstream Triton DFlash input expansion kernel. The full
+    DFlash parallel-drafting path can be layered on top once the 0.15.1 runner
+    has all upstream #36847 state fields.
+    """
+
+    def __init__(self, vllm_config, device: torch.device, runner=None):
+        super().__init__(vllm_config, device, runner=runner)
+        self.parallel_drafting_hidden_state_tensor = None
+
+    def _raise_if_multimodal(self):
+        # DFlash targets Qwen3/Qwen3.5 style models. Keep multimodal checks
+        # permissive to match upstream DFlash; actual multimodal behavior is
+        # still guarded by model support.
+        pass
+
+    def model_returns_tuple(self) -> bool:
+        return True
+
+    def _get_eagle3_use_aux_hidden_state_from_config(self) -> bool:
+        dflash_config = getattr(
+            self.draft_model_config.hf_config, "dflash_config", None
+        )
+        if dflash_config is not None:
+            return dflash_config.get("use_aux_hidden_state", True)
+        eagle_config = getattr(self.draft_model_config.hf_config, "eagle_config", None)
+        if eagle_config is not None:
+            return eagle_config.get("use_aux_hidden_state", True)
+        return True
+
+
+def copy_and_expand_dflash_inputs_native(
+    next_token_ids: torch.Tensor,
+    target_positions: torch.Tensor,
+    query_start_loc: torch.Tensor,
+    block_table: torch.Tensor,
+    block_size: int,
+    num_speculative_tokens: int,
+    parallel_drafting_token_id: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Native Torch fallback for DFlash query input expansion.
+
+    Returns (input_ids, query_positions, query_slot_mapping) for a batch with
+    one bonus token followed by num_speculative_tokens mask tokens per request.
+    """
+    batch_size = next_token_ids.shape[0]
+    num_query_per_req = num_speculative_tokens + 1
+    device = next_token_ids.device
+    offsets = torch.arange(
+        num_query_per_req, device=device, dtype=target_positions.dtype
+    )
+    last_indices = query_start_loc[1:].to(torch.long) - 1
+    last_positions = target_positions[last_indices]
+    query_positions = (last_positions[:, None] + 1 + offsets[None, :]).reshape(-1)
+    input_ids = torch.full(
+        (batch_size, num_query_per_req),
+        int(parallel_drafting_token_id),
+        dtype=next_token_ids.dtype,
+        device=device,
+    )
+    input_ids[:, 0] = next_token_ids
+    input_ids = input_ids.reshape(-1)
+    block_numbers = query_positions // block_size
+    block_ids = block_table.gather(1, block_numbers.to(torch.long).view(batch_size, -1))
+    query_slot_mapping = (
+        block_ids * block_size + query_positions.view(batch_size, -1) % block_size
+    ).reshape(-1)
+    return input_ids, query_positions, query_slot_mapping

--- a/vllm_kunlun/v1/worker/block_table.py
+++ b/vllm_kunlun/v1/worker/block_table.py
@@ -3,9 +3,12 @@
 """Kunlun-specific monkey-patch for ``vllm.v1.worker.block_table``.
 
 Replaces ``BlockTable.compute_slot_mapping`` (which dispatches a Triton
-kernel ``_compute_slot_mapping_kernel`` upstream) with a torch-native
-equivalent. Kunlun XPU cannot JIT-compile Triton kernels via the CUDA
-driver path.
+kernel ``_compute_slot_mapping_kernel`` upstream) with the native Kunlun
+XPU op ``kunlun_ops.compute_slot_mappings``. Kunlun XPU cannot JIT-compile
+Triton kernels via the CUDA driver path; the previous torch-native fallback
+relied on ``torch.searchsorted``, which has no Kunlun XPU implementation and
+silently falls back to CPU (host sync + D2H/H2D round trip every step). The
+native op computes the whole mapping on-device in a single launch.
 
 Triggering: imported from ``vllm_kunlun.__init__`` post-import hook
 once ``vllm.v1.worker.block_table`` is loaded. Idempotent under fork()
@@ -14,6 +17,7 @@ and re-import via the ``_kunlun_slot_patched`` flag on the class.
 
 import logging
 
+import kunlun_ops
 import torch
 from vllm.v1.worker.block_table import PAD_SLOT_ID
 from vllm.v1.worker.block_table import BlockTable as _upstream_cls
@@ -23,57 +27,88 @@ logger = logging.getLogger("vllm_kunlun")
 
 def _compute_slot_mapping(self, num_reqs, query_start_loc, positions):
     num_tokens = positions.shape[0]
-    max_num_tokens = self.max_num_batched_tokens
-    block_size = self.block_size
-    slot_mapping = self.slot_mapping.gpu
-    block_table = self.block_table.gpu
-    total_cp = self.pcp_world_size * self.dcp_world_size
-
-    # Common case: no context parallelism. Pure torch index path.
-    if total_cp == 1:
-        if num_tokens > 0:
-            pos = positions[:num_tokens].to(torch.int64)
-            # Per-token req index: search query_start_loc.
-            qsl = query_start_loc[: num_reqs + 1].to(torch.int64)
-            token_arange = torch.arange(
-                num_tokens, device=pos.device, dtype=torch.int64
-            )
-            # req_idx[t] = number of starts <= t, minus 1.
-            req_idx = (torch.searchsorted(qsl, token_arange, right=True) - 1).clamp_(
-                min=0, max=num_reqs - 1
-            )
-            block_idx = pos // block_size
-            offset = pos - block_idx * block_size
-            block_num = block_table[req_idx, block_idx].to(torch.int64)
-            slot_mapping[:num_tokens] = block_num * block_size + offset
-        if max_num_tokens > num_tokens:
-            slot_mapping[num_tokens:max_num_tokens] = PAD_SLOT_ID
-        return
-
-    # CP path: fall back to per-req loop on host.
+    total_cp_world_size = self.pcp_world_size * self.dcp_world_size
     total_cp_rank = self.pcp_rank * self.dcp_world_size + self.dcp_rank
-    cp_int = self.cp_kv_cache_interleave_size
-    virtual_block_size = block_size * total_cp
-    qsl_cpu = query_start_loc[: num_reqs + 1].cpu().tolist()
-    for r in range(num_reqs):
-        s, e = qsl_cpu[r], qsl_cpu[r + 1]
-        if e <= s:
-            continue
-        pos = positions[s:e].to(torch.int64)
-        block_indices = pos // virtual_block_size
-        block_numbers = block_table[r, block_indices].to(torch.int64)
-        virtual_off = pos - block_indices * virtual_block_size
-        is_local = (virtual_off // cp_int) % total_cp == total_cp_rank
-        local_off = (virtual_off // (total_cp * cp_int)) * cp_int + (
-            virtual_off % cp_int
-        )
-        slot = block_numbers * block_size + local_off
-        slot_mapping[s:e] = torch.where(
-            is_local, slot, torch.full_like(slot, PAD_SLOT_ID)
-        )
-    if max_num_tokens > num_tokens:
-        slot_mapping[num_tokens:max_num_tokens] = PAD_SLOT_ID
+    block_sizes = torch.tensor(
+        [self.block_size], dtype=torch.int32, device=self.block_table.gpu.device
+    )
+    kunlun_ops.compute_slot_mappings(
+        [self.slot_mapping.gpu],  # list
+        [self.block_table.gpu],  # list
+        positions,
+        query_start_loc,
+        block_sizes,  # int32 tensor
+        num_reqs,
+        num_tokens,
+        PAD_SLOT_ID,
+        total_cp_world_size,
+        total_cp_rank,
+        self.cp_kv_cache_interleave_size,
+    )
 
+
+# def _compute_slot_mapping(self, num_reqs, query_start_loc, positions):
+#     num_tokens = positions.shape[0]
+#     max_num_tokens = self.max_num_batched_tokens
+#     block_size = self.block_size
+#     # CPU mirrors maintained by CpuGpuBuffer. block_table.np is kept in
+#     # sync via commit_block_table (CPU->GPU H2D each step), so reading
+#     # from it here observes the same data the upstream Triton kernel
+#     # would have read from block_table.gpu.
+#     block_table_np = self.block_table.np
+#     slot_mapping_np = self.slot_mapping.np
+#     total_cp = self.pcp_world_size * self.dcp_world_size
+
+#     # Common case: no context parallelism. Pure NumPy path.
+#     if total_cp == 1:
+#         if num_tokens > 0:
+#             # One D2H sync for two small tensors:
+#             #   positions: int64[num_tokens] (<= 64 KB at max_num_batched_tokens=8192)
+#             #   qsl:       int32[num_reqs+1]
+#             pos_np = positions[:num_tokens].cpu().numpy()
+#             qsl_np = query_start_loc[: num_reqs + 1].cpu().numpy()
+#             # Per-token req index via searchsorted (matches the Triton
+#             # kernel's behavior).
+#             token_arange = np.arange(num_tokens, dtype=qsl_np.dtype)
+#             req_idx = np.searchsorted(qsl_np, token_arange, side="right") - 1
+#             np.clip(req_idx, 0, num_reqs - 1, out=req_idx)
+#             block_idx = pos_np // block_size
+#             offset = pos_np - block_idx * block_size
+#             block_num = block_table_np[req_idx, block_idx].astype(np.int64)
+#             np.add(
+#                 block_num * block_size,
+#                 offset,
+#                 out=slot_mapping_np[:num_tokens],
+#             )
+#         if max_num_tokens > num_tokens:
+#             slot_mapping_np[num_tokens:max_num_tokens] = PAD_SLOT_ID
+#         # H2D the prepared slot_mapping in one shot.
+#         self.slot_mapping.copy_to_gpu()
+#         return
+
+#     # CP path: per-req loop on host, also in NumPy.
+#     total_cp_rank = self.pcp_rank * self.dcp_world_size + self.dcp_rank
+#     cp_int = self.cp_kv_cache_interleave_size
+#     virtual_block_size = block_size * total_cp
+#     qsl_np = query_start_loc[: num_reqs + 1].cpu().numpy()
+#     pos_np = positions[:num_tokens].cpu().numpy() if num_tokens > 0 else None
+#     for r in range(num_reqs):
+#         s, e = int(qsl_np[r]), int(qsl_np[r + 1])
+#         if e <= s:
+#             continue
+#         pos = pos_np[s:e]
+#         block_indices = pos // virtual_block_size
+#         block_numbers = block_table_np[r, block_indices].astype(np.int64)
+#         virtual_off = pos - block_indices * virtual_block_size
+#         is_local = (virtual_off // cp_int) % total_cp == total_cp_rank
+#         local_off = (virtual_off // (total_cp * cp_int)) * cp_int + (
+#             virtual_off % cp_int
+#         )
+#         slot = block_numbers * block_size + local_off
+#         slot_mapping_np[s:e] = np.where(is_local, slot, PAD_SLOT_ID)
+#     if max_num_tokens > num_tokens:
+#         slot_mapping_np[num_tokens:max_num_tokens] = PAD_SLOT_ID
+#     self.slot_mapping.copy_to_gpu()
 
 # Idempotent monkey-patch: safe under fork() and re-import.
 if not getattr(_upstream_cls, "_kunlun_slot_patched", False):

--- a/vllm_kunlun/v1/worker/mamba_utils.py
+++ b/vllm_kunlun/v1/worker/mamba_utils.py
@@ -1,0 +1,395 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import dataclasses
+import itertools
+from collections.abc import Callable
+from math import prod
+from typing import Any
+
+import torch
+from vllm.config import CacheConfig
+from vllm.model_executor.layers.mamba.mamba_utils import MambaStateCopyFunc
+from vllm.triton_utils import tl, triton
+from vllm.utils.math_utils import cdiv
+from vllm.utils.torch_utils import get_dtype_size
+from vllm.v1.core.sched.output import SchedulerOutput
+from vllm.v1.kv_cache_interface import AttentionSpec, KVCacheConfig, MambaSpec
+from vllm.v1.utils import CpuGpuBuffer
+from vllm.v1.worker.gpu_input_batch import CachedRequestState
+from vllm.v1.worker.lora_model_runner_mixin import GPUInputBatch
+
+
+@triton.jit
+def batch_memcpy_kernel(src_ptrs, dst_ptrs, sizes, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(0)
+
+    src_ptr = tl.load(src_ptrs + pid)
+    dst_ptr = tl.load(dst_ptrs + pid)
+    size = tl.load(sizes + pid)
+
+    offsets = tl.arange(0, BLOCK_SIZE)
+    for i in range(0, size, BLOCK_SIZE):
+        mask = (i + offsets) < size
+
+        curr_src_ptr = (src_ptr + i + offsets).to(tl.pointer_type(tl.uint8))
+        curr_dst_ptr = (dst_ptr + i + offsets).to(tl.pointer_type(tl.uint8))
+
+        data = tl.load(curr_src_ptr, mask=mask)
+        tl.store(curr_dst_ptr, data, mask=mask)
+
+
+def batch_memcpy(src_ptrs, dst_ptrs, sizes):
+    batch = src_ptrs.shape[0]
+    assert dst_ptrs.shape[0] == batch
+    assert sizes.shape[0] == batch
+    torch.ops.xspeedgate_ops.batch_memcpy(src_ptrs, dst_ptrs, sizes)
+
+
+#     grid = (batch,)
+#     BLOCK_SIZE = 1024
+#     batch_memcpy_kernel[grid](src_ptrs, dst_ptrs, sizes, BLOCK_SIZE=BLOCK_SIZE)
+
+# def _make_uint8_view_from_ptr(ptr: int, size: int, device: torch.device) -> torch.Tensor:
+#    storage = torch._C._construct_storage_from_data_pointer(ptr, device, size)
+#    tensor = torch.empty(0, dtype=torch.uint8, device=device)
+#    return tensor.set_(storage, 0, (size,), (1,))
+
+
+# def batch_memcpy(src_ptrs, dst_ptrs, sizes):
+#    batch = src_ptrs.shape[0]
+#    assert dst_ptrs.shape[0] == batch
+#    assert sizes.shape[0] == batch
+#    if batch == 0:
+#        return
+#
+#    device = src_ptrs.device
+#    src_ptrs_cpu = src_ptrs.detach().cpu().tolist()
+#    dst_ptrs_cpu = dst_ptrs.detach().cpu().tolist()
+#    sizes_cpu = sizes.detach().cpu().tolist()
+#
+#    for src_ptr, dst_ptr, size in zip(src_ptrs_cpu, dst_ptrs_cpu, sizes_cpu):
+#        if size <= 0 or src_ptr == dst_ptr:
+#            continue
+#        src = _make_uint8_view_from_ptr(src_ptr, size, device)
+#        dst = _make_uint8_view_from_ptr(dst_ptr, size, device)
+#        dst.copy_(src, non_blocking=True)
+
+
+def get_mamba_groups(kv_cache_config: KVCacheConfig) -> tuple[list[int], MambaSpec]:
+    mamba_group_ids: list[int] = []
+    mamba_specs: list[MambaSpec] = []
+    for i in range(len(kv_cache_config.kv_cache_groups)):
+        kv_cache_spec = kv_cache_config.kv_cache_groups[i].kv_cache_spec
+        if isinstance(kv_cache_spec, MambaSpec):
+            mamba_group_ids.append(i)
+            mamba_specs.append(kv_cache_spec)
+    assert len(mamba_group_ids) > 0, "no mamba layers in the model"
+    assert all(mamba_specs[0] == spec for spec in mamba_specs)
+    return mamba_group_ids, mamba_specs[0]
+
+
+@dataclasses.dataclass
+class MambaCopyBuffers:
+    src_ptrs: CpuGpuBuffer
+    dst_ptrs: CpuGpuBuffer
+    sizes: CpuGpuBuffer
+    mamba_group_ids: list[int]
+    mamba_spec: MambaSpec
+    offset: int = 0
+
+    @classmethod
+    def create(
+        cls,
+        max_num_reqs: int,
+        kv_cache_config: KVCacheConfig,
+        copy_funcs: tuple[MambaStateCopyFunc, ...],
+        make_buffer: Callable[..., CpuGpuBuffer],
+    ) -> "MambaCopyBuffers":
+        mamba_group_ids, mamba_spec = get_mamba_groups(kv_cache_config)
+        entries_per_req = sum(
+            len(kv_cache_config.kv_cache_groups[gid].layer_names)
+            for gid in mamba_group_ids
+        ) * len(copy_funcs)
+        n = max_num_reqs * entries_per_req
+        return cls(
+            src_ptrs=make_buffer(n, dtype=torch.int64),
+            dst_ptrs=make_buffer(n, dtype=torch.int64),
+            sizes=make_buffer(n, dtype=torch.int64),
+            mamba_group_ids=mamba_group_ids,
+            mamba_spec=mamba_spec,
+        )
+
+
+def collect_mamba_copy_meta(
+    copy_bufs: MambaCopyBuffers,
+    kv_cache_config: KVCacheConfig,
+    mamba_state_copy_funcs: tuple[MambaStateCopyFunc, ...],
+    mamba_group_ids: list[int],
+    src_block_idx: int,
+    dest_block_idx: int,
+    accept_token_bias: int,
+    req_state: CachedRequestState,
+    forward_context: dict[str, Any],
+) -> None:
+    if src_block_idx == dest_block_idx and accept_token_bias == 0:
+        return
+
+    src_ptrs_np = copy_bufs.src_ptrs.np
+    dst_ptrs_np = copy_bufs.dst_ptrs.np
+    sizes_np = copy_bufs.sizes.np
+    offset = copy_bufs.offset
+
+    for mamba_group_id in mamba_group_ids:
+        block_ids = req_state.block_ids[mamba_group_id]
+        dest_block_id = block_ids[dest_block_idx]
+        layer_names = kv_cache_config.kv_cache_groups[mamba_group_id].layer_names
+        for layer_name in layer_names:
+            attention = forward_context[layer_name]
+            kv_caches: list[torch.Tensor] = attention.kv_cache
+            for state, state_copy_func in zip(kv_caches, mamba_state_copy_funcs):
+                copy_spec = state_copy_func(
+                    state, block_ids, src_block_idx, accept_token_bias + 1
+                )
+
+                src_ptrs_np[offset] = copy_spec.start_addr
+                dst_ptrs_np[offset] = state[dest_block_id].data_ptr()
+                sizes_np[offset] = copy_spec.num_elements * state.element_size()
+                offset += 1
+
+    copy_bufs.offset = offset
+
+
+def do_mamba_copy_block(copy_bufs: MambaCopyBuffers):
+    n = copy_bufs.offset
+    if n == 0:
+        return
+    batch_memcpy(
+        copy_bufs.src_ptrs.copy_to_gpu(n),
+        copy_bufs.dst_ptrs.copy_to_gpu(n),
+        copy_bufs.sizes.copy_to_gpu(n),
+    )
+
+
+def preprocess_mamba(
+    scheduler_output: SchedulerOutput,
+    kv_cache_config: KVCacheConfig,
+    cache_config: CacheConfig,
+    mamba_state_idx: dict[str, int],
+    input_batch: GPUInputBatch,
+    requests: dict[str, CachedRequestState],
+    forward_context: dict[str, Any],
+    mamba_state_copy_funcs: tuple[MambaStateCopyFunc, ...],
+    copy_bufs: MambaCopyBuffers,
+):
+    """
+    Copy the mamba state of previous step to the last
+    (1 + num_speculative_blocks) block.
+    """
+    mamba_group_ids = copy_bufs.mamba_group_ids
+    mamba_spec = copy_bufs.mamba_spec
+    num_speculative_blocks = mamba_spec.num_speculative_blocks
+    # TODO(Chen): we need to optimize this function a lot
+    assert cache_config.enable_prefix_caching
+    block_size = mamba_spec.block_size
+    finished_req_ids = scheduler_output.finished_req_ids
+    preempted_req_ids = scheduler_output.preempted_req_ids or set()
+    # We need to clear mamba_state_idx for resumed requests. When requests are
+    # force-preempted (e.g., during reset_prefix_cache / KV cache flush),
+    # they appear in resumed_req_ids without a corresponding entry in
+    # preempted_req_ids, leaving stale mamba_state_idx entries that can
+    # point to block indices beyond the new (smaller) block allocation.
+    resumed_req_ids = scheduler_output.scheduled_cached_reqs.resumed_req_ids
+    for req_id in itertools.chain(finished_req_ids, preempted_req_ids, resumed_req_ids):
+        mamba_state_idx.pop(req_id, None)
+
+    copy_bufs.offset = 0
+    for i, req_id in enumerate(input_batch.req_ids):
+        req_state = requests[req_id]
+        prev_state_idx = mamba_state_idx.get(req_id)
+        if prev_state_idx is None:
+            # new / resumed request, no previous state
+            # if num_computed_tokens is 0, prev_state_idx will be -1
+            prev_state_idx = (req_state.num_computed_tokens - 1) // block_size
+
+        num_scheduled_tokens = scheduler_output.num_scheduled_tokens[req_id]
+        num_blocks: int = (
+            cdiv(req_state.num_computed_tokens + num_scheduled_tokens, block_size)
+            + num_speculative_blocks
+        )
+
+        # We always save the current running state at the last
+        # (1 + num_speculative_blocks) block.
+        # A corner case worth mention here: assume we have block_size = 4 and
+        # num_speculative_tokens = 2. The request is [A, B, C] and contains 2 draft
+        # tokens [draft 1, draft 2]. Then we will have:
+        # Block 0: [A, B, C, draft 1]
+        # Block 1: [draft 2, TOFILL, TOFILL, TOFILL]
+        # Block 2: speculative block
+        # Block 3: speculative block
+        # And use block 1 to save the running state.
+        curr_state_idx = num_blocks - 1 - num_speculative_blocks
+        mamba_state_idx[req_id] = curr_state_idx
+        if prev_state_idx != -1 and prev_state_idx != curr_state_idx:
+            collect_mamba_copy_meta(
+                copy_bufs,
+                kv_cache_config,
+                mamba_state_copy_funcs,
+                mamba_group_ids,
+                prev_state_idx,
+                curr_state_idx,
+                input_batch.num_accepted_tokens_cpu[i] - 1,
+                req_state,
+                forward_context,
+            )
+            input_batch.num_accepted_tokens_cpu[i] = 1
+    do_mamba_copy_block(copy_bufs)
+
+
+@dataclasses.dataclass
+class MambaBuffers:
+    """Single owner for all mamba-specific runner buffers.
+
+    On Kunlun XPU, speculative decoding with hybrid models is not supported,
+    so postprocess_align is always None.
+    """
+
+    preprocess: MambaCopyBuffers
+    # TODO(kunlun): MambaSpecDecodeGPUContext is not implemented on Kunlun XPU.
+    # postprocess_align is required when running speculative decoding on a hybrid
+    # model (e.g. DeepSeek V4 flash). When that use case is needed, implement
+    # MambaSpecDecodeGPUContext in this file (referencing vllm 0.25.1 upstream)
+    # and replace the None stub below.
+    postprocess_align: None = None
+
+    @classmethod
+    def create(
+        cls,
+        max_num_reqs: int,
+        kv_cache_config: KVCacheConfig,
+        copy_funcs: tuple[MambaStateCopyFunc, ...],
+        make_buffer: Callable[..., CpuGpuBuffer],
+        device=None,
+        with_postprocess_align: bool = False,
+    ) -> "MambaBuffers":
+        if with_postprocess_align:
+            # TODO(kunlun): implement MambaSpecDecodeGPUContext for spec-decode
+            # + hybrid model support (e.g. DeepSeek V4 flash).
+            raise NotImplementedError(
+                "Speculative decoding on hybrid Mamba models is not yet "
+                "supported on Kunlun XPU. Need to implement "
+                "MambaSpecDecodeGPUContext."
+            )
+        return cls(
+            preprocess=MambaCopyBuffers.create(
+                max_num_reqs, kv_cache_config, copy_funcs, make_buffer
+            ),
+            postprocess_align=None,
+        )
+
+
+def get_hybrid_attention_mamba_layout(
+    kv_cache_shape: tuple[int, ...],
+    kv_cache_stride: tuple[int, ...],
+    kv_cache_spec: AttentionSpec,
+    block_dim: int,
+    layer_idx: int,
+    kernel_block_size: int,
+) -> tuple[tuple[int, ...], int]:
+    """
+    Compute the stride and storage offset for the hybrid attention+mamba layout.
+
+    Args:
+        kv_cache_shape: The shape of the KV cache tensor.
+        kv_cache_stride: The stride of the KV cache tensor.
+        kv_cache_spec: The specification of the KV cache.
+        layer_idx: The index of the layer.
+        kernel_num_blocks: The number of kernel blocks.
+        kernel_block_size: The size of the kernel block.
+    Returns:
+        A tuple containing the target stride and storage offset.
+    """
+    target_stride_list = list(kv_cache_stride)
+    storage_offset = 0
+
+    attn_pack_size = kv_cache_spec.pack_size
+    # block_dim: 0 means (num_blocks, 2, ...); 1 means (2, num_blocks, ...).
+    if block_dim != 0:
+        # Hybrid attention+mamba uses (2, num_blocks, ...) logical shape but
+        # (num_blocks, 2, ...) physical layout.
+        assert kv_cache_shape[0] == 2, (
+            "Fail to determine whether the layout is "
+            "(2, num_blocks, ...) or (num_blocks, 2, ...) for "
+            f"a tensor of shape {kv_cache_shape}"
+        )
+        assert block_dim == 1
+        hidden_size = prod(kv_cache_shape[2:])
+        target_stride_list[0] = hidden_size
+        target_stride_list[1] = 2 * hidden_size
+    # When multiple attention layers share one physical KV cache block
+    # (attn_pack_size > 1), scale the block-dim stride by attn_pack_size
+    # and compute this layer's element offset within the shared block.
+    if attn_pack_size > 1:
+        target_stride_list[block_dim] *= attn_pack_size
+        dtype_size = get_dtype_size(kv_cache_spec.dtype)
+        num_element_per_page = kv_cache_spec.page_size_bytes // dtype_size
+        num_blocks_per_kv_block = kv_cache_spec.block_size // kernel_block_size
+        num_element_per_attn_pack = (
+            num_element_per_page // num_blocks_per_kv_block // attn_pack_size
+        )
+        attn_pack_idx = layer_idx % attn_pack_size
+        storage_offset = attn_pack_idx * num_element_per_attn_pack
+    return tuple(target_stride_list), storage_offset
+
+
+def postprocess_mamba(
+    scheduler_output: SchedulerOutput,
+    kv_cache_config: KVCacheConfig,
+    input_batch: GPUInputBatch,
+    requests: dict[str, CachedRequestState],
+    mamba_state_idx: dict[str, int],
+    forward_context: dict[str, Any],
+    mamba_state_copy_funcs: tuple[MambaStateCopyFunc, ...],
+    copy_bufs: MambaCopyBuffers,
+):
+    """
+    If a blocks is converted from partial block to full block in this step, copy the
+    state from the block for running state to the new full block.
+    """
+    num_scheduled_tokens_dict = scheduler_output.num_scheduled_tokens
+    scheduled_spec_decode_tokens_dict = scheduler_output.scheduled_spec_decode_tokens
+    num_accepted_tokens_cpu = input_batch.num_accepted_tokens_cpu
+    mamba_group_ids = copy_bufs.mamba_group_ids
+    mamba_spec = copy_bufs.mamba_spec
+    copy_bufs.offset = 0
+    for i, req_id in enumerate(input_batch.req_ids):
+        req_state = requests[req_id]
+        num_computed_tokens = req_state.num_computed_tokens
+        num_draft_tokens = len(scheduled_spec_decode_tokens_dict.get(req_id, []))
+        num_scheduled_tokens = num_scheduled_tokens_dict[req_id]
+        num_accepted_tokens = num_accepted_tokens_cpu[i]
+        num_tokens_running_state = (
+            num_computed_tokens + num_scheduled_tokens - num_draft_tokens
+        )
+        new_num_computed_tokens = num_tokens_running_state + num_accepted_tokens - 1
+        aligned_new_computed_tokens = (
+            new_num_computed_tokens // mamba_spec.block_size * mamba_spec.block_size
+        )
+        # TODO: how to ensure all blocks that cache_blocks called are cached here?
+        if aligned_new_computed_tokens >= num_tokens_running_state:
+            accept_token_bias = aligned_new_computed_tokens - num_tokens_running_state
+            src_block_idx = mamba_state_idx[req_id]
+            dest_block_idx = aligned_new_computed_tokens // mamba_spec.block_size - 1
+            collect_mamba_copy_meta(
+                copy_bufs,
+                kv_cache_config,
+                mamba_state_copy_funcs,
+                mamba_group_ids,
+                src_block_idx,
+                dest_block_idx,
+                accept_token_bias,
+                req_state,
+                forward_context,
+            )
+            if src_block_idx == dest_block_idx:
+                num_accepted_tokens_cpu[i] = 1
+    do_mamba_copy_block(copy_bufs)


### PR DESCRIPTION
## Summary
- Add Qwen3.6 35B support for vLLM 0.25.1 on Kunlun.
- Sync model, sampling, quantization, and worker updates from the standalone vllm-kunlun 0.25.1 plugin.
- Add native op fallbacks and Torch 2.5.1 compatibility patch.

## service.sh

unset XPU_DUMMY_EVENT
export XPU_VISIBLE_DEVICES=4,5
export CUDA_VISIBLE_DEVICES=4,5
export XFT_USE_FAST_SWIGLU=1
export XMLIR_CUDNN_ENABLED=1
export XMLIR_ENABLE_FAST_FC=true
export XPUAPI_SDNN_BF16_ROUND_MODE=3
export XPU_USE_MOE_SORTED_THRES=1
export XPU_USE_DEFAULT_CTX=1
export XMLIR_FORCE_USE_XPU_GRAPH=1
export XPU_USE_FAST_SWIGLU=1
export XPU_FLASH_ATTENTION_DECODER_USE_NEW_IMPL=1
export XPU_SET_RECURRENT_GATED_DELTA_RULE_FWDV2_FP16_FAST_OPT=3

nohup vllm serve /data/Qwen3.6-35B-A3B \
    --dtype float16 \
    --tensor-parallel-size 2 \
    --trust-remote-code \
    --max-model-len 65536 \
    --max-num-seqs 128 \
    --max-num-batched-tokens 65536 \
    --block-size 128 \
    --distributed-executor-backend mp \
    --port 8998 \
    --host 0.0.0.0 \
    --served-model-name Qwen3.6-35B-A3B \
    --gpu-memory-utilization 0.9 \
    --reasoning-parser qwen3 \
    --enable-auto-tool-choice \
    --tool-call-parser qwen3_coder \
    --enable-force-include-usage \
    --mamba-ssm-cache-dtype float16 \
    --skip-mm-profiling \
    > server.log 2>&1 &
