### PR TITLE
[Build] Unify version source and bump to 0.25.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "vllm-kunlun"
-version = "0.21.0.dev0"
+dynamic = ["version"]
 description = "vLLM Kunlun3 backend plugin"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -22,6 +22,9 @@ kunlun = "vllm_kunlun:register"
 kunlun_model = "vllm_kunlun:register_model"
 kunlun_reasoning_parser = "vllm_kunlun:register_reasoning_parser"
 kunlun_tool_parser = "vllm_kunlun:register_tool_parser"
+
+[tool.hatch.version]
+path = "vllm_kunlun/platforms/version.py"
 
 [tool.hatch.build]
 packages = ["vllm_kunlun"]

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@
 #
 
 import os
+import re
 import shutil
 
 from setuptools import find_packages, setup
@@ -13,10 +14,16 @@ ROOT_DIR = os.path.dirname(__file__)
 
 def get_version():
     version_file = os.path.join(ROOT_DIR, "vllm_kunlun", "platforms", "version.py")
-    ns = {}
-    with open(version_file) as f:
-        exec(f.read(), ns)
-    return ns["__version__"]
+    with open(version_file, encoding="utf-8") as f:
+        content = f.read()
+    m = re.search(
+        r"^__version__\s*=\s*['\"]([^'\"]+)['\"]\s*$",
+        content,
+        flags=re.MULTILINE,
+    )
+    if not m:
+        raise RuntimeError(f"Unable to find __version__ in {version_file}")
+    return m.group(1)
 
 ext_modules = [
     CppExtension(

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ def get_version():
         raise RuntimeError(f"Unable to find __version__ in {version_file}")
     return m.group(1)
 
+
 ext_modules = [
     CppExtension(
         name="vllm_kunlun._kunlun",

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,14 @@ from torch.utils.cpp_extension import BuildExtension, CppExtension
 
 ROOT_DIR = os.path.dirname(__file__)
 
+
+def get_version():
+    version_file = os.path.join(ROOT_DIR, "vllm_kunlun", "platforms", "version.py")
+    ns = {}
+    with open(version_file) as f:
+        exec(f.read(), ns)
+    return ns["__version__"]
+
 ext_modules = [
     CppExtension(
         name="vllm_kunlun._kunlun",
@@ -42,7 +50,7 @@ if __name__ == "__main__":
 
     setup(
         name="vllm_kunlun",
-        version="0.21.0",
+        version=get_version(),
         author="vLLM-Kunlun team",
         license="Apache 2.0",
         description="vLLM Kunlun3 backend plugin",

--- a/vllm_kunlun/platforms/version.py
+++ b/vllm_kunlun/platforms/version.py
@@ -1,10 +1,3 @@
-"""vllm_kunlun version.py"""
+"""vllm_kunlun version."""
 
-vllm_version = "0.15.1"
-
-xvllm_version_tuple = (0, 15, 1)
-
-
-def get_xvllm_version():
-    major, minor, patch = xvllm_version_tuple
-    return f"{major}.{minor}.{patch}"
+__version__ = "0.25.1"


### PR DESCRIPTION
## Summary
Fixes the version-number inconsistency where the package always reported
0.21.0.dev0 regardless of edits to setup.py.

Root cause: with modern setuptools (PEP 621), the static `version` in
`pyproject.toml` overrides the `version=` passed to `setup()`. The value
in setup.py (0.21.0) was therefore dead, and the internal
`platforms/version.py` (0.15.1) was stale and unreferenced.

## Changes
- Single source of truth: `vllm_kunlun/platforms/version.py` now exposes
  `__version__` and is the only place to bump the version.
- `pyproject.toml`: `version` → `dynamic = ["version"]`, resolved by
  `[tool.hatch.version]` (used by `pip`/`uv`/hatchling).
- `setup.py`: reads the same file via `get_version()` (used by the legacy
  `python setup.py build/install` flow).
- Removed unused `vllm_version` / `xvllm_version_tuple` / `get_xvllm_version`
  dead code.
- Bumped version to **0.25.1** to align with `vllm==0.25.1`.

## Testing
- `python setup.py --version` → 0.25.1
- `python setup.py egg_info` → PKG-INFO `Version: 0.25.1`
- `python -m hatchling version` → 0.25.1

Both build paths now report the same version; the existing
`python setup.py build/install` flow is unchanged.

## Note for reviewers
Old installs may retain a stale `0.21.0.dev0` egg-info — uninstall/reinstall
to pick up the new version.
