### PR TITLE
[Bugfix] Fix Triton kernel CUDA_ERROR_NOT_SUPPORTED in mamba_utils and VocabParallelEmbedding on Kunlun XPU

### DIFF
--- a/vllm_kunlun/__init__.py
+++ b/vllm_kunlun/__init__.py
@@ -153,6 +153,22 @@ _register_post_import_hook(
 )
 
 
+# --- hook 3b: batch_memcpy in vllm.v1.worker.mamba_utils ------------------
+# Replace the upstream hand-written Triton kernel with xspeedgate_ops.
+def _mamba_utils_applied(mod):
+    fn = getattr(mod, "batch_memcpy", None)
+    return fn is None or getattr(mod, "_kunlun_batch_memcpy_patched", False)
+
+
+def _mamba_utils_apply(mod):
+    import vllm_kunlun.v1.worker.mamba_utils  # noqa: F401  (self-applies on import)
+
+
+_register_post_import_hook(
+    "vllm.v1.worker.mamba_utils", _mamba_utils_applied, _mamba_utils_apply
+)
+
+
 # --- hook 4: apply_grammar_bitmask in vllm.v1.structured_output.utils -----
 # Replace the upstream xgrammar auto backend with torch_native on Kunlun XPU.
 def _grammar_bitmask_applied(mod):

--- a/vllm_kunlun/__init__.py
+++ b/vllm_kunlun/__init__.py
@@ -315,8 +315,10 @@ def register():
 
     # --- import wrapper & patch utils ---
     try:
-        from .schema import direct_register_custom_op  # noqa: F401
-        from .schema import patch_annotations_for_schema  # noqa: F401
+        from .schema import (  # noqa: F401
+            direct_register_custom_op,
+            patch_annotations_for_schema,
+        )
 
         logger.info("[KunlunPlugin] vllm_utils_wrapper loaded and patched")
     except Exception:

--- a/vllm_kunlun/ops/vocab_parallel_embedding.py
+++ b/vllm_kunlun/ops/vocab_parallel_embedding.py
@@ -15,18 +15,25 @@
 # This file is a part of the vllm-kunlun project.
 #
 """
-Kunlun-optimized VocabParallelEmbedding using vLLM's CustomOp.register_oot mechanism.
+Kunlun-optimized VocabParallelEmbedding using vLLM's PluggableLayer.register_oot mechanism.
 
 Design:
-- Uses @CustomOp.register_oot to register Kunlun-optimized VocabParallelEmbedding
+- Uses @PluggableLayer.register_oot to register Kunlun-optimized VocabParallelEmbedding
 - This class automatically replaces the default implementation when instantiated
-- Since KunlunPlatform uses _enum=PlatformEnum.OOT, dispatch_forward() selects
-  forward_oot, so we implement forward_oot
 
 OOT Mechanism:
-- When code calls VocabParallelEmbedding(...), vLLM's CustomOp.__new__ checks op_registry_oot
+- When code calls VocabParallelEmbedding(...), vLLM's PluggableLayer.__new__ checks
+  op_registry_oot
 - If "VocabParallelEmbedding" is found in OOT registry, it returns KunlunVocabParallelEmbedding instance
 - This is the official vLLM way to replace operators without modifying source code
+
+NOTE:
+- VocabParallelEmbedding inherits from PluggableLayer, not CustomOp. PluggableLayer
+  only swaps the instantiated class via __new__; it has no forward_native/forward_oot
+  dispatch (that mechanism is specific to CustomOp). So forward() must be overridden
+  directly here -- defining forward_oot() (the CustomOp convention) is never called
+  and silently falls back to the base class's forward(), which triggers vLLM's
+  torch.compile'd get_masked_input_and_mask and can fail on Kunlun XPU.
 """
 
 import logging
@@ -34,7 +41,7 @@ import logging
 import torch
 import xspeedgate_ops  # noqa
 from vllm.distributed import tensor_model_parallel_all_reduce
-from vllm.model_executor.custom_op import CustomOp
+from vllm.model_executor.custom_op import PluggableLayer
 from vllm.model_executor.layers.vocab_parallel_embedding import VocabParallelEmbedding
 
 logger = logging.getLogger("vllm_kunlun.ops.vocab_parallel_embedding")
@@ -72,14 +79,15 @@ def get_masked_input_and_mask(
 # =============================================================================
 
 
-@CustomOp.register_oot(name="VocabParallelEmbedding")
+@PluggableLayer.register_oot(name="VocabParallelEmbedding")
 class KunlunVocabParallelEmbedding(VocabParallelEmbedding):
     """
     Kunlun-optimized VocabParallelEmbedding registered via OOT mechanism.
 
     This class replaces the default VocabParallelEmbedding when instantiated through
-    vLLM's CustomOp registry. When code calls VocabParallelEmbedding(...), vLLM's
-    CustomOp.__new__ checks op_registry_oot and returns KunlunVocabParallelEmbedding instance.
+    vLLM's PluggableLayer registry. When code calls VocabParallelEmbedding(...), vLLM's
+    PluggableLayer.__new__ checks op_registry_oot and returns KunlunVocabParallelEmbedding
+    instance.
     """
 
     def __init__(self, *args, **kwargs):
@@ -91,8 +99,14 @@ class KunlunVocabParallelEmbedding(VocabParallelEmbedding):
             )
             _oot_vocab_embedding_init_logged = True
 
-    def forward_oot(self, input_):
-        """Kunlun-optimized forward_oot implementation."""
+    def forward(self, input_):
+        """Kunlun-optimized forward implementation.
+
+        VocabParallelEmbedding derives from PluggableLayer, which has no
+        forward_native/forward_oot dispatch (that mechanism only exists on
+        CustomOp). forward() must be overridden directly, or this
+        implementation is never invoked.
+        """
         if self.tp_size > 1:
             # Build the mask using compiled function
             masked_input, input_mask = get_masked_input_and_mask(
@@ -120,5 +134,5 @@ class KunlunVocabParallelEmbedding(VocabParallelEmbedding):
 
 # Log that OOT registration is complete
 logger.info(
-    "[KunlunOOT] Registered KunlunVocabParallelEmbedding via CustomOp.register_oot"
+    "[KunlunOOT] Registered KunlunVocabParallelEmbedding via PluggableLayer.register_oot"
 )

--- a/vllm_kunlun/v1/worker/mamba_utils.py
+++ b/vllm_kunlun/v1/worker/mamba_utils.py
@@ -1,0 +1,56 @@
+#
+# Copyright (c) 2025 Baidu, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-kunlun project.
+#
+"""Kunlun-specific monkey-patch for ``vllm.v1.worker.mamba_utils``.
+
+Replaces ``batch_memcpy`` (which dispatches a hand-written Triton kernel
+``batch_memcpy_kernel`` upstream) with the xspeedgate_ops equivalent.
+Kunlun XPU cannot JIT-compile Triton kernels via the CUDA driver path,
+so the upstream implementation raises ``CUDA_ERROR_NOT_SUPPORTED``.
+
+``batch_memcpy`` is only called from within this same upstream module
+(by ``do_mamba_copy_block``), so patching the module attribute is
+sufficient -- no other module binds the symbol into its own namespace.
+
+Triggering: imported from ``vllm_kunlun.__init__`` post-import hook
+once ``vllm.v1.worker.mamba_utils`` is loaded. Idempotent under fork()
+and re-import via the ``_kunlun_batch_memcpy_patched`` flag on the
+upstream module.
+"""
+
+import logging
+
+import torch
+from vllm.v1.worker import mamba_utils as _upstream
+
+logger = logging.getLogger("vllm_kunlun")
+
+
+def batch_memcpy(src_ptrs, dst_ptrs, sizes):
+    # Upstream allocates ``sizes`` as int32 (see ``MambaCopyBuffers.create``),
+    # but the xspeedgate_ops kernel requires int64.
+    if sizes.dtype != torch.int64:
+        sizes = sizes.to(torch.int64)
+    torch.ops.xspeedgate_ops.batch_memcpy(src_ptrs, dst_ptrs, sizes)
+
+
+if not getattr(_upstream, "_kunlun_batch_memcpy_patched", False):
+    _upstream.batch_memcpy = batch_memcpy
+    _upstream._kunlun_batch_memcpy_patched = True
+    logger.info(
+        "[KunlunPlugin] batch_memcpy patched "
+        "in vllm_kunlun/v1/worker/mamba_utils.py"
+    )

--- a/vllm_kunlun/v1/worker/mamba_utils.py
+++ b/vllm_kunlun/v1/worker/mamba_utils.py
@@ -51,6 +51,5 @@ if not getattr(_upstream, "_kunlun_batch_memcpy_patched", False):
     _upstream.batch_memcpy = batch_memcpy
     _upstream._kunlun_batch_memcpy_patched = True
     logger.info(
-        "[KunlunPlugin] batch_memcpy patched "
-        "in vllm_kunlun/v1/worker/mamba_utils.py"
+        "[KunlunPlugin] batch_memcpy patched in vllm_kunlun/v1/worker/mamba_utils.py"
     )


### PR DESCRIPTION
## PR Description

This PR contains two independent bugfixes for Triton-kernel-related failures on
Kunlun XPU, both following the existing `_POST_IMPORT_HOOKS` monkey-patch
convention used elsewhere in `vllm_kunlun` (e.g. `BlockTable.compute_slot_mapping`).

---

### Commit 1: Replace Triton `batch_memcpy` in `mamba_utils` with xspeedgate_ops kernel

**Problem:**

`vllm.v1.worker.mamba_utils.batch_memcpy` launches a hand-written
`@triton.jit` kernel (`batch_memcpy_kernel`) directly via grid-launch syntax,
completely bypassing the `torch.compile`/Inductor pipeline. Kunlun XPU cannot
JIT-compile Triton kernels via the CUDA driver path, so this raises:

```
CUDA_ERROR_NOT_SUPPORTED
```

during mamba / linear-attention (e.g. Qwen3-Next) KV cache block copies in
`do_mamba_copy_block` (called from `preprocess_mamba` / `postprocess_mamba` in
`gpu_model_runner.py`).

Because `batch_memcpy` is a plain module-level function (not a `CustomOp` /
`PluggableLayer` subclass), the existing `CustomOp.register_oot` /
`PluggableLayer.register_oot` mechanisms do not apply — those only intercept
`__new__` on registered classes.

**Fix:**

- Added `vllm_kunlun/v1/worker/mamba_utils.py`, which defines a replacement
  `batch_memcpy(src_ptrs, dst_ptrs, sizes)` backed by
  `torch.ops.xspeedgate_ops.batch_memcpy`, and monkey-patches it onto the
  upstream `vllm.v1.worker.mamba_utils` module object (idempotent via a
  `_kunlun_batch_memcpy_patched` flag).
- Registered a new post-import hook in `vllm_kunlun/__init__.py` (hook 3b),
  following the exact same pattern as hook 3 (`BlockTable.compute_slot_mapping`),
  so the patch is applied automatically once `vllm.v1.worker.mamba_utils` is
  imported.
- `gpu_model_runner.py` calls `mamba_utils.preprocess_mamba(...)` /
  `mamba_utils.postprocess_mamba(...)` via **module attribute access**
  (`from vllm.v1.worker import mamba_utils`), and `do_mamba_copy_block` looks
  up `batch_memcpy` as a module-level global at call time — so patching just
  this one attribute is sufficient. No other file needs to change, and any
  future upstream changes to other functions in `mamba_utils.py` (e.g.
  `MambaCopyBuffers`, `preprocess_mamba`) flow through untouched.
- `sizes` is allocated as `int32` upstream (see `MambaCopyBuffers.create`),
  but the `xspeedgate_ops` kernel requires `int64`; the patched function casts
  before dispatching.

**Why not a full-module replacement:**

`vllm_kunlun/__init__.py` already has a (commented-out) `_MODULE_MAPPINGS`
entry for `vllm.v1.worker.mamba_utils` that would swap in an entire
replacement module. That approach was intentionally avoided here because it
requires re-implementing/forking every function in the file and keeping it
in sync with upstream on every vLLM bump. Patching only the single function
that is actually broken minimizes maintenance surface.

**Testing:**

- Verified the post-import hook fires exactly once per process and sets
  `vllm.v1.worker.mamba_utils._kunlun_batch_memcpy_patched = True`.
- Verified `mamba_utils.batch_memcpy` resolves to the patched implementation
  after `import vllm_kunlun`, without needing to touch `gpu_model_runner.py`.
- Reproduced and fixed a follow-up `RuntimeError: batch_memcpy: sizes must be
  int64, got int` by casting `sizes` to `int64` before calling the kernel.

---

### Commit 2: Fix `KunlunVocabParallelEmbedding.forward_oot` never invoked under `PluggableLayer`

**Problem:**

`KunlunVocabParallelEmbedding` (in `vllm_kunlun/ops/vocab_parallel_embedding.py`)
was registered via `@CustomOp.register_oot(name="VocabParallelEmbedding")` and
only overrode `forward_oot()`. This convention was correct when
`vllm.model_executor.layers.vocab_parallel_embedding.VocabParallelEmbedding`
inherited from `CustomOp`, whose `forward()` dispatches per-platform to
`forward_native` / `forward_cuda` / `forward_oot` / etc. via `dispatch_forward()`.

In the current vLLM version, `VocabParallelEmbedding` inherits from
`PluggableLayer` instead of `CustomOp`. `PluggableLayer` has no
`dispatch_forward()` / `forward_oot` mechanism at all — it only swaps the
**instantiated class** at `__new__` time via `op_registry_oot`. Once the OOT
class is instantiated, normal Python method resolution applies: calling the
instance invokes `forward()`, not `forward_oot()`.

Because `KunlunVocabParallelEmbedding` never overrode `forward()`, every call
fell back to the inherited `VocabParallelEmbedding.forward()` from upstream
vLLM. That implementation calls the module-level `get_masked_input_and_mask()`,
which is wrapped with `@torch.compile(...)` upstream. On Kunlun XPU this
triggers Triton/Inductor compilation and fails with:

```
torch._inductor.exc.InductorError: RuntimeError: CUDA driver error: CUDA_ERROR_NOT_SUPPORTED
```

The Kunlun-optimized `forward_oot()` (which calls the non-compiled
`torch.ops.xspeedgate_ops.get_masked_input_and_mask` custom kernel to avoid
exactly this problem) was dead code — it was registered but never executed.

Verified with instrumentation: after `vllm_kunlun.register()` +
`vllm_kunlun.ops.vocab_parallel_embedding` import,
`op_registry_oot["VocabParallelEmbedding"]` correctly resolves to
`KunlunVocabParallelEmbedding`, and instantiation does return a
`KunlunVocabParallelEmbedding` instance — the OOT class-swap itself works as
designed. The bug is purely that the swapped-in class lacked a `forward()`
override.

**Fix:**

- Import `PluggableLayer` instead of `CustomOp` (matches
  `VocabParallelEmbedding`'s actual current base class).
- Register with `@PluggableLayer.register_oot(name="VocabParallelEmbedding")`
  instead of `@CustomOp.register_oot(...)`. Both decorators write into the
  same underlying `op_registry_oot` dict, so this is not itself the
  functional fix, but it makes the registration mechanism consistent with the
  real base class and avoids implying a `forward_oot` dispatch that doesn't
  exist for `PluggableLayer`.
- Rename `forward_oot()` to `forward()` so the Kunlun-optimized
  masked-embedding path (using the pre-compiled `xspeedgate_ops` kernel) is
  actually invoked at runtime.
- Update the module docstring and class docstrings to describe the current
  `PluggableLayer` OOT mechanism and explicitly call out why `forward()` must
  be overridden directly.

No behavior change to the masked-embedding logic itself — only the method
name/dispatch path changed so it is reachable.

**Testing:**

- Verified via direct instantiation test that
  `op_registry_oot["VocabParallelEmbedding"]` resolves to
  `KunlunVocabParallelEmbedding` and that the class now defines `forward` in
  `__dict__` (previously only `forward_oot`, which was never called).
- Started vLLM server (`Qwen3.5-35B-A3B`, TP=2,
  `--distributed-executor-backend mp`) and confirmed `embed_tokens.forward`
  no longer falls through to vLLM's `torch.compile`'d
  `get_masked_input_and_mask`, resolving the `CUDA_ERROR_NOT_SUPPORTED` crash
  during model execution.

---

## Checklist (Required)

- [x] All code changes pass the [`pre-commit`](https://github.com/baidu/vLLM-Kunlun/blob/main/CONTRIBUTING.md) checks.
- [x] Commits are signed off using `git commit -s`.
- [x] The PR title is properly classified (see below).

---

## Commits

1. `[Bugfix] Replace Triton batch_memcpy in mamba_utils with xspeedgate_ops kernel`
2. `[Bugfix] Fix KunlunVocabParallelEmbedding forward_oot never invoked under PluggableLayer`

---

## Verification After Fix
- model: Qwen3.6-35B-A3B
- single curl test result:

<img width="2320" height="950" alt="image" src="https://github.com/user-attachments/assets/9cc88429-698a-48a3-8208-9b8e29db4316" />

- accuracy / output check:

<img width="2050" height="288" alt="image" src="https://github.com/user-attachments/assets/df7f67fd-995e-45ec-9f33-b5aa027db09a" />
