### PR TITLE
[Compatibility] Support vLLM 0.15.1 and enable GLM-5.2 on Kunlun

### DIFF
--- a/.github/workflows/pylint-check.yml
+++ b/.github/workflows/pylint-check.yml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Install tools
         run: |
-          pip install black isort ruff
+          pip install black==26.1.0 isort==5.13.2 ruff==0.14.14
 
       - name: Get changed python files
         id: changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,3 +30,6 @@ include = ["vllm_kunlun/conf/*", "vllm_kunlun/data/*"]
 [tool.hatch.build.targets.wheel]
 packages = ["vllm_kunlun"]
 output-dir = "output/dist"
+
+[tool.black]
+target-version = ["py310"]

--- a/vllm_kunlun/models/deepseek_mtp.py
+++ b/vllm_kunlun/models/deepseek_mtp.py
@@ -189,6 +189,7 @@ class DeepSeekMTP(nn.Module, SupportsPP):
         ]
 
         expert_params_mapping = FusedMoE.make_expert_params_mapping(
+            model=self,  # v0.15.1 compat: new required positional/keyword arg
             ckpt_gate_proj_name="gate_proj",
             ckpt_down_proj_name="down_proj",
             ckpt_up_proj_name="up_proj",

--- a/vllm_kunlun/models/deepseek_v2.py
+++ b/vllm_kunlun/models/deepseek_v2.py
@@ -33,7 +33,6 @@ import torch
 from torch import nn
 from torch.library import custom_op
 from transformers import DeepseekV2Config, DeepseekV3Config
-from vllm.attention.ops.common import pack_seq_triton, unpack_seq_triton
 from vllm.compilation.decorators import support_torch_compile
 from vllm.config import CacheConfig, ParallelConfig, VllmConfig
 from vllm.distributed import (
@@ -46,6 +45,7 @@ from vllm.distributed import (
 from vllm.forward_context import get_forward_context
 from vllm.logger import init_logger
 from vllm.model_executor.layers.fused_moe import FusedMoE
+from vllm.model_executor.layers.fused_moe.shared_fused_moe import SharedFusedMoE
 from vllm.model_executor.layers.layernorm import LayerNorm, RMSNorm
 from vllm.model_executor.layers.linear import (
     ColumnParallelLinear,
@@ -53,10 +53,12 @@ from vllm.model_executor.layers.linear import (
     RowParallelLinear,
 )
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
-from vllm.model_executor.layers.mla import MLAModules, MultiHeadLatentAttention
+from vllm.model_executor.layers.mla import MLAModules
+from vllm.model_executor.layers.mla import (
+    MultiHeadLatentAttentionWrapper as MultiHeadLatentAttention,
+)
 from vllm.model_executor.layers.quantization import QuantizationConfig
 from vllm.model_executor.layers.rotary_embedding import get_rope
-from vllm.model_executor.layers.shared_fused_moe import SharedFusedMoE
 from vllm.model_executor.layers.vocab_parallel_embedding import (
     ParallelLMHead,
     VocabParallelEmbedding,
@@ -73,6 +75,7 @@ from vllm.model_executor.models.interfaces import (
 )
 from vllm.model_executor.models.utils import (
     PPMissingLayer,
+    extract_layer_index,
     is_pp_missing_parameter,
     make_empty_intermediate_tensors_factory,
     make_layers,
@@ -81,6 +84,7 @@ from vllm.model_executor.models.utils import (
 )
 from vllm.platforms import current_platform
 from vllm.sequence import IntermediateTensors
+from vllm.v1.attention.ops.common import pack_seq_triton, unpack_seq_triton
 
 from vllm_kunlun.ops.activation import SiluAndMul
 from vllm_kunlun.ops.attention.layer import Attention
@@ -403,19 +407,21 @@ class DeepseekV2Attention(nn.Module):
             quant_config=quant_config,
             prefix=f"{prefix}.o_proj",
         )
-        if rope_scaling:
+        if rope_scaling and "factor" in rope_scaling:
             rope_scaling["rope_type"] = "deepseek_yarn"
 
+        # v0.15.1 compat: get_rope() now takes rope_parameters (a single dict)
+        # instead of separate rotary_dim/base/rope_scaling kwargs.
+        _rope_parameters = dict(rope_scaling) if rope_scaling else {}
+        _rope_parameters.setdefault("rope_theta", rope_theta)
         self.rotary_emb = get_rope(
             qk_rope_head_dim,
-            rotary_dim=qk_rope_head_dim,
             max_position=max_position_embeddings,
-            base=rope_theta,
-            rope_scaling=rope_scaling,
+            rope_parameters=_rope_parameters,
             is_neox_style=False,
         )
 
-        if rope_scaling:
+        if rope_scaling and "factor" in rope_scaling:
             mscale_all_dim = rope_scaling.get("mscale_all_dim", False)
             scaling_factor = rope_scaling["factor"]
             mscale = yarn_get_mscale(scaling_factor, float(mscale_all_dim))
@@ -707,6 +713,10 @@ class Indexer(nn.Module):
         self.scale_fmt = "ue8m0"
         self.quant_block_size = 128  # TODO: get from config
         self.topk_indices_buffer = topk_indices_buffer
+        # IndexCache skip flag; set from DeepseekV2MLAAttention after construction.
+        # When True, this layer reuses the topk indices computed by the previous
+        # non-skipped layer instead of running the sparse indexer kernel.
+        self._skip_topk = False
 
         # NOTE: (zyongye) we use fp8 naive cache,
         #       where we store value in fp8 and scale in fp32
@@ -734,6 +744,9 @@ class Indexer(nn.Module):
     def forward(
         self, hidden_states: torch.Tensor, qr: torch.Tensor, positions, rotary_emb
     ) -> torch.Tensor:
+        if self._skip_topk:
+            # Reuse topk indices from the previous non-skipped layer.
+            return self.topk_indices_buffer
         q, _ = self.wq_b(qr)
         q = q.view(-1, self.n_head, self.head_dim)
         q_pe, q_nope = torch.split(
@@ -886,17 +899,19 @@ class DeepseekV2MLAAttention(nn.Module):
             prefix=f"{prefix}.o_proj",
         )
 
-        if rope_scaling:
+        if rope_scaling and "factor" in rope_scaling:
             rope_scaling["rope_type"] = "deepseek_yarn"
+        # v0.15.1 compat: get_rope() now takes rope_parameters (a single dict)
+        # instead of separate rotary_dim/base/rope_scaling kwargs.
+        _rope_parameters = dict(rope_scaling) if rope_scaling else {}
+        _rope_parameters.setdefault("rope_theta", rope_theta)
         self.rotary_emb = get_rope(
             qk_rope_head_dim,
-            rotary_dim=qk_rope_head_dim,
             max_position=max_position_embeddings,
-            base=rope_theta,
-            rope_scaling=rope_scaling,
+            rope_parameters=_rope_parameters,
             is_neox_style=False,
         )
-        if rope_scaling:
+        if rope_scaling and "factor" in rope_scaling:
             mscale_all_dim = rope_scaling.get("mscale_all_dim", False)
             scaling_factor = rope_scaling["factor"]
             mscale = yarn_get_mscale(scaling_factor, float(mscale_all_dim))
@@ -905,6 +920,15 @@ class DeepseekV2MLAAttention(nn.Module):
         self.is_v32 = hasattr(config, "index_topk")
 
         if self.is_v32:
+            # Aligned with upstream vllm 0.23: sparse indexer rope layout follows config flag.
+            _indexer_rope_parameters = dict(rope_scaling) if rope_scaling else {}
+            _indexer_rope_parameters.setdefault("rope_theta", rope_theta)
+            self.indexer_rope_emb = get_rope(
+                qk_rope_head_dim,
+                max_position=max_position_embeddings,
+                rope_parameters=_indexer_rope_parameters,
+                is_neox_style=not getattr(config, "indexer_rope_interleave", False),
+            )
             self.indexer = Indexer(
                 vllm_config,
                 config,
@@ -915,8 +939,39 @@ class DeepseekV2MLAAttention(nn.Module):
                 topk_indices_buffer,
                 f"{prefix}.indexer",
             )
+
+            # IndexCache config (aligned with upstream vllm 0.23).
+            # NOTE: v0.15.1 MultiHeadLatentAttentionWrapper does not accept
+            # `skip_topk`; the computed value is stored on self for parity
+            # and future wrapper support. The kunlun sparse indexer currently
+            # runs on every layer regardless.
+            _index_topk_freq = getattr(config, "index_topk_freq", 1)
+            _index_topk_pattern = getattr(config, "index_topk_pattern", None)
+            _index_skip_topk_offset = getattr(config, "index_skip_topk_offset", 2)
+            layer_id = extract_layer_index(prefix)
+
+            if _index_topk_pattern is None:
+                self._skip_topk = (
+                    max(layer_id - _index_skip_topk_offset + 1, 0) % _index_topk_freq
+                    != 0
+                )
+            elif 0 <= layer_id < len(_index_topk_pattern):
+                self._skip_topk = _index_topk_pattern[layer_id] == "S"
+            else:
+                self._skip_topk = False
+            # Forward the skip flag to the Indexer instance so its forward()
+            # can early-return without running the sparse indexer kernel.
+            self.indexer._skip_topk = self._skip_topk
+            logger.info(
+                "IndexCache topk %s: layer_id=%d prefix=%s.indexer",
+                "SKIP (reuse buffer)" if self._skip_topk else "COMPUTE (hot)",
+                layer_id,
+                prefix,
+            )
         else:
+            self.indexer_rope_emb = None
             self.indexer = None
+            self._skip_topk = False
 
         mla_modules = MLAModules(
             kv_a_layernorm=self.kv_a_layernorm,
@@ -933,6 +988,7 @@ class DeepseekV2MLAAttention(nn.Module):
             q_b_proj=self.q_b_proj if self.q_lora_rank is not None else None,
             q_proj=self.q_proj if self.q_lora_rank is None else None,
             indexer=self.indexer,
+            indexer_rotary_emb=self.indexer_rope_emb,
             is_sparse=self.is_v32,
             topk_indices_buffer=topk_indices_buffer,
         )
@@ -1263,6 +1319,9 @@ class DeepseekV2ForCausalLM(nn.Module, SupportsPP, MixtureOfExperts, SupportsLoR
     def get_input_embeddings(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.model.get_input_embeddings(input_ids)
 
+    # Compat: vllm 0.15.1 VllmModel protocol renamed method to embed_input_ids
+    embed_input_ids = get_input_embeddings
+
     def forward(
         self,
         input_ids: torch.Tensor,
@@ -1294,6 +1353,7 @@ class DeepseekV2ForCausalLM(nn.Module, SupportsPP, MixtureOfExperts, SupportsLoR
         # Params for weights, fp8 weight scales, fp8 activation scales
         # (param_name, weight_name, expert_id, shard_id)
         expert_params_mapping = FusedMoE.make_expert_params_mapping(
+            model=self,  # v0.15.1 compat: new required positional/keyword arg
             ckpt_gate_proj_name="gate_proj",
             ckpt_down_proj_name="down_proj",
             ckpt_up_proj_name="up_proj",

--- a/vllm_kunlun/models/gpt_oss.py
+++ b/vllm_kunlun/models/gpt_oss.py
@@ -40,7 +40,7 @@ from vllm.model_executor.models.utils import (
     sequence_parallel_chunk,
 )
 from vllm.sequence import IntermediateTensors
-from vllm.utils import cdiv
+from vllm.utils.math_utils import cdiv  # v0.15.1 compat
 
 from vllm_kunlun.ops.attention.layer import Attention
 

--- a/vllm_kunlun/models/mimo_v2_flash.py
+++ b/vllm_kunlun/models/mimo_v2_flash.py
@@ -5,7 +5,6 @@ from itertools import islice
 
 import torch
 from torch import nn
-from vllm.attention.backends.abstract import AttentionType
 from vllm.config import CacheConfig, VllmConfig, get_current_vllm_config
 from vllm.distributed import (
     get_ep_group,
@@ -42,6 +41,7 @@ from vllm.model_executor.models.utils import (
     maybe_prefix,
 )
 from vllm.sequence import IntermediateTensors
+from vllm.v1.attention.backend import AttentionType  # v0.15.1 compat
 
 from vllm_kunlun.ops.activation import SiluAndMul
 from vllm_kunlun.ops.attention.layer import Attention

--- a/vllm_kunlun/ops/attention/backends/utils.py
+++ b/vllm_kunlun/ops/attention/backends/utils.py
@@ -10,10 +10,10 @@ from typing import TYPE_CHECKING, Any, Dict, List, Tuple, Type, TypeVar, Union
 import numpy as np
 import torch
 from vllm.attention import AttentionMetadata, AttentionMetadataBuilder, AttentionState
-from vllm.attention.backends.abstract import AttentionType
 from vllm.logger import init_logger
 from vllm.multimodal import MultiModalPlaceholderMap
 from vllm.utils import async_tensor_h2d, make_tensor_with_pad
+from vllm.v1.attention.backend import AttentionType  # v0.15.1 compat
 
 logger = init_logger(__name__)
 

--- a/vllm_kunlun/ops/attention/layer.py
+++ b/vllm_kunlun/ops/attention/layer.py
@@ -5,9 +5,7 @@ from typing import List, Optional
 import torch
 import torch.nn.functional as F
 from torch.library import custom_op
-from vllm.attention import Attention as VllmAttention
-from vllm.attention import AttentionType
-from vllm.attention.layer import MultiHeadAttention as VllmMultiHeadAttention
+from vllm.attention.layer import Attention as VllmAttention
 from vllm.config import CacheConfig
 from vllm.distributed.kv_transfer import (
     get_kv_transfer_group,
@@ -15,8 +13,12 @@ from vllm.distributed.kv_transfer import (
     is_v1_kv_transfer_group,
 )
 from vllm.forward_context import ForwardContext, get_forward_context
+from vllm.model_executor.layers.attention.mm_encoder_attention import (
+    MMEncoderAttention as VllmMultiHeadAttention,
+)
 from vllm.model_executor.layers.quantization.base_config import QuantizationConfig
-from vllm.platforms import _Backend
+from vllm.v1.attention.backend import AttentionType
+from vllm.v1.attention.backends.registry import AttentionBackendEnum as _Backend
 
 
 class Attention(VllmAttention):

--- a/vllm_kunlun/platforms/kunlun.py
+++ b/vllm_kunlun/platforms/kunlun.py
@@ -26,6 +26,13 @@ class KunlunPlatform(Platform):
     dist_backend: str = "nccl"
     ray_device_key: str = "GPU"
     device_name: str = "cuda"
+    # Kunlun XPU is exposed to torch via the CUDA runtime (xpytorch hook), and
+    # all Kunlun tensors report device.type == "cuda". Custom ops registered
+    # via direct_register_custom_op(dispatch_key=current_platform.dispatch_key)
+    # must therefore be attached to the "CUDA" dispatch key, otherwise the
+    # torch dispatcher will silently move CUDA inputs to CPU before invoking
+    # the kernel (root cause of the MLA CPU/CUDA mixed-device crash).
+    dispatch_key: str = "CUDA"
 
     @property
     def device_type(self):
@@ -35,6 +42,29 @@ class KunlunPlatform(Platform):
         The device type is always ``"cuda"``.
         """
         return "cuda"
+
+    _dedicated_capture_stream = None
+
+    def current_stream(self):
+        """
+        Return the stream vLLM uses for CUDA graph capture / replay.
+
+        On Kunlun XPU ``torch.cuda.current_stream()`` returns the default
+        (null) stream. CUDA graphs captured on the default stream come out
+        empty ("captured on wrong device or stream"), so every capture was a
+        no-op. Mirror the CUDA branch in
+        ``vllm.utils.torch_utils.current_stream`` by returning a dedicated,
+        non-default stream (created once per process) and making it the
+        process-wide current stream so capture, replay and normal execution
+        all share one capturable stream.
+        """
+        import torch
+
+        cls = type(self)
+        if cls._dedicated_capture_stream is None:
+            cls._dedicated_capture_stream = torch.cuda.Stream()
+            torch.cuda.set_stream(cls._dedicated_capture_stream)
+        return cls._dedicated_capture_stream
 
     def is_kunlun(self) -> bool:
         """is_kunlun"""
@@ -180,6 +210,35 @@ class KunlunPlatform(Platform):
         # scheduler_config = vllm_config.scheduler_config
         model_config = vllm_config.model_config
 
+        # ------------------------------------------------------------------
+        # Kunlun compat: force MLA for glm_moe_dsa (GLM-5.2 GlmMoeDsaForCausalLM).
+        # vllm 0.15.1's is_deepseek_mla() only whitelists a fixed set of
+        # model_types; glm_moe_dsa is not on it, so model_arch_config.is_deepseek_mla
+        # is False and DeepseekV2Attention (which asserts topk_indices_buffer is
+        # None) gets picked instead of DeepseekV2MLAAttention. Overwrite the flag
+        # here, before any downstream code (backend selection, decoder layer
+        # construction) reads model_config.use_mla.
+        # ------------------------------------------------------------------
+        try:
+            if (
+                model_config is not None
+                and getattr(model_config, "model_arch_config", None) is not None
+                and not model_config.model_arch_config.is_deepseek_mla
+                and getattr(model_config.hf_text_config, "model_type", None)
+                == "glm_moe_dsa"
+                and getattr(model_config.hf_text_config, "kv_lora_rank", None)
+                is not None
+            ):
+                model_config.model_arch_config.is_deepseek_mla = True
+                logger.info(
+                    "[KunlunPlugin] forcing is_deepseek_mla=True for model_type=glm_moe_dsa"
+                )
+        except Exception as _exc:
+            logger.warning(
+                "[KunlunPlugin] failed to force is_deepseek_mla for glm_moe_dsa: %s",
+                _exc,
+            )
+
         if parallel_config.worker_cls == "auto":
             # v0.15.1 do not support v0.15.1, remove the if condition
             if vllm_config.speculative_config:
@@ -199,11 +258,21 @@ class KunlunPlatform(Platform):
             # we default to FlashMLA backend, so we need to force the blocksize
             # here
             use_sparse = hasattr(vllm_config.model_config.hf_config, "index_topk")
-            use_flashmla = (
-                envs.VLLM_ATTENTION_BACKEND is None
-                or envs.VLLM_ATTENTION_BACKEND == "FLASHMLA"
+            # v0.15.1 compat: attention backend selection moved from env var
+            # (VLLM_ATTENTION_BACKEND) into vllm_config.attention_config.backend
+            # (an AttentionBackendEnum). "not set" is now `backend is None`.
+            _attn_backend = getattr(
+                getattr(vllm_config, "attention_config", None), "backend", None
             )
-            from vllm.attention.ops.flashmla import is_flashmla_supported
+            _attn_backend_name = (
+                _attn_backend.name if _attn_backend is not None else None
+            )
+            use_flashmla = (
+                _attn_backend_name is None or _attn_backend_name == "FLASHMLA"
+            )
+            from vllm.v1.attention.ops.flashmla import (
+                is_flashmla_dense_supported as is_flashmla_supported,
+            )
 
             if (
                 use_flashmla

--- a/vllm_kunlun/v1/attention/backends/mla/common.py
+++ b/vllm_kunlun/v1/attention/backends/mla/common.py
@@ -197,27 +197,27 @@ import torch
 import vllm.envs as envs
 from tqdm import tqdm
 from vllm import _custom_ops as ops
-from vllm.attention.backends.abstract import (
-    AttentionBackend,
-    AttentionLayer,
-    AttentionMetadata,
-    MLAAttentionImpl,
-)
-from vllm.attention.backends.utils import get_mla_dims
-from vllm.attention.ops.common import cp_lse_ag_out_rs
-from vllm.attention.ops.merge_attn_states import merge_attn_states
-from vllm.attention.utils.fa_utils import get_flash_attn_version
 from vllm.config import VllmConfig, get_current_vllm_config
 from vllm.distributed.parallel_state import get_dcp_group, is_global_first_rank
 from vllm.logger import init_logger
+from vllm.model_executor.layers.attention.mla_attention import get_mla_dims
 from vllm.model_executor.layers.linear import (
     ColumnParallelLinear,
     LinearBase,
     UnquantizedLinearMethod,
 )
 from vllm.platforms import current_platform
-from vllm.utils import cdiv, round_down
 from vllm.utils.flashinfer import has_nvidia_artifactory
+from vllm.utils.math_utils import cdiv, round_down  # v0.15.1 compat
+
+# v0.15.1 compat: legacy vllm.attention.backends.* namespace no longer exists.
+from vllm.v1.attention.backend import (
+    AttentionBackend,
+    AttentionLayer,
+    AttentionMetadata,
+    MLAAttentionImpl,
+)
+from vllm.v1.attention.backends.fa_utils import get_flash_attn_version
 from vllm.v1.attention.backends.utils import (
     AttentionMetadataBuilder,
     CommonAttentionMetadata,
@@ -225,6 +225,8 @@ from vllm.v1.attention.backends.utils import (
     infer_global_hyperparameters,
     split_decodes_and_prefills,
 )
+from vllm.v1.attention.ops.common import cp_lse_ag_out_rs
+from vllm.v1.attention.ops.merge_attn_states import merge_attn_states
 from vllm.v1.kv_cache_interface import AttentionSpec
 
 import vllm_kunlun.platforms.envs as vllm_kunlun_envs

--- a/vllm_kunlun/v1/attention/backends/mla/flashmla.py
+++ b/vllm_kunlun/v1/attention/backends/mla/flashmla.py
@@ -5,9 +5,9 @@ from dataclasses import dataclass
 from typing import ClassVar, Optional, Union
 
 import torch
-from vllm.attention.backends.abstract import AttentionLayer, AttentionType
 from vllm.config import VllmConfig
 from vllm.logger import init_logger
+from vllm.v1.attention.backend import AttentionLayer, AttentionType  # v0.15.1 compat
 from vllm.v1.attention.backends.utils import AttentionCGSupport
 from vllm.v1.kv_cache_interface import AttentionSpec
 

--- a/vllm_kunlun/v1/attention/backends/mla/flashmla_sparse.py
+++ b/vllm_kunlun/v1/attention/backends/mla/flashmla_sparse.py
@@ -6,22 +6,28 @@ from typing import TYPE_CHECKING, ClassVar, Optional
 
 import numpy as np
 import torch
-from vllm.attention.backends.abstract import (
-    AttentionBackend,
-    AttentionLayer,
-    AttentionMetadata,
-)
-from vllm.attention.backends.utils import get_mla_dims
 from vllm.config import VllmConfig
 from vllm.logger import init_logger
+from vllm.model_executor.layers.attention.mla_attention import (
+    MLACommonBaseImpl,
+    get_mla_dims,
+)
 from vllm.platforms import current_platform
 from vllm.triton_utils import tl, triton
-from vllm.utils import cdiv
-from vllm.v1.attention.backends.mla.common import MLACommonBaseImpl
-from vllm.v1.attention.backends.utils import (
+from vllm.utils.math_utils import cdiv  # v0.15.1 compat
+
+# v0.15.1 compat: vllm.attention.backends.abstract moved to vllm.v1.attention.backend;
+# get_mla_dims and MLACommonBaseImpl moved to vllm.model_executor.layers.attention.mla_attention;
+# AttentionCGSupport/AttentionMetadataBuilder/CommonAttentionMetadata now live in vllm.v1.attention.backend.
+from vllm.v1.attention.backend import (
+    AttentionBackend,
     AttentionCGSupport,
+    AttentionLayer,
+    AttentionMetadata,
     AttentionMetadataBuilder,
     CommonAttentionMetadata,
+)
+from vllm.v1.attention.backends.utils import (
     reshape_attn_output_for_spec_decode,
     reshape_query_for_spec_decode,
     split_decodes_and_prefills,
@@ -427,7 +433,7 @@ def kunlun_concat_and_cache_mla(
 
 @dataclass
 class FlashMLASparseMetadataBuilder(AttentionMetadataBuilder[FlashMLASparseMetadata]):
-    cudagraph_support: ClassVar[AttentionCGSupport] = AttentionCGSupport.UNIFORM_BATCH
+    _cudagraph_support: ClassVar[AttentionCGSupport] = AttentionCGSupport.UNIFORM_BATCH
 
     def __init__(
         self,

--- a/vllm_kunlun/v1/attention/backends/mla/indexer.py
+++ b/vllm_kunlun/v1/attention/backends/mla/indexer.py
@@ -149,7 +149,7 @@ def kunlun_build(
     prefill_metadata = None
     if num_prefills > 0:
         chunk_seq_ids = split_prefill_chunks(
-            common_attn_metadata.seq_lens_cpu,
+            common_attn_metadata.seq_lens_cpu[num_decodes:],
             self.max_prefill_buffer_size,
             num_decodes,
         )
@@ -223,4 +223,4 @@ DeepseekV32IndexerMetadataBuilder.build = kunlun_build
 # Monkey patch: Upgrade cudagraph_support to UNIFORM_BATCH for spec-decode compatibility
 from vllm.v1.attention.backend import AttentionCGSupport  # noqa
 
-DeepseekV32IndexerMetadataBuilder.cudagraph_support = AttentionCGSupport.UNIFORM_BATCH
+DeepseekV32IndexerMetadataBuilder._cudagraph_support = AttentionCGSupport.UNIFORM_BATCH

--- a/vllm_kunlun/v1/worker/utils.py
+++ b/vllm_kunlun/v1/worker/utils.py
@@ -5,13 +5,13 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Optional
 
 import torch
-from vllm.attention.backends.abstract import AttentionBackend
 from vllm.config import ModelConfig, SchedulerConfig, VllmConfig
 from vllm.model_executor.models.interfaces import MultiModalEmbeddings
 from vllm.model_executor.models.utils import extract_layer_index
 from vllm.multimodal.cache import processor_only_cache_from_config
 from vllm.multimodal.registry import MultiModalRegistry
 from vllm.platforms import current_platform
+from vllm.v1.attention.backend import AttentionBackend  # v0.15.1 compat
 from vllm.v1.attention.backends.utils import AttentionMetadataBuilder
 from vllm.v1.core.encoder_cache_manager import compute_mm_encoder_budget
 from vllm.v1.kv_cache_interface import KVCacheGroupSpec, KVCacheSpec


### PR DESCRIPTION
## Summary

This PR adds compatibility patches for vLLM 0.15.1 and enables GLM-5.2 (`glm_moe_dsa`) execution on Kunlun devices.

The changes update the Kunlun plugin to match the attention, MLA, MoE, rotary embedding, and platform APIs introduced in vLLM 0.15.1. They also enable the sparse MLA path required by GLM-5.2 and add IndexCache-compatible top-k reuse behavior.

## Changes

### vLLM 0.15.1 compatibility

- Updated attention-related imports to the vLLM v1 namespaces.
- Adapted `Attention`, `AttentionType`, attention backend registry, MLA utilities, and metadata builder APIs.
- Updated `cdiv` and `round_down` imports to `vllm.utils.math_utils`.
- Updated `SharedFusedMoE` and `MultiHeadLatentAttentionWrapper` imports.
- Passed the newly required `model` argument to `FusedMoE.make_expert_params_mapping`.
- Adapted rotary embedding initialization to the new `rope_parameters` API.
- Added the `embed_input_ids` model protocol alias.
- Updated FlashMLA backend selection to use `vllm_config.attention_config.backend`.
- Updated CUDA graph support fields to the new `_cudagraph_support` interface.
- Fixed prefill sequence-length slicing when decode requests are also present.

### GLM-5.2 / `glm_moe_dsa` enablement

- Force-enabled MLA for `glm_moe_dsa` models with `kv_lora_rank`.
- Added sparse indexer rotary embedding configuration with support for `indexer_rope_interleave`.
- Added IndexCache layer selection using:
  - `index_topk_freq`
  - `index_topk_pattern`
  - `index_skip_topk_offset`
- Reused cached top-k indices on skipped sparse-indexer layers.
- Forwarded the indexer rotary embedding through `MLAModules`.

### Kunlun platform fixes

- Registered custom operations with the `CUDA` dispatch key because Kunlun tensors are exposed through the CUDA-compatible xpytorch runtime.
- Added a dedicated non-default stream for CUDA graph capture and replay.
- Updated FlashMLA capability detection for the vLLM 0.15.1 API.

## Validation

- All configured pre-commit checks passed:
  - Ruff
  - isort
  - Black
  - YAML/TOML validation where applicable
  - trailing-whitespace and end-of-file checks
  - large-file and filename checks
## Verification
  * 8-TP eager launch (--enforce-eager) on 8 × P800 XPU: OK, /v1/chat/completions returns coherent Chinese/English/math answers.
  * CUDA-graph launch with --compilation-config '{"splitting_ops": [...16 ops incl.   sparse_attn_indexer_vllm_kunlun...]}': OK, no "Comments\nComments\n..." degenerate loop.
  * No cpu and cuda mixed-device hits (was root cause of MLA crash).
  * Perf: single-request throughput 60+ tok/s (piecewise CUDA graph replay confirmed).
## Scope

This PR updates the Kunlun integration for vLLM 0.15.1 while preserving the existing DeepSeek MLA, sparse FlashMLA, speculative decoding, and MoE integration paths.