### PR TITLE
[ModelRunner][Platform] Support MRV2 on Kunlun XPU without Triton (WIP)

### DIFF
--- a/vllm_kunlun/__init__.py
+++ b/vllm_kunlun/__init__.py
@@ -43,6 +43,26 @@ _MODULE_MAPPINGS = {
     "vllm.attention.ops.merge_attn_states": "vllm_kunlun.ops.attention.merge_attn_states",
     "vllm.v1.worker.mamba_utils": "vllm_kunlun.v1.worker.mamba_utils",
     # "vllm.v1.worker.gpu_model_runner": "vllm_kunlun.v1.worker.gpu_model_runner",
+    # --- Model Runner V2: torch-native / kunlun_ops replacements for the
+    # Triton kernels in the V2 sampling + input-preparation pipeline. See
+    # vllm_kunlun/v1/worker/gpu/. Spec-decode (rejection_sampler_utils) is a
+    # deferred milestone and intentionally not mapped here.
+    "vllm.v1.worker.gpu.buffer_utils": "vllm_kunlun.v1.worker.gpu.buffer_utils",
+    "vllm.v1.worker.gpu.block_table": "vllm_kunlun.v1.worker.gpu.block_table",
+    "vllm.v1.worker.gpu.input_batch": "vllm_kunlun.v1.worker.gpu.input_batch",
+    "vllm.v1.worker.gpu.structured_outputs": "vllm_kunlun.v1.worker.gpu.structured_outputs",
+    "vllm.v1.worker.gpu.sample.gumbel": "vllm_kunlun.v1.worker.gpu.sample.gumbel",
+    "vllm.v1.worker.gpu.sample.min_p": "vllm_kunlun.v1.worker.gpu.sample.min_p",
+    "vllm.v1.worker.gpu.sample.penalties": "vllm_kunlun.v1.worker.gpu.sample.penalties",
+    "vllm.v1.worker.gpu.sample.logit_bias": "vllm_kunlun.v1.worker.gpu.sample.logit_bias",
+    "vllm.v1.worker.gpu.sample.bad_words": "vllm_kunlun.v1.worker.gpu.sample.bad_words",
+    "vllm.v1.worker.gpu.sample.logprob": "vllm_kunlun.v1.worker.gpu.sample.logprob",
+    "vllm.v1.worker.gpu.sample.prompt_logprob": "vllm_kunlun.v1.worker.gpu.sample.prompt_logprob",
+    # Multimodal M-RoPE / XD-RoPE position preparation (every Qwen-VL model).
+    "vllm.v1.worker.gpu.mm.rope": "vllm_kunlun.v1.worker.gpu.mm.rope",
+    # Hybrid attention + mamba model state (Qwen3-Next, Qwen3.5, ...). Only
+    # reached when model_config.is_hybrid, via model_states/__init__.py:31.
+    "vllm.v1.worker.gpu.model_states.mamba_hybrid": "vllm_kunlun.v1.worker.gpu.model_states.mamba_hybrid",
 }
 
 

--- a/vllm_kunlun/platforms/kunlun.py
+++ b/vllm_kunlun/platforms/kunlun.py
@@ -1,5 +1,6 @@
 """kunlun"""
 
+import os
 from typing import TYPE_CHECKING, Optional
 
 import psutil
@@ -213,6 +214,35 @@ class KunlunPlatform(Platform):
         parallel_config = vllm_config.parallel_config  # Not use scheduler_config
         # scheduler_config = vllm_config.scheduler_config
         model_config = vllm_config.model_config
+
+        # --- Model Runner V2 Triton gate (Kunlun XPU has no Triton) ---
+        # Kunlun replaces the V2 Triton kernels with torch-native / kunlun_ops
+        # equivalents (see the ``vllm.v1.worker.gpu.*`` module swaps in
+        # vllm_kunlun/__init__.py), so upstream's Triton veto has to be lifted:
+        # ``vllm.config.vllm`` uses HAS_TRITON only for the two V2 checks
+        # (``use_v2_model_runner`` returns False when ``not HAS_TRITON``, and
+        # ``_validate_v2_model_runner`` hard raises "Model Runner V2 requires
+        # Triton."), so forcing it True here has no other side effects.
+        #
+        # NOTE: we deliberately do NOT set VLLM_USE_V2_MODEL_RUNNER. Upstream
+        # already routes only *some* models to V2, and its own selection logic
+        # (config/vllm.py::use_v2_model_runner) is more trustworthy than a table
+        # maintained here -- in particular ``_is_default_v2_model_runner_model``
+        # excludes hybrid models, which the V2 runner does not fully support on
+        # Kunlun yet. Defaulting the env var to "1" made the property
+        # early-return True and skipped all of those filters, which is how a
+        # hybrid model (Qwen3.5) reached V2 and died importing
+        # ``vllm.v1.worker.gpu.model_states.mamba_hybrid``. Users can still opt
+        # in explicitly with VLLM_USE_V2_MODEL_RUNNER=1 (or force V1 with "0").
+        import vllm.config.vllm as _vllm_cfg_mod
+
+        if not getattr(_vllm_cfg_mod, "_kunlun_v2_triton_gate_opened", False):
+            _vllm_cfg_mod.HAS_TRITON = True
+            _vllm_cfg_mod._kunlun_v2_triton_gate_opened = True
+            logger.info(
+                "[KunlunPlugin] Opened Model Runner V2 Triton gate "
+                "(upstream decides whether V2 is used)."
+            )
 
         if parallel_config.worker_cls == "auto":
             # v0.15.1 do not support v0.15.1, remove the if condition

--- a/vllm_kunlun/v1/worker/gpu/__init__.py
+++ b/vllm_kunlun/v1/worker/gpu/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project

--- a/vllm_kunlun/v1/worker/gpu/_kernels.py
+++ b/vllm_kunlun/v1/worker/gpu/_kernels.py
@@ -1,0 +1,132 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""torch-native stand-ins for the V2 model-runner Triton kernels.
+
+Deliberately depends on ``torch`` only -- no ``vllm``, no ``kunlun_ops`` -- so
+these can be unit-tested on CPU without XPU hardware. Each function documents
+the upstream kernel it mirrors and any intentional semantic divergence.
+"""
+
+import torch
+
+
+class TorchKernel:
+    """Stand-in for a Triton kernel object: ``obj[grid](*args, **kw)`` -> fn.
+
+    Lets a replacement swap a module-private kernel *object* rather than
+    rewriting the method that launches it, which keeps the surrounding upstream
+    logic intact.
+    """
+
+    def __init__(self, fn):
+        self._fn = fn
+        self.__name__ = getattr(fn, "__name__", "kunlun_torch_kernel")
+
+    def __getitem__(self, grid):
+        return self._fn
+
+    def __call__(self, *args, **kwargs):
+        return self._fn(*args, **kwargs)
+
+
+def scatter_num_accepted(idx_mapping, num_sampled, num_accepted) -> None:
+    """Mirror ``mamba_hybrid._scatter_num_accepted_kernel``.
+
+    Upstream kernel (model_states/mamba_hybrid.py:337-348), grid
+    ``(idx_mapping.shape[0],)``, one program per batch row::
+
+        req = idx_mapping[row]
+        if req < 0: return
+        num_accepted[req] = max(num_sampled[row], 1)
+
+    ``idx_mapping`` is injective over its valid rows, so this scatter has no
+    duplicate-index race. The ``-1`` sentinels only appear under pipeline
+    parallelism (rows filtered out on non-last PP ranks).
+
+    Cost note: the boolean mask needs the selected-row count, i.e. one small
+    D2H sync -- the same order of cost as the ``.item()`` already accepted in
+    ``BlockTables.compute_slot_mappings``.
+    """
+    valid = idx_mapping >= 0
+    rows = idx_mapping[valid].to(torch.long)
+    if rows.numel() == 0:
+        return
+    num_accepted[rows] = num_sampled[valid].clamp(min=1).to(num_accepted.dtype)
+
+
+def prepare_rope_positions(
+    positions,  # [num_dims, max_num_tokens + 1] int64, written in place
+    prefill_positions,  # [max_num_reqs * num_dims, max_model_len] int32
+    prefill_delta,  # [max_num_reqs] int32 (all zeros for XD-RoPE)
+    idx_mapping,  # [num_reqs] batch_idx -> req_state_idx
+    query_start_loc,  # [num_reqs + 1] cumulative token offsets
+    prefill_lens,  # [max_num_reqs]
+    num_computed_tokens,  # [max_num_reqs]
+    num_dims: int,
+    max_model_len: int,
+) -> None:
+    """Mirror ``mm/rope.py::_prepare_rope_positions_kernel``.
+
+    Upstream kernel (mm/rope.py:166-214), grid ``(num_reqs,)``, per batch row
+    ``i`` with ``s = idx_mapping[i]``::
+
+        is_prefill = num_computed_tokens[s] < prefill_lens[s]
+        for t in [0, query_len_i):
+            orig = num_computed_tokens[s] + t
+            pos[j] = prefill_positions[s * num_dims + j, orig] if is_prefill
+                     else orig + prefill_delta[s]
+            positions[j, query_start_loc[i] + t] = pos[j]
+
+    The launch site (rope.py:118-131) passes ``stride0 = num_dims *
+    max_model_len`` (per request) and ``stride1 = max_model_len`` (per dim), so
+    the kernel's pointer arithmetic is equivalent to the 2-D index
+    ``prefill_positions[s * num_dims + j, orig]``; the store side is equivalent
+    to ``positions[j, query_start_loc[i] + t]``.
+
+    Because ``query_start_loc`` is a cumsum, ``query_start_loc[i] + t`` is the
+    global token index, so the whole batch is one contiguous write.
+
+    Two intentional divergences from the kernel:
+
+    * ``orig_pos`` is clamped to ``max_model_len - 1`` before the gather. The
+      kernel masks only on ``t < query_len`` and would read past the row
+      (undefined) if a prefill request were ever scheduled beyond
+      ``prefill_len``.
+    * negative ``idx_mapping`` entries are clamped to 0. Note this kernel --
+      unlike the mamba scatter kernel -- does *not* filter ``-1``, so upstream
+      would read garbage there too; the clamp only avoids a hard torch
+      indexing error.
+    """
+    num_reqs = idx_mapping.shape[0]
+    if num_reqs == 0:
+        return
+    device = positions.device
+    qsl = query_start_loc[: num_reqs + 1].to(torch.long)
+    # One small D2H sync; the V2 runner offers no sync-free way to size this.
+    num_tokens = int(qsl[num_reqs].item())
+    if num_tokens == 0:
+        return
+
+    tok = torch.arange(num_tokens, device=device)
+    # token -> batch row. searchsorted on the per-request *ends* handles
+    # zero-length requests correctly and needs no extra sync.
+    batch = torch.searchsorted(qsl[1:].contiguous(), tok, right=True)
+    req = idx_mapping.to(torch.long).clamp(min=0)[batch]
+    offset = tok - qsl[:num_reqs][batch]
+
+    num_computed = num_computed_tokens.to(torch.long)[req]
+    orig_pos = num_computed + offset
+    is_prefill = num_computed < prefill_lens.to(torch.long)[req]
+    delta = prefill_delta.to(torch.long)[req]
+
+    rows = (req * num_dims).unsqueeze(0) + torch.arange(
+        num_dims, device=device
+    ).unsqueeze(
+        1
+    )  # [D, T]
+    cols = orig_pos.clamp(max=max_model_len - 1).unsqueeze(0).expand(num_dims, -1)
+    gathered = prefill_positions[rows, cols].to(torch.long)  # [D, T]
+
+    positions[:num_dims, :num_tokens] = torch.where(
+        is_prefill.unsqueeze(0), gathered, (orig_pos + delta).unsqueeze(0)
+    )

--- a/vllm_kunlun/v1/worker/gpu/_upstream.py
+++ b/vllm_kunlun/v1/worker/gpu/_upstream.py
@@ -1,0 +1,72 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Helper to execute a genuine upstream ``vllm`` module, bypassing the Kunlun
+``sys.modules`` swap installed by ``vllm_kunlun/__init__.py``.
+
+The V2 model-runner replacement modules under ``vllm_kunlun.v1.worker.gpu.*``
+reuse the pure-Python parts of their upstream counterparts (state classes,
+constants, dataclasses) and only override the functions / methods that launch
+Triton kernels. To get at the genuine upstream code they must load the real
+file directly -- a plain ``import vllm.v1.worker.gpu.<leaf>`` would resolve to
+the swapped Kunlun module (i.e. themselves) and recurse.
+"""
+
+import importlib
+import importlib.util
+import os
+import sys
+
+
+def load_upstream(vllm_module_name: str):
+    """Load and execute the genuine upstream vllm module file.
+
+    Args:
+        vllm_module_name: Dotted path of the upstream module, e.g.
+            ``"vllm.v1.worker.gpu.buffer_utils"``.
+
+    Returns:
+        The executed upstream module object, cached under a private name so
+        repeated calls are cheap and idempotent.
+    """
+    private = "_kunlun_upstream_" + vllm_module_name.replace(".", "_")
+    cached = sys.modules.get(private)
+    if cached is not None:
+        return cached
+
+    parts = vllm_module_name.split(".")
+    parent_name = ".".join(parts[:-1])
+    leaf = parts[-1]
+
+    # The parent package (e.g. ``vllm.v1.worker.gpu``) is NOT swapped, so this
+    # resolves to the real on-disk package and gives us its directory.
+    parent = importlib.import_module(parent_name)
+    parent_dir = os.path.dirname(parent.__file__)
+    file_path = os.path.join(parent_dir, leaf + ".py")
+
+    spec = importlib.util.spec_from_file_location(private, file_path)
+    module = importlib.util.module_from_spec(spec)
+    # Register before exec so any self-reference resolves to this instance.
+    sys.modules[private] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def reexport(upstream_module, namespace: dict) -> None:
+    """Copy the upstream module's whole public surface into ``namespace``.
+
+    A ``sys.modules`` swap is a *whole module* replacement: the replacement has
+    to provide every name any upstream consumer might
+    ``from <module> import X``, or the import blows up -- even for features
+    Kunlun never intends to support. Hand-maintained re-export lists drift
+    silently whenever upstream adds a symbol (this is exactly how
+    ``vllm.v1.worker.gpu.model_states.mamba_hybrid`` failed to import
+    ``MambaSpecDecodeGPUContext``).
+
+    The set of names upstream can legally import from a module is exactly the
+    set of non-dunder keys of its ``__dict__``, so copying that wholesale is
+    both correct and drift-proof. Callers must invoke this *before* defining
+    their own overrides, so the overrides win in the caller's namespace.
+    """
+    namespace.update(
+        {k: v for k, v in vars(upstream_module).items() if not k.startswith("__")}
+    )

--- a/vllm_kunlun/v1/worker/gpu/block_table.py
+++ b/vllm_kunlun/v1/worker/gpu/block_table.py
@@ -1,0 +1,103 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Kunlun replacement for ``vllm.v1.worker.gpu.block_table``.
+
+Reuses the upstream ``BlockTables`` class (loaded via ``load_upstream``) and
+overrides its three Triton-backed methods with torch-native / ``kunlun_ops``
+equivalents:
+
+* ``apply_staged_writes`` — loop ``StagedWriteTensor.apply_write`` per group
+  (the Kunlun ``buffer_utils`` provides a torch-native ``apply_write``), which
+  also removes the need for the fused multi-group Triton writer.
+* ``gather_block_tables`` — gather source rows by ``idx_mapping`` with
+  ``index_select`` and zero the padded rows.
+* ``compute_slot_mappings`` — reuse the native ``kunlun_ops.compute_slot_mappings``
+  (same op the V1 Kunlun path uses), feeding it block tables pre-gathered by
+  ``idx_mapping`` so the op's per-token request lookup matches V2 semantics.
+"""
+
+import logging
+
+import kunlun_ops
+import torch
+
+from vllm_kunlun.v1.worker.gpu._upstream import load_upstream
+
+logger = logging.getLogger("vllm_kunlun")
+
+_up = load_upstream("vllm.v1.worker.gpu.block_table")
+
+PAD_SLOT_ID = _up.PAD_SLOT_ID
+BlockTables = _up.BlockTables
+
+
+def _apply_staged_writes(self) -> None:
+    # Single- and multi-group both handled by per-group torch-native writes.
+    for block_table in self.block_tables:
+        block_table.apply_write()
+    self.num_blocks.copy_to_uva()
+
+
+def _gather_block_tables(self, idx_mapping: torch.Tensor, num_reqs_padded: int):
+    num_reqs = idx_mapping.shape[0]
+    idx_long = idx_mapping.to(torch.long)
+    for i in range(self.num_kv_cache_groups):
+        src = self.block_tables[i].gpu  # [max_num_reqs, max_num_blocks]
+        dst = self.input_block_tables[i]
+        if num_reqs_padded > num_reqs:
+            dst[num_reqs:num_reqs_padded].zero_()
+        if num_reqs > 0:
+            dst[:num_reqs] = src.index_select(0, idx_long)
+    return tuple(bt[:num_reqs_padded] for bt in self.input_block_tables)
+
+
+def _compute_slot_mappings(
+    self,
+    idx_mapping: torch.Tensor,
+    query_start_loc: torch.Tensor,
+    positions: torch.Tensor,
+    num_tokens_padded: int,
+) -> torch.Tensor:
+    num_reqs = idx_mapping.shape[0]
+    num_groups = self.num_kv_cache_groups
+    # Total number of real tokens this step (one small D2H sync). Everything
+    # past this is padding and must map to PAD_SLOT_ID.
+    num_tokens = int(query_start_loc[num_reqs].item())
+
+    # Pad the whole buffer first; valid slots are overwritten below.
+    self.slot_mappings.fill_(PAD_SLOT_ID)
+
+    if num_tokens > 0:
+        idx_long = idx_mapping.to(torch.long)
+        # Pre-gather block tables into batch order so the native op's
+        # per-token request index (derived from query_start_loc) addresses
+        # the correct rows -- V2 keeps block tables in request-state order and
+        # indirects through idx_mapping, which the V1-style op does not do.
+        bt_batch = [
+            self.block_tables[g].gpu.index_select(0, idx_long)
+            for g in range(num_groups)
+        ]
+        slot_list = [self.slot_mappings[g] for g in range(num_groups)]
+        kunlun_ops.compute_slot_mappings(
+            slot_list,
+            bt_batch,
+            positions,
+            query_start_loc,
+            self.block_sizes_tensor,
+            num_reqs,
+            num_tokens,
+            PAD_SLOT_ID,
+            self.cp_size,
+            self.cp_rank,
+            self.cp_interleave,
+        )
+
+    return self.slot_mappings[:, :num_tokens_padded]
+
+
+if not getattr(BlockTables, "_kunlun_v2_patched", False):
+    BlockTables.apply_staged_writes = _apply_staged_writes
+    BlockTables.gather_block_tables = _gather_block_tables
+    BlockTables.compute_slot_mappings = _compute_slot_mappings
+    BlockTables._kunlun_v2_patched = True
+    logger.info("[KunlunPlugin] V2 BlockTables patched (torch-native + kunlun_ops)")

--- a/vllm_kunlun/v1/worker/gpu/buffer_utils.py
+++ b/vllm_kunlun/v1/worker/gpu/buffer_utils.py
@@ -1,0 +1,142 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Kunlun torch-native replacement for ``vllm.v1.worker.gpu.buffer_utils``.
+
+The genuine upstream module is executed via ``load_upstream`` so that all its
+pure-Python machinery (``UvaBufferPool``, ``UvaBackedTensor``, dataclasses,
+constants) is reused verbatim. Only the two Triton kernel launch sites are
+overridden with torch-native equivalents:
+
+* ``StagedWriteTensor.apply_write`` — applies staged row/segment writes to a
+  device tensor. Replaces ``_apply_write_kernel``.
+* ``FusedStagedWriter.apply`` — upstream fuses writes across several tensors
+  through raw pointers. Kunlun never calls it because the Kunlun
+  ``BlockTables.apply_staged_writes`` override loops ``apply_write`` per group
+  instead (raw-pointer fan-out is not expressible in torch-native). It is
+  overridden here to raise, so an accidental caller fails loudly rather than
+  launching an uncompilable Triton kernel.
+
+UVA handling: upstream ``UvaBuffer`` hard-raises when ``is_uva_available()`` is
+False. Kunlun XPU presents as CUDA (``torch_xmlir``); when UVA is available the
+upstream classes are used unchanged. When it is not, a device-tensor fallback
+is installed so the ``.uva`` views become real device tensors kept in sync via
+explicit H2D copies.
+"""
+
+import logging
+
+import torch
+from vllm.utils.platform_utils import is_uva_available
+from vllm.utils.torch_utils import get_accelerator_view_from_cpu_tensor
+
+from vllm_kunlun.v1.worker.gpu._upstream import load_upstream
+
+logger = logging.getLogger("vllm_kunlun")
+
+_up = load_upstream("vllm.v1.worker.gpu.buffer_utils")
+
+# Re-export the upstream public surface so consumers importing from this
+# (swapped) module name resolve the same symbols.
+async_copy_to_gpu = _up.async_copy_to_gpu
+set_default_max_concurrency = _up.set_default_max_concurrency
+UvaBuffer = _up.UvaBuffer
+UvaBufferPool = _up.UvaBufferPool
+UvaBackedTensor = _up.UvaBackedTensor
+StagedWriteTensor = _up.StagedWriteTensor
+FusedStagedWriter = _up.FusedStagedWriter
+# Imported (but never called) by the genuine block_table module; keep the name
+# so its ``from ...buffer_utils import _load_ptr`` succeeds.
+_load_ptr = getattr(_up, "_load_ptr", None)
+
+
+def _apply_write(self) -> None:
+    """torch-native replacement of ``StagedWriteTensor.apply_write``.
+
+    For each staged write ``i`` the upstream Triton kernel writes
+    ``contents[cu_start:cu_end]`` into the flat device buffer at offset
+    ``indices[i] * gpu.stride(0) + starts[i]``. This reproduces it with slice
+    assignments on ``self.gpu`` (contiguous, so a flattened view + linear
+    offset matches the kernel's pointer arithmetic exactly).
+    """
+    n = len(self._staged_write_indices)
+    if n == 0:
+        return
+
+    flat = self.gpu.view(-1)
+    stride0 = self.gpu.stride(0)
+    contents = torch.tensor(
+        self._staged_write_contents, dtype=self.dtype, device=self.device
+    )
+
+    cu_start = 0
+    for i in range(n):
+        cu_end = self._staged_write_cu_lens[i]
+        length = cu_end - cu_start
+        if length > 0:
+            base = (
+                self._staged_write_indices[i] * stride0 + self._staged_write_starts[i]
+            )
+            flat[base : base + length] = contents[cu_start:cu_end]
+        cu_start = cu_end
+
+    self.clear_staged_writes()
+
+
+def _fused_apply(self, tensors, output_ptrs, output_strides) -> None:
+    raise NotImplementedError(
+        "FusedStagedWriter.apply is not supported on Kunlun XPU; "
+        "BlockTables.apply_staged_writes loops per-group apply_write instead."
+    )
+
+
+StagedWriteTensor.apply_write = _apply_write
+FusedStagedWriter.apply = _fused_apply
+
+
+def _uva_view_supported() -> bool:
+    """Probe whether a real UVA accelerator view can be built on this platform.
+
+    ``is_uva_available()`` only checks for pinned memory, which is True on
+    Kunlun XPU. The actual view is created by
+    ``get_accelerator_view_from_cpu_tensor``, which dispatches on
+    ``current_platform.is_xpu() / is_cuda_alike()`` and then calls a
+    ``vllm._C`` custom op. KunlunPlatform matches neither branch (and
+    ``vllm._C`` is not built), so the call raises. Probe it once instead of
+    trusting ``is_uva_available()``.
+    """
+    if not is_uva_available():
+        return False
+    try:
+        probe = torch.zeros(1, dtype=torch.int32, device="cpu", pin_memory=True)
+        get_accelerator_view_from_cpu_tensor(probe)
+    except Exception as e:  # noqa: BLE001 - any failure means "unsupported"
+        logger.info("[KunlunPlugin] UVA view probe failed (%s)", e)
+        return False
+    return True
+
+
+if not _uva_view_supported():
+    # Device-tensor fallback: keep a plain CPU source of truth and a real
+    # device tensor as the ``.uva`` view, synced with explicit H2D copies.
+    logger.warning(
+        "[KunlunPlugin] UVA unavailable; using device-tensor fallback for "
+        "Model Runner V2 buffers (extra H2D copies per step)."
+    )
+
+    def _uvabuffer_init(self, size, dtype):
+        self.cpu = torch.zeros(size, dtype=dtype, device="cpu")
+        self.np = self.cpu.numpy()
+        dev = torch.device("cuda", torch.cuda.current_device())
+        self.uva = torch.zeros(size, dtype=dtype, device=dev)
+
+    def _pool_copy_to_uva(self, x):
+        self._curr = (self._curr + 1) % self.max_concurrency
+        buf = self._uva_bufs[self._curr]
+        dst = buf.cpu if isinstance(x, torch.Tensor) else buf.np
+        n = len(x)
+        dst[:n] = x
+        buf.uva[:n].copy_(buf.cpu[:n], non_blocking=True)
+        return buf.uva[:n]
+
+    UvaBuffer.__init__ = _uvabuffer_init
+    UvaBufferPool.copy_to_uva = _pool_copy_to_uva

--- a/vllm_kunlun/v1/worker/gpu/input_batch.py
+++ b/vllm_kunlun/v1/worker/gpu/input_batch.py
@@ -1,0 +1,228 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Kunlun torch-native replacement for ``vllm.v1.worker.gpu.input_batch``.
+
+Reuses the upstream ``InputBuffers`` / ``InputBatch`` dataclasses (loaded via
+``load_upstream``) and reimplements the seven Triton-backed module functions
+with torch-native equivalents. The functions operate on jagged per-request
+segments; the correctness-first implementation loops per request in Python
+(``num_reqs`` is small, typically <= a few hundred) and pulls the small
+metadata index tensors to host once per call. Optimizing the hot ones with
+``kunlun_ops`` is a later step.
+"""
+
+import torch
+
+from vllm_kunlun.v1.worker.gpu._upstream import load_upstream
+
+_up = load_upstream("vllm.v1.worker.gpu.input_batch")
+
+InputBuffers = _up.InputBuffers
+InputBatch = _up.InputBatch
+
+
+def prepare_prefill_inputs(
+    input_ids: torch.Tensor,
+    next_prefill_tokens: torch.Tensor,
+    idx_mapping: torch.Tensor,
+    query_start_loc: torch.Tensor,
+    all_token_ids: torch.Tensor,
+    prefill_len: torch.Tensor,
+    num_computed_tokens: torch.Tensor,
+) -> None:
+    num_reqs = idx_mapping.shape[0]
+    idx = idx_mapping.tolist()
+    qsl = query_start_loc.tolist()
+    pl = prefill_len.tolist()
+    nc = num_computed_tokens.tolist()
+    for b in range(num_reqs):
+        rs = idx[b]
+        prefill = pl[rs]
+        computed = nc[rs]
+        if computed >= prefill:
+            # Not prefilling this step.
+            continue
+        qs = qsl[b]
+        qe = qsl[b + 1]
+        query_len = qe - qs
+        input_ids[qs:qe] = all_token_ids[rs, computed : computed + query_len]
+        next_pos = computed + query_len
+        if next_pos < prefill:
+            next_prefill_tokens[rs] = all_token_ids[rs, next_pos]
+
+
+def prepare_pos_seq_lens(
+    idx_mapping: torch.Tensor,
+    query_start_loc: torch.Tensor,
+    num_computed_tokens: torch.Tensor,
+    pos: torch.Tensor,
+    seq_lens: torch.Tensor,
+) -> None:
+    num_reqs = idx_mapping.shape[0]
+    # Pad unused seq_lens as 0 (full CUDA graph parity).
+    seq_lens[num_reqs:] = 0
+    idx = idx_mapping.tolist()
+    qsl = query_start_loc.tolist()
+    nc = num_computed_tokens.tolist()
+    for b in range(num_reqs):
+        computed = nc[idx[b]]
+        qs = qsl[b]
+        qe = qsl[b + 1]
+        query_len = qe - qs
+        seq_lens[b] = computed + query_len
+        if query_len > 0:
+            pos[qs:qe] = torch.arange(
+                computed, computed + query_len, dtype=pos.dtype, device=pos.device
+            )
+
+
+def combine_sampled_and_draft_tokens(
+    input_ids: torch.Tensor,
+    idx_mapping: torch.Tensor,
+    last_sampled_tokens: torch.Tensor,
+    query_start_loc: torch.Tensor,
+    seq_lens: torch.Tensor,
+    prefill_len: torch.Tensor,
+    draft_tokens: torch.Tensor,
+    cu_num_logits: torch.Tensor,
+    num_logits: int,
+    num_new_sampled_tokens: int = 1,
+) -> torch.Tensor:
+    assert num_new_sampled_tokens in (
+        0,
+        1,
+    ), f"num_new_sampled_tokens must be 0 or 1, got {num_new_sampled_tokens}"
+    num_reqs = idx_mapping.shape[0]
+    device = input_ids.device
+    logits_indices = torch.empty(num_logits, dtype=torch.int64, device=device)
+
+    idx = idx_mapping.tolist()
+    qsl = query_start_loc.tolist()
+    cnl = cu_num_logits.tolist()
+    sl = seq_lens.tolist()
+    pl = prefill_len.tolist()
+    for b in range(num_reqs):
+        rs = idx[b]
+        cl_start = cnl[b]
+        cl_end = cnl[b + 1]
+        nlog = cl_end - cl_start
+        query_end = qsl[b + 1]
+        logits_start = query_end - nlog
+        logits_indices[cl_start:cl_end] = torch.arange(
+            logits_start, logits_start + nlog, dtype=torch.int64, device=device
+        )
+
+        seq_len = sl[b]
+        prefill = pl[rs]
+        if seq_len <= prefill:
+            # Prefill tokens: no sampled/draft tokens to splice in.
+            continue
+
+        num_draft = nlog - num_new_sampled_tokens
+        first_logit_seq_pos = seq_len - nlog
+        if num_new_sampled_tokens > 0 and first_logit_seq_pos >= prefill:
+            input_ids[logits_start] = last_sampled_tokens[rs]
+        if num_draft > 0:
+            input_ids[query_end - num_draft : query_end] = draft_tokens[rs, :num_draft]
+    return logits_indices
+
+
+def get_num_sampled_and_rejected(
+    num_sampled: torch.Tensor,
+    seq_lens: torch.Tensor,
+    cu_num_logits: torch.Tensor,
+    idx_mapping: torch.Tensor,
+    prefill_len: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    num_reqs = idx_mapping.shape[0]
+    idx_long = idx_mapping.to(torch.long)
+    prefill = prefill_len[idx_long]
+    is_chunked = seq_lens[:num_reqs] < prefill
+    num_logits = cu_num_logits[1 : num_reqs + 1] - cu_num_logits[:num_reqs]
+
+    zero = torch.zeros_like(num_sampled[:num_reqs])
+    num_sampled[:num_reqs] = torch.where(is_chunked, zero, num_sampled[:num_reqs])
+    num_rejected = torch.empty_like(num_sampled)
+    rejected = num_logits - num_sampled[:num_reqs]
+    num_rejected[:num_reqs] = torch.where(
+        is_chunked, torch.zeros_like(rejected), rejected
+    )
+    return num_sampled, num_rejected
+
+
+def post_update(
+    idx_mapping: torch.Tensor,
+    num_computed_tokens: torch.Tensor,
+    last_sampled_tokens: torch.Tensor,
+    output_bin_counts: torch.Tensor | None,
+    sampled_tokens: torch.Tensor,
+    num_sampled: torch.Tensor,
+    num_rejected: torch.Tensor,
+    query_start_loc: torch.Tensor | None,
+    all_token_ids: torch.Tensor,
+    total_len: torch.Tensor,
+) -> None:
+    num_reqs = idx_mapping.shape[0]
+    idx = idx_mapping.tolist()
+    ns = num_sampled.tolist()
+    nr = num_rejected.tolist()
+    tl_list = total_len.tolist()
+    qsl = query_start_loc.tolist() if query_start_loc is not None else None
+    for b in range(num_reqs):
+        rs = idx[b]
+        if rs < 0:
+            # Filtered row.
+            continue
+        num_s = ns[b]
+        if num_s > 0:
+            base = tl_list[rs]
+            last_sampled_tokens[rs] = sampled_tokens[b, num_s - 1]
+            tokens = sampled_tokens[b, :num_s]
+            all_token_ids[rs, base : base + num_s] = tokens
+            total_len[rs] = base + num_s
+            if output_bin_counts is not None:
+                toks = tokens.to(torch.long)
+                output_bin_counts[rs].scatter_add_(
+                    0, toks, torch.ones_like(toks, dtype=output_bin_counts.dtype)
+                )
+        query_len = 0 if qsl is None else (qsl[b + 1] - qsl[b])
+        computed_delta = query_len - nr[b]
+        if computed_delta != 0:
+            num_computed_tokens[rs] += computed_delta
+
+
+def post_update_num_computed_tokens(
+    idx_mapping: torch.Tensor,
+    num_computed_tokens: torch.Tensor,
+    query_start_loc: torch.Tensor,
+) -> None:
+    num_reqs = idx_mapping.shape[0]
+    idx_long = idx_mapping.to(torch.long)
+    query_len = (query_start_loc[1 : num_reqs + 1] - query_start_loc[:num_reqs]).to(
+        num_computed_tokens.dtype
+    )
+    # Each request appears once per batch, so plain indexed add is correct.
+    num_computed_tokens[idx_long] += query_len
+
+
+def expand_idx_mapping(
+    idx_mapping: torch.Tensor,
+    total_num_logits: int,
+    cu_num_logits: torch.Tensor,
+    max_expand_len: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    num_reqs = idx_mapping.shape[0]
+    device = idx_mapping.device
+    expanded_idx_mapping = idx_mapping.new_empty(total_num_logits)
+    expanded_local_pos = torch.empty(total_num_logits, dtype=torch.int32, device=device)
+    cnl = cu_num_logits.tolist()
+    idx = idx_mapping.tolist()
+    for r in range(num_reqs):
+        s = cnl[r]
+        e = cnl[r + 1]
+        n = e - s
+        if n <= 0:
+            continue
+        expanded_idx_mapping[s:e] = idx[r]
+        expanded_local_pos[s:e] = torch.arange(n, dtype=torch.int32, device=device)
+    return expanded_idx_mapping, expanded_local_pos

--- a/vllm_kunlun/v1/worker/gpu/mm/__init__.py
+++ b/vllm_kunlun/v1/worker/gpu/mm/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project

--- a/vllm_kunlun/v1/worker/gpu/mm/rope.py
+++ b/vllm_kunlun/v1/worker/gpu/mm/rope.py
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Kunlun replacement for ``vllm.v1.worker.gpu.mm.rope``.
+
+Only ``RopeState.prepare_positions`` launches Triton
+(``_prepare_rope_positions_kernel``, launched at ``mm/rope.py:118``). It is on
+the live path for every mrope / XD-RoPE model, reached from
+``DefaultModelState.prepare_inputs`` (``model_states/default.py:114-119``) --
+which includes the whole Qwen3-VL family and the Qwen3.5 hybrid VL
+architecture, since ``MambaHybridModelState`` extends ``DefaultModelState``.
+
+Everything else in the module (``init_prefill_positions``,
+``apply_staged_writes``, ``read_prefill_positions``,
+``update_prefill_positions``, ``get_positions``, ``get_rope_state``) is plain
+torch and is reused as-is.
+"""
+
+import logging
+
+from vllm_kunlun.v1.worker.gpu._kernels import prepare_rope_positions
+from vllm_kunlun.v1.worker.gpu._upstream import load_upstream, reexport
+
+logger = logging.getLogger("vllm_kunlun")
+
+_up = load_upstream("vllm.v1.worker.gpu.mm.rope")
+reexport(_up, globals())
+
+
+def _prepare_positions(
+    self, idx_mapping, query_start_loc, prefill_lens, num_computed_tokens
+) -> None:
+    # ``prefill_positions`` is a StagedWriteTensor and ``prefill_delta`` a
+    # UvaBackedTensor from gpu.buffer_utils, which is itself swapped for the
+    # Kunlun device-tensor version -- ``.gpu`` is valid either way.
+    prepare_rope_positions(
+        positions=self.positions,
+        prefill_positions=self.prefill_positions.gpu,
+        prefill_delta=self.prefill_delta.gpu,
+        idx_mapping=idx_mapping,
+        query_start_loc=query_start_loc,
+        prefill_lens=prefill_lens,
+        num_computed_tokens=num_computed_tokens,
+        num_dims=self.num_dims,
+        max_model_len=self.max_model_len,
+    )
+
+
+if not getattr(_up.RopeState, "_kunlun_v2_patched", False):
+    _up.RopeState.prepare_positions = _prepare_positions
+    _up.RopeState._kunlun_v2_patched = True
+    logger.info("[KunlunPlugin] V2 RopeState.prepare_positions patched (torch-native)")

--- a/vllm_kunlun/v1/worker/gpu/model_states/__init__.py
+++ b/vllm_kunlun/v1/worker/gpu/model_states/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project

--- a/vllm_kunlun/v1/worker/gpu/model_states/mamba_hybrid.py
+++ b/vllm_kunlun/v1/worker/gpu/model_states/mamba_hybrid.py
@@ -1,0 +1,72 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Kunlun replacement for ``vllm.v1.worker.gpu.model_states.mamba_hybrid``.
+
+Upstream has three Triton launch sites in this module:
+
+* ``:195`` ``preprocess_mamba_align_fused_kernel``        -- align mode only
+* ``:308`` ``_scatter_num_accepted_kernel``               -- every step (live)
+* ``MambaSpecDecodeGPUContext.run_fused_precopy`` / ``run_fused_postprocess_align``
+  (``:207`` / ``:328``)                                   -- align mode only
+
+Align mode requires prefix caching (``models/config.py:596-600`` forces
+``mamba_cache_mode="none"`` otherwise, which leaves ``_align_mode`` False at
+``mamba_hybrid.py:86``), so only the scatter kernel is live in a
+prefix-caching-off configuration. It is replaced with a torch-native scatter.
+
+We patch the module-level *kernel object* rather than the method that launches
+it: ``MambaHybridModelState.postprocess_state`` is defined in the upstream
+module, so its ``__globals__`` *is* the upstream module dict, and rebinding the
+name there is picked up at call time. That leaves the surrounding logic --
+including the ``int`` branch at ``:311-315`` (plain ``index_fill_``, no Triton)
+and the align branch -- completely untouched.
+"""
+
+import logging
+
+from vllm_kunlun.v1.worker.gpu._kernels import TorchKernel, scatter_num_accepted
+from vllm_kunlun.v1.worker.gpu._upstream import load_upstream, reexport
+
+logger = logging.getLogger("vllm_kunlun")
+
+_up = load_upstream("vllm.v1.worker.gpu.model_states.mamba_hybrid")
+reexport(_up, globals())
+
+if not getattr(_up.MambaHybridModelState, "_kunlun_v2_patched", False):
+    _up._scatter_num_accepted_kernel = TorchKernel(scatter_num_accepted)
+
+    # ``MambaHybridAttnMetadata.get_extra_attn_kwargs`` (:47-64) decides whether
+    # to forward ``num_accepted_tokens`` / ``num_decode_draft_tokens_cpu`` by
+    # doing an isinstance check against the GDN builder class resolved from this
+    # module's globals (bound at :17 from vllm.v1.attention.backends.gdn_attn).
+    #
+    # Kunlun's builder is NOT a subclass of upstream's -- it works today only
+    # because vllm_kunlun/v1/attention/backends/gdn_attn.py:510-512
+    # monkey-patches the upstream module and happens to be imported first (via
+    # vllm_kunlun/models/qwen3_next.py). If that ordering ever inverts the
+    # isinstance check silently fails and the spec-decode kwargs are dropped --
+    # wrong results, no error. Bind it explicitly so the check is
+    # order-independent.
+    try:
+        from vllm_kunlun.v1.attention.backends.gdn_attn import (
+            GDNAttentionMetadataBuilder as _KunlunGDNBuilder,
+        )
+
+        _up.GDNAttentionMetadataBuilder = _KunlunGDNBuilder
+        GDNAttentionMetadataBuilder = _KunlunGDNBuilder
+    except Exception:
+        logger.warning(
+            "[KunlunPlugin] could not bind the Kunlun GDN metadata builder into "
+            "mamba_hybrid; spec-decode extra attn kwargs may be dropped",
+            exc_info=True,
+        )
+
+    _up.MambaHybridModelState._kunlun_v2_patched = True
+    logger.info(
+        "[KunlunPlugin] V2 MambaHybridModelState patched "
+        "(torch-native scatter_num_accepted)"
+    )
+
+# Keep this module's name pointing at whatever is installed upstream, so a
+# consumer importing it from here sees the patched object.
+_scatter_num_accepted_kernel = _up._scatter_num_accepted_kernel

--- a/vllm_kunlun/v1/worker/gpu/sample/__init__.py
+++ b/vllm_kunlun/v1/worker/gpu/sample/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project

--- a/vllm_kunlun/v1/worker/gpu/sample/bad_words.py
+++ b/vllm_kunlun/v1/worker/gpu/sample/bad_words.py
@@ -1,0 +1,77 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Kunlun torch-native replacement for ``vllm.v1.worker.gpu.sample.bad_words``.
+
+Reuses the upstream ``BadWordsState`` / constants and reimplements
+``apply_bad_words``. For each sampled position it checks, per bad-word, whether
+the trailing generated tokens match the bad-word prefix and, if so, bans the
+final token by setting its logit to -inf.
+
+NOTE: the spec-decode path (reading candidate tokens from ``input_ids`` when
+``expanded_local_pos`` > 0) is not implemented; milestone-1 has
+``expanded_local_pos == 0`` so all comparison tokens come from the committed
+output sequence.
+"""
+
+import torch
+
+from vllm_kunlun.v1.worker.gpu._upstream import load_upstream
+
+_up = load_upstream("vllm.v1.worker.gpu.sample.bad_words")
+
+BadWordsState = _up.BadWordsState
+MAX_BAD_WORDS_TOTAL_TOKENS = _up.MAX_BAD_WORDS_TOTAL_TOKENS
+MAX_NUM_BAD_WORDS = _up.MAX_NUM_BAD_WORDS
+
+_NEG_INF = float("-inf")
+
+
+def apply_bad_words(
+    logits: torch.Tensor,
+    expanded_idx_mapping: torch.Tensor,
+    bad_word_token_ids: torch.Tensor,
+    bad_word_offsets: torch.Tensor,
+    num_bad_words: torch.Tensor,
+    all_token_ids: torch.Tensor,
+    prompt_len: torch.Tensor,
+    total_len: torch.Tensor,
+    input_ids: torch.Tensor,
+    expanded_local_pos: torch.Tensor,
+    max_num_bad_words: int,
+) -> None:
+    num_tokens = logits.shape[0]
+    idx = expanded_idx_mapping.tolist()
+    nbw_list = num_bad_words.tolist()
+    pl_list = prompt_len.tolist()
+    tl_list = total_len.tolist()
+    pos_list = expanded_local_pos.tolist()
+
+    for t in range(num_tokens):
+        rs = idx[t]
+        nbw = nbw_list[rs]
+        if nbw == 0:
+            continue
+        prompt = pl_list[rs]
+        output_len = tl_list[rs] - prompt
+        effective_len = output_len + pos_list[t]
+        offsets_row = bad_word_offsets[rs, : nbw + 1].tolist()
+        for bw in range(nbw):
+            start = offsets_row[bw]
+            end = offsets_row[bw + 1]
+            prefix_len = end - start - 1
+            if prefix_len > effective_len:
+                continue
+            last_token = bad_word_token_ids[rs, end - 1 : end].to(torch.long)
+            if prefix_len == 0:
+                logits[t, last_token] = _NEG_INF
+                continue
+            expected = bad_word_token_ids[rs, start : end - 1].to(torch.long)
+            a_start = prompt + (effective_len - prefix_len)
+            actual = all_token_ids[rs, a_start : a_start + prefix_len].to(torch.long)
+            if bool((expected == actual).all()):
+                logits[t, last_token] = _NEG_INF
+
+
+# BadWordsState (reused from the genuine module) resolves ``apply_bad_words``
+# from that module's globals; install the torch-native version there.
+_up.apply_bad_words = apply_bad_words

--- a/vllm_kunlun/v1/worker/gpu/sample/gumbel.py
+++ b/vllm_kunlun/v1/worker/gpu/sample/gumbel.py
@@ -1,0 +1,92 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Kunlun torch-native replacement for ``vllm.v1.worker.gpu.sample.gumbel``.
+
+Replaces the Triton Gumbel-max sampler. Greedy requests (temperature == 0)
+reduce to a plain argmax and are bit-exact vs upstream. Random requests use
+torch-native Gumbel-max noise, which is distributionally equivalent but NOT
+bit-reproducible against the upstream Philox kernel; per-request seed
+reproducibility is therefore not preserved in this milestone (documented
+limitation -- a seeded ``kunlun_ops`` gumbel kernel is the planned follow-up).
+
+``gumbel_sample`` is only ever called on the sampled-position logits
+(``num_tokens`` ~= number of requests), so the tensors here are small.
+"""
+
+import torch
+
+# fp32-safe clamp bounds so log/log1p never see 0 or 1.
+_TINY = 1.0e-20
+_ONE_MINUS = 1.0 - 1.0e-7
+
+
+def apply_temperature(
+    logits: torch.Tensor,
+    expanded_idx_mapping: torch.Tensor,
+    temperature: torch.Tensor,
+) -> None:
+    """In-place divide each row's logits by its request temperature.
+
+    Rows whose temperature is 0 (greedy) or 1 are left unchanged, matching the
+    upstream kernel's early-return.
+    """
+    idx = expanded_idx_mapping.to(torch.long)
+    temp = temperature[idx].to(torch.float32)  # [num_tokens]
+    # temp == 0 -> greedy (skip); use 1.0 as a no-op divisor.
+    safe = torch.where(temp == 0.0, torch.ones_like(temp), temp)
+    logits.div_(safe.unsqueeze(1).to(logits.dtype))
+
+
+def gumbel_sample(
+    logits: torch.Tensor,  # [num_tokens, vocab_size]
+    expanded_idx_mapping: torch.Tensor,  # [num_tokens]
+    temperature: torch.Tensor,  # [max_num_reqs]
+    seed: torch.Tensor,  # [max_num_reqs]
+    pos: torch.Tensor,  # [num_tokens]
+    apply_temperature: bool,
+    output_processed_logits: torch.Tensor | None = None,
+    output_processed_logits_col: torch.Tensor | None = None,
+    use_fp64: bool = False,
+) -> torch.Tensor:
+    assert output_processed_logits is None, (
+        "gumbel_sample: output_processed_logits (spec-decode path) is not "
+        "supported on the Kunlun V2 milestone-1 sampler."
+    )
+    idx = expanded_idx_mapping.to(torch.long)
+    temp = temperature[idx].to(torch.float32).unsqueeze(1)  # [num_tokens, 1]
+
+    lf = logits.to(torch.float32)
+    if apply_temperature:
+        safe = torch.where(temp == 0.0, torch.ones_like(temp), temp)
+        lf = lf / safe
+
+    # Gumbel-max: argmax(logits + gumbel_noise). Draw the winning tail from
+    # u -> 0 via log1p(-u), matching the upstream numerics choice.
+    u = torch.rand_like(lf).clamp_(_TINY, _ONE_MINUS)
+    gumbel = -torch.log(-torch.log1p(-u))
+
+    # Greedy rows (temp == 0): no noise, plain argmax.
+    noised = torch.where(temp == 0.0, lf, lf + gumbel)
+    return noised.argmax(dim=-1).to(torch.int64)
+
+
+# ``vllm.v1.worker.gpu.spec_decode.rejection_sampler_utils`` imports these two
+# Triton device functions at module scope, and that module is imported
+# unconditionally by the V2 model runner (via kernel_warmup), so the names must
+# exist here or the worker fails to start. They are only ever referenced from
+# inside ``@triton.jit`` kernel bodies, which never execute on Kunlun XPU
+# (HAS_TRITON is False), so plain raising stubs are sufficient.
+_SPEC_DECODE_UNSUPPORTED = (
+    "{name} is a Triton device function and is not supported on Kunlun XPU; "
+    "the V2 GPU spec-decode rejection sampler path is unavailable."
+)
+
+
+def tl_rand32(seed, offset, includes_zero=False):
+    raise NotImplementedError(_SPEC_DECODE_UNSUPPORTED.format(name="tl_rand32"))
+
+
+def gumbel_block_argmax(*args, **kwargs):
+    raise NotImplementedError(
+        _SPEC_DECODE_UNSUPPORTED.format(name="gumbel_block_argmax")
+    )

--- a/vllm_kunlun/v1/worker/gpu/sample/logit_bias.py
+++ b/vllm_kunlun/v1/worker/gpu/sample/logit_bias.py
@@ -1,0 +1,73 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Kunlun torch-native replacement for ``vllm.v1.worker.gpu.sample.logit_bias``.
+
+Reuses the upstream ``LogitBiasState`` / constants and reimplements
+``apply_logit_bias`` (allowed-token masking, logit-bias addition, and min-token
+stop-token masking) with per-request torch ops. ``num_tokens`` here equals the
+number of sampled positions (~ request count), so the per-request loop is cheap.
+"""
+
+import torch
+
+from vllm_kunlun.v1.worker.gpu._upstream import load_upstream
+
+_up = load_upstream("vllm.v1.worker.gpu.sample.logit_bias")
+
+LogitBiasState = _up.LogitBiasState
+MAX_NUM_ALLOWED_TOKEN_IDS = _up.MAX_NUM_ALLOWED_TOKEN_IDS
+MAX_NUM_LOGIT_BIAS_TOKENS = _up.MAX_NUM_LOGIT_BIAS_TOKENS
+MAX_NUM_STOP_TOKEN_IDS = _up.MAX_NUM_STOP_TOKEN_IDS
+
+_NEG_INF = float("-inf")
+
+
+def apply_logit_bias(
+    logits: torch.Tensor,
+    expanded_idx_mapping: torch.Tensor,
+    pos: torch.Tensor,
+    num_allowed_token_ids: torch.Tensor,
+    allowed_token_ids: torch.Tensor,
+    num_logit_bias: torch.Tensor,
+    logit_bias_token_ids: torch.Tensor,
+    logit_bias: torch.Tensor,
+    min_lens: torch.Tensor,
+    num_stop_token_ids: torch.Tensor,
+    stop_token_ids: torch.Tensor,
+) -> None:
+    num_tokens = logits.shape[0]
+    idx = expanded_idx_mapping.tolist()
+    na = num_allowed_token_ids.tolist()
+    nb = num_logit_bias.tolist()
+    ns = num_stop_token_ids.tolist()
+    ml = min_lens.tolist()
+    pos_l = pos.tolist()
+
+    for t in range(num_tokens):
+        rs = idx[t]
+        row = logits[t]
+
+        # Allowed token IDs: keep only those logits, mask the rest to -inf.
+        n_allow = na[rs]
+        if n_allow > 0:
+            allowed = allowed_token_ids[rs, :n_allow].to(torch.long)
+            saved = row[allowed].clone()
+            row.fill_(_NEG_INF)
+            row[allowed] = saved
+
+        # Logit bias: add bias to the specified token IDs.
+        n_bias = nb[rs]
+        if n_bias > 0:
+            tids = logit_bias_token_ids[rs, :n_bias].to(torch.long)
+            row[tids] += logit_bias[rs, :n_bias].to(row.dtype)
+
+        # Min tokens: block stop tokens until min length is reached.
+        n_stop = ns[rs]
+        if n_stop > 0 and pos_l[t] + 1 < ml[rs]:
+            stids = stop_token_ids[rs, :n_stop].to(torch.long)
+            row[stids] = _NEG_INF
+
+
+# LogitBiasState (reused from the genuine module) resolves ``apply_logit_bias``
+# from that module's globals; install the torch-native version there.
+_up.apply_logit_bias = apply_logit_bias

--- a/vllm_kunlun/v1/worker/gpu/sample/logprob.py
+++ b/vllm_kunlun/v1/worker/gpu/sample/logprob.py
@@ -1,0 +1,95 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Kunlun torch-native replacement for ``vllm.v1.worker.gpu.sample.logprob``.
+
+Reuses the upstream ``LogprobTokenIdsState`` and reimplements the logprob
+computation (log-softmax gather + selected-token ranks) with torch ops. The
+custom per-request ``logprob_token_ids`` path is reimplemented with a small
+per-row loop.
+"""
+
+import torch
+from vllm.v1.outputs import LogprobsTensors
+
+from vllm_kunlun.v1.worker.gpu._upstream import load_upstream
+
+_up = load_upstream("vllm.v1.worker.gpu.sample.logprob")
+
+LogprobTokenIdsState = _up.LogprobTokenIdsState
+
+
+def compute_token_logprobs(
+    logits: torch.Tensor, token_ids: torch.Tensor
+) -> torch.Tensor:
+    token_ids = token_ids.to(torch.int64)
+    lf = logits.to(torch.float32)
+    log_probs = lf - torch.logsumexp(lf, dim=-1, keepdim=True)
+    return torch.gather(log_probs, 1, token_ids)
+
+
+def compute_topk_logprobs(
+    logits: torch.Tensor,
+    num_logprobs: int,
+    sampled_token_ids: torch.Tensor,
+    cu_num_logits=None,
+    logprob_token_ids_state=None,
+    expanded_idx_mapping=None,
+    max_per_req_token_ids: int = 0,
+) -> LogprobsTensors:
+    assert num_logprobs >= 0
+    batch_size, vocab_size = logits.shape
+    lf = logits.to(torch.float32)
+
+    if max_per_req_token_ids == 0:
+        logprob_token_ids = sampled_token_ids.unsqueeze(-1)
+        if num_logprobs > 0:
+            topk_indices = torch.topk(logits, num_logprobs, dim=-1).indices
+            logprob_token_ids = torch.cat((logprob_token_ids, topk_indices), dim=1)
+        logprobs = compute_token_logprobs(logits, logprob_token_ids)
+    else:
+        assert logprob_token_ids_state is not None
+        assert expanded_idx_mapping is not None
+        num_cols = max(num_logprobs, max_per_req_token_ids)
+        logprob_token_ids = sampled_token_ids.new_zeros((batch_size, 1 + num_cols))
+        valid_mask = torch.zeros_like(logprob_token_ids, dtype=torch.bool)
+        logprob_token_ids[:, 0] = sampled_token_ids
+        valid_mask[:, 0] = True
+
+        topk_token_ids = None
+        if num_logprobs > 0:
+            topk_token_ids = torch.topk(logits, num_logprobs, dim=-1).indices
+
+        idx = expanded_idx_mapping.to(torch.long)
+        num_custom = logprob_token_ids_state.num_token_ids.gpu[idx].tolist()
+        per_req = logprob_token_ids_state.token_ids.gpu
+        for b in range(batch_size):
+            nc = num_custom[b]
+            if nc > 0:
+                logprob_token_ids[b, 1 : 1 + nc] = per_req[idx[b], :nc].to(
+                    logprob_token_ids.dtype
+                )
+                valid_mask[b, 1 : 1 + nc] = True
+            elif num_logprobs > 0:
+                logprob_token_ids[b, 1 : 1 + num_logprobs] = topk_token_ids[b].to(
+                    logprob_token_ids.dtype
+                )
+                valid_mask[b, 1 : 1 + num_logprobs] = True
+        logprobs = compute_token_logprobs(logits, logprob_token_ids)
+        logprobs = logprobs.masked_fill(~valid_mask, float("-inf"))
+
+    # Selected-token ranks: count logits >= the sampled token's logit.
+    x = torch.gather(lf, 1, sampled_token_ids.view(-1, 1).to(torch.int64))
+    token_ranks = (lf >= x).sum(dim=-1).to(torch.int64)
+
+    return LogprobsTensors(
+        logprob_token_ids=logprob_token_ids,
+        logprobs=logprobs,
+        selected_token_ranks=token_ranks,
+        cu_num_generated_tokens=cu_num_logits,
+    )
+
+
+# Keep the genuine module's globals in sync so any reused code there also picks
+# up the torch-native implementations.
+_up.compute_token_logprobs = compute_token_logprobs
+_up.compute_topk_logprobs = compute_topk_logprobs

--- a/vllm_kunlun/v1/worker/gpu/sample/min_p.py
+++ b/vllm_kunlun/v1/worker/gpu/sample/min_p.py
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Kunlun torch-native replacement for ``vllm.v1.worker.gpu.sample.min_p``."""
+
+import torch
+
+
+def apply_min_p(
+    logits: torch.Tensor, expanded_idx_mapping: torch.Tensor, min_p: torch.Tensor
+) -> None:
+    """In-place min-p filtering.
+
+    Tokens whose logit is below ``max_logit + log(min_p)`` are set to -inf.
+    Rows with ``min_p == 0`` are left unchanged (threshold -> -inf).
+    """
+    idx = expanded_idx_mapping.to(torch.long)
+    mp = min_p[idx].to(torch.float32)  # [num_tokens]
+    max_val = logits.max(dim=-1, keepdim=True).values.to(torch.float32)
+    log_mp = torch.where(mp > 0.0, torch.log(mp), torch.full_like(mp, float("-inf")))
+    threshold = (max_val + log_mp.unsqueeze(1)).to(logits.dtype)
+    logits.masked_fill_(logits < threshold, float("-inf"))

--- a/vllm_kunlun/v1/worker/gpu/sample/penalties.py
+++ b/vllm_kunlun/v1/worker/gpu/sample/penalties.py
@@ -1,0 +1,111 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Kunlun torch-native replacement for ``vllm.v1.worker.gpu.sample.penalties``.
+
+Reuses the upstream ``PenaltiesState`` / ``use_penalty`` and reimplements the
+two Triton functions ``bincount`` (prompt/output token statistics, built once
+per new penalty request) and ``apply_penalties`` (per-step repetition /
+frequency / presence penalties).
+
+NOTE: the spec-decode draft-token accumulation (the ``expanded_local_pos``
+loop in the upstream kernel) is omitted; in the milestone-1 non-spec path
+``expanded_local_pos`` is all zeros, so ``output_bin_counts`` as maintained by
+``post_update`` is already correct.
+"""
+
+import torch
+
+from vllm_kunlun.v1.worker.gpu._upstream import load_upstream
+
+_up = load_upstream("vllm.v1.worker.gpu.sample.penalties")
+
+PenaltiesState = _up.PenaltiesState
+use_penalty = _up.use_penalty
+
+
+def bincount(
+    expanded_idx_mapping: torch.Tensor,
+    all_token_ids: torch.Tensor,
+    prompt_len: torch.Tensor,
+    prefill_len: torch.Tensor,
+    prompt_bin_mask: torch.Tensor,
+    output_bin_counts: torch.Tensor,
+    max_prefill_len: int,
+) -> None:
+    idx_long = expanded_idx_mapping.long()
+    # Reset stats for the affected requests (index_fill_ avoids a host sync).
+    prompt_bin_mask.index_fill_(0, idx_long, 0)
+    output_bin_counts.index_fill_(0, idx_long, 0)
+
+    device = prompt_bin_mask.device
+    vocab_size = output_bin_counts.shape[1]
+    packed_cols = prompt_bin_mask.shape[1]
+    padded = packed_cols * 32
+    shifts = torch.arange(32, device=device, dtype=torch.int64)
+
+    reqs = idx_long.tolist()
+    pls = prompt_len.tolist()
+    pfl = prefill_len.tolist()
+    for rs in reqs:
+        pl = pls[rs]
+        pf = pfl[rs]
+        tokens = all_token_ids[rs, :pf].to(torch.long)
+        if pl > 0:
+            # Pack prompt-token presence into 32-bit words (word=tok//32,
+            # bit=tok%32) to match the layout apply_penalties unpacks.
+            present = torch.zeros(padded, dtype=torch.int64, device=device)
+            present[tokens[:pl]] = 1
+            words = (present.view(packed_cols, 32) << shifts).sum(dim=1)
+            prompt_bin_mask[rs] = words.to(torch.int32)
+        if pf > pl:
+            counts = torch.bincount(tokens[pl:pf], minlength=vocab_size)[:vocab_size]
+            output_bin_counts[rs] = counts.to(torch.int32)
+
+
+def apply_penalties(
+    logits: torch.Tensor,
+    expanded_idx_mapping: torch.Tensor,
+    token_ids: torch.Tensor,
+    expanded_local_pos: torch.Tensor,
+    repetition_penalty: torch.Tensor,
+    frequency_penalty: torch.Tensor,
+    presence_penalty: torch.Tensor,
+    prompt_bin_mask: torch.Tensor,
+    output_bin_counts: torch.Tensor,
+) -> None:
+    num_tokens, vocab_size = logits.shape
+    device = logits.device
+    idx = expanded_idx_mapping.to(torch.long)  # [num_tokens]
+    rep = repetition_penalty[idx].to(torch.float32)  # [num_tokens]
+    freq = frequency_penalty[idx].to(torch.float32)
+    pres = presence_penalty[idx].to(torch.float32)
+
+    lf = logits.to(torch.float32)
+
+    # Per-position output token counts (spec-decode draft accumulation omitted).
+    out_counts = output_bin_counts[idx].to(torch.float32)  # [num_tokens, vocab]
+    output_mask = out_counts > 0
+
+    # Unpack prompt-token bitmask to a [num_tokens, vocab] boolean.
+    packed = prompt_bin_mask[idx].to(torch.int64) & 0xFFFFFFFF  # [num_tokens, packed]
+    shifts = torch.arange(32, device=device, dtype=torch.int64)
+    bits = (packed.unsqueeze(-1) >> shifts) & 1  # [num_tokens, packed, 32]
+    prompt_mask = bits.reshape(num_tokens, -1)[:, :vocab_size].to(torch.bool)
+
+    # Repetition penalty: divide positive logits, multiply negative ones.
+    ones = torch.ones_like(rep).unsqueeze(1)
+    scale = torch.where(prompt_mask | output_mask, rep.unsqueeze(1), ones)
+    lf = lf * torch.where(lf > 0, 1.0 / scale, scale)
+
+    # Frequency and presence penalties.
+    lf = lf - freq.unsqueeze(1) * out_counts
+    lf = lf - pres.unsqueeze(1) * output_mask.to(torch.float32)
+
+    logits.copy_(lf.to(logits.dtype))
+
+
+# The reused PenaltiesState (defined in the genuine module) resolves
+# ``apply_penalties`` / ``bincount`` from that module's globals, so the
+# torch-native versions must be installed there, not just re-exported here.
+_up.apply_penalties = apply_penalties
+_up.bincount = bincount

--- a/vllm_kunlun/v1/worker/gpu/sample/prompt_logprob.py
+++ b/vllm_kunlun/v1/worker/gpu/sample/prompt_logprob.py
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Kunlun torch-native replacement for ``vllm.v1.worker.gpu.sample.prompt_logprob``.
+
+Reuses the upstream ``PromptLogprobsWorker`` (and its chunked-logits helper,
+which already routes through the swapped ``logprob`` module) and only
+reimplements the single Triton function ``get_prompt_logprobs_token_ids`` that
+gathers the shifted next-token ids for each prompt position.
+"""
+
+import torch
+
+from vllm_kunlun.v1.worker.gpu._upstream import load_upstream
+
+_up = load_upstream("vllm.v1.worker.gpu.sample.prompt_logprob")
+
+PromptLogprobsWorker = _up.PromptLogprobsWorker
+compute_prompt_logprobs_with_chunking = _up.compute_prompt_logprobs_with_chunking
+
+
+def get_prompt_logprobs_token_ids(
+    num_tokens: int,
+    query_start_loc: torch.Tensor,
+    idx_mapping: torch.Tensor,
+    num_computed_tokens: torch.Tensor,
+    all_token_ids: torch.Tensor,
+) -> torch.Tensor:
+    device = idx_mapping.device
+    token_ids = torch.empty(num_tokens, dtype=torch.int64, device=device)
+    num_reqs = idx_mapping.shape[0]
+    idx = idx_mapping.tolist()
+    qsl = query_start_loc.tolist()
+    nct = num_computed_tokens.tolist()
+    for b in range(num_reqs):
+        rs = idx[b]
+        qs = qsl[b]
+        qe = qsl[b + 1]
+        query_len = qe - qs
+        if query_len <= 0:
+            continue
+        # Shift by one: the logprob at each position targets the next token.
+        base = nct[rs] + 1
+        token_ids[qs:qe] = all_token_ids[rs, base : base + query_len].to(torch.int64)
+    return token_ids
+
+
+# PromptLogprobsWorker (reused from the genuine module) resolves
+# ``get_prompt_logprobs_token_ids`` from that module's globals.
+_up.get_prompt_logprobs_token_ids = get_prompt_logprobs_token_ids

--- a/vllm_kunlun/v1/worker/gpu/structured_outputs.py
+++ b/vllm_kunlun/v1/worker/gpu/structured_outputs.py
@@ -1,0 +1,86 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Kunlun torch-native replacement for ``vllm.v1.worker.gpu.structured_outputs``.
+
+The V2 model runner has its own grammar-bitmask kernel
+(``_apply_grammar_bitmask_kernel``), separate from the V1 path patched in
+``vllm_kunlun/v1/structured_output/utils.py``. Launching it on Kunlun XPU fails
+with ``Triton Error [CUDA]: CUDA_ERROR_NOT_SUPPORTED``, and the worker process
+cannot rely on ``HAS_TRITON`` being False (Triton finds an active driver once
+``torch_xmlir`` is initialised), so the launch site is replaced explicitly.
+
+Only ``StructuredOutputsWorker.apply_grammar_bitmask`` is overridden; the
+upstream class (buffers, sizing) is reused verbatim via ``load_upstream``. The
+upstream side copy-stream is dropped: the H2D copies are issued on the current
+stream instead, which keeps the ordering trivially correct on XPU.
+"""
+
+import logging
+
+import numpy as np
+import torch
+from vllm.v1.worker.gpu.buffer_utils import async_copy_to_gpu
+
+from vllm_kunlun.v1.worker.gpu._upstream import load_upstream
+
+logger = logging.getLogger("vllm_kunlun")
+
+_up = load_upstream("vllm.v1.worker.gpu.structured_outputs")
+
+StructuredOutputsWorker = _up.StructuredOutputsWorker
+
+_BITS_PER_WORD = 32
+
+
+def _apply_grammar_bitmask(
+    self,
+    logits: torch.Tensor,
+    input_batch,
+    grammar_req_ids: list[str],
+    grammar_bitmask: np.ndarray,
+) -> None:
+    """torch-native replacement of ``_apply_grammar_bitmask_kernel``.
+
+    ``grammar_bitmask`` packs one bit per token id into int32 words; a zero bit
+    means the token is disallowed and its logit must become ``-inf``. Row ``i``
+    of the bitmask applies to logits row ``mapping[i]``.
+    """
+    if not grammar_req_ids:
+        return
+
+    num_masks = grammar_bitmask.shape[0]
+    bitmask = async_copy_to_gpu(grammar_bitmask, out=self.grammar_bitmask[:num_masks])
+
+    # Construct bitmask -> logits mapping (identical to upstream).
+    mapping: list[int] = []
+    req_ids = input_batch.req_ids
+    cu_num_logits = input_batch.cu_num_logits_np.tolist()
+    req_id_to_idx = {req_id: i for i, req_id in enumerate(req_ids)}
+    for grammar_req_id in grammar_req_ids:
+        req_idx = req_id_to_idx[grammar_req_id]
+        mapping.extend(range(cu_num_logits[req_idx], cu_num_logits[req_idx + 1]))
+    assert num_masks == len(mapping)
+
+    rows = async_copy_to_gpu(
+        np.asarray(mapping, dtype=np.int32), out=self.logits_indices[: len(mapping)]
+    ).to(torch.long)
+
+    # Unpack the bitmask: bit j of word w covers token w * 32 + j. int32 right
+    # shift is arithmetic, but the low bit of the result is still the wanted
+    # bit, so sign-bit words are handled correctly.
+    shifts = torch.arange(_BITS_PER_WORD, dtype=torch.int32, device=bitmask.device)
+    bits = (bitmask.unsqueeze(-1) >> shifts) & 1
+    vocab_size = logits.shape[-1]
+    allowed = bits.view(num_masks, -1)[:, :vocab_size].to(torch.bool)
+
+    selected = logits.index_select(0, rows)
+    selected.masked_fill_(~allowed, float("-inf"))
+    logits.index_copy_(0, rows, selected)
+
+
+if not getattr(StructuredOutputsWorker, "_kunlun_v2_patched", False):
+    StructuredOutputsWorker.apply_grammar_bitmask = _apply_grammar_bitmask
+    StructuredOutputsWorker._kunlun_v2_patched = True
+    logger.info(
+        "[KunlunPlugin] V2 StructuredOutputsWorker patched (torch-native bitmask)"
+    )

--- a/vllm_kunlun/v1/worker/mamba_utils.py
+++ b/vllm_kunlun/v1/worker/mamba_utils.py
@@ -1,395 +1,109 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-import dataclasses
-import itertools
-from collections.abc import Callable
-from math import prod
-from typing import Any
+"""Kunlun replacement for ``vllm.v1.worker.mamba_utils``.
+
+Exactly two things differ from upstream on Kunlun XPU:
+
+* ``batch_memcpy`` must go through ``torch.ops.xspeedgate_ops.batch_memcpy``
+  instead of launching the Triton ``batch_memcpy_kernel``.
+* ``MambaCopyBuffers.create`` allocates ``int64`` pointer/size buffers, which is
+  what the xspeedgate op expects (upstream uses ``uint64``/``int32``).
+
+Everything else -- the 5 Triton kernels, ``MambaSpecDecodeGPUContext``,
+``MambaBuffers``, and the V1 pre/postprocess helpers -- is reused verbatim from
+the genuine upstream module via ``load_upstream`` + ``reexport``.
+
+That is safe because ``@triton.jit`` is lazy: decorating a kernel compiles
+nothing, only a ``kernel[grid](...)`` launch does. The kernels we do not
+replace are reachable only from the mamba "align" cache mode, which requires
+prefix caching to be enabled.
+
+This replaces a 396-line fork of an *older* upstream revision that was missing
+12 symbols the current upstream imports. Two of them broke Qwen3.5 outright::
+
+    vllm/v1/worker/gpu/model_states/mamba_hybrid.py:27
+    ImportError: cannot import name 'MambaSpecDecodeGPUContext'
+
+and four more were latent ``AttributeError``s on the V1 path
+(``gpu_model_runner.py`` lines 1547, 1570, 2098, 4258). Deriving the export
+surface from upstream instead of hand-maintaining it removes that whole class
+of failure.
+
+Also dropped here: ``get_hybrid_attention_mamba_layout`` and
+``postprocess_mamba``, two symbols the old fork carried that exist neither
+upstream nor in any caller.
+"""
+
+import logging
 
 import torch
-from vllm.config import CacheConfig
-from vllm.model_executor.layers.mamba.mamba_utils import MambaStateCopyFunc
-from vllm.triton_utils import tl, triton
-from vllm.utils.math_utils import cdiv
-from vllm.utils.torch_utils import get_dtype_size
-from vllm.v1.core.sched.output import SchedulerOutput
-from vllm.v1.kv_cache_interface import AttentionSpec, KVCacheConfig, MambaSpec
-from vllm.v1.utils import CpuGpuBuffer
-from vllm.v1.worker.gpu_input_batch import CachedRequestState
-from vllm.v1.worker.lora_model_runner_mixin import GPUInputBatch
 
+from vllm_kunlun.v1.worker.gpu._upstream import load_upstream, reexport
 
-@triton.jit
-def batch_memcpy_kernel(src_ptrs, dst_ptrs, sizes, BLOCK_SIZE: tl.constexpr):
-    pid = tl.program_id(0)
+logger = logging.getLogger("vllm_kunlun")
 
-    src_ptr = tl.load(src_ptrs + pid)
-    dst_ptr = tl.load(dst_ptrs + pid)
-    size = tl.load(sizes + pid)
+_up = load_upstream("vllm.v1.worker.mamba_utils")
 
-    offsets = tl.arange(0, BLOCK_SIZE)
-    for i in range(0, size, BLOCK_SIZE):
-        mask = (i + offsets) < size
-
-        curr_src_ptr = (src_ptr + i + offsets).to(tl.pointer_type(tl.uint8))
-        curr_dst_ptr = (dst_ptr + i + offsets).to(tl.pointer_type(tl.uint8))
-
-        data = tl.load(curr_src_ptr, mask=mask)
-        tl.store(curr_dst_ptr, data, mask=mask)
+# Must come before our own definitions below so they win in this namespace.
+reexport(_up, globals())
 
 
 def batch_memcpy(src_ptrs, dst_ptrs, sizes):
+    """xspeedgate stand-in for upstream's Triton ``batch_memcpy_kernel``.
+
+    ``xspeedgate_ops.batch_memcpy`` wants int64 pointer tensors. Buffers built
+    by our ``MambaCopyBuffers.create`` below are already int64; the ``view``
+    calls only matter if some other caller hands us upstream-dtype buffers.
+    ``view`` is a metadata-only reinterpret, so it is free and bit-exact.
+    """
     batch = src_ptrs.shape[0]
     assert dst_ptrs.shape[0] == batch
     assert sizes.shape[0] == batch
+    if batch == 0:
+        return
+    if src_ptrs.dtype is not torch.int64:
+        src_ptrs = src_ptrs.view(torch.int64)
+    if dst_ptrs.dtype is not torch.int64:
+        dst_ptrs = dst_ptrs.view(torch.int64)
     torch.ops.xspeedgate_ops.batch_memcpy(src_ptrs, dst_ptrs, sizes)
 
 
-#     grid = (batch,)
-#     BLOCK_SIZE = 1024
-#     batch_memcpy_kernel[grid](src_ptrs, dst_ptrs, sizes, BLOCK_SIZE=BLOCK_SIZE)
+def _mamba_copy_buffers_create(
+    cls,
+    max_num_reqs,
+    kv_cache_config,
+    copy_funcs,
+    make_buffer,
+):
+    """Same as upstream ``MambaCopyBuffers.create`` but with int64 buffers.
 
-# def _make_uint8_view_from_ptr(ptr: int, size: int, device: torch.device) -> torch.Tensor:
-#    storage = torch._C._construct_storage_from_data_pointer(ptr, device, size)
-#    tensor = torch.empty(0, dtype=torch.uint8, device=device)
-#    return tensor.set_(storage, 0, (size,), (1,))
-
-
-# def batch_memcpy(src_ptrs, dst_ptrs, sizes):
-#    batch = src_ptrs.shape[0]
-#    assert dst_ptrs.shape[0] == batch
-#    assert sizes.shape[0] == batch
-#    if batch == 0:
-#        return
-#
-#    device = src_ptrs.device
-#    src_ptrs_cpu = src_ptrs.detach().cpu().tolist()
-#    dst_ptrs_cpu = dst_ptrs.detach().cpu().tolist()
-#    sizes_cpu = sizes.detach().cpu().tolist()
-#
-#    for src_ptr, dst_ptr, size in zip(src_ptrs_cpu, dst_ptrs_cpu, sizes_cpu):
-#        if size <= 0 or src_ptr == dst_ptr:
-#            continue
-#        src = _make_uint8_view_from_ptr(src_ptr, size, device)
-#        dst = _make_uint8_view_from_ptr(dst_ptr, size, device)
-#        dst.copy_(src, non_blocking=True)
-
-
-def get_mamba_groups(kv_cache_config: KVCacheConfig) -> tuple[list[int], MambaSpec]:
-    mamba_group_ids: list[int] = []
-    mamba_specs: list[MambaSpec] = []
-    for i in range(len(kv_cache_config.kv_cache_groups)):
-        kv_cache_spec = kv_cache_config.kv_cache_groups[i].kv_cache_spec
-        if isinstance(kv_cache_spec, MambaSpec):
-            mamba_group_ids.append(i)
-            mamba_specs.append(kv_cache_spec)
-    assert len(mamba_group_ids) > 0, "no mamba layers in the model"
-    assert all(mamba_specs[0] == spec for spec in mamba_specs)
-    return mamba_group_ids, mamba_specs[0]
-
-
-@dataclasses.dataclass
-class MambaCopyBuffers:
-    src_ptrs: CpuGpuBuffer
-    dst_ptrs: CpuGpuBuffer
-    sizes: CpuGpuBuffer
-    mamba_group_ids: list[int]
-    mamba_spec: MambaSpec
-    offset: int = 0
-
-    @classmethod
-    def create(
-        cls,
-        max_num_reqs: int,
-        kv_cache_config: KVCacheConfig,
-        copy_funcs: tuple[MambaStateCopyFunc, ...],
-        make_buffer: Callable[..., CpuGpuBuffer],
-    ) -> "MambaCopyBuffers":
-        mamba_group_ids, mamba_spec = get_mamba_groups(kv_cache_config)
-        entries_per_req = sum(
-            len(kv_cache_config.kv_cache_groups[gid].layer_names)
-            for gid in mamba_group_ids
-        ) * len(copy_funcs)
-        n = max_num_reqs * entries_per_req
-        return cls(
-            src_ptrs=make_buffer(n, dtype=torch.int64),
-            dst_ptrs=make_buffer(n, dtype=torch.int64),
-            sizes=make_buffer(n, dtype=torch.int64),
-            mamba_group_ids=mamba_group_ids,
-            mamba_spec=mamba_spec,
-        )
-
-
-def collect_mamba_copy_meta(
-    copy_bufs: MambaCopyBuffers,
-    kv_cache_config: KVCacheConfig,
-    mamba_state_copy_funcs: tuple[MambaStateCopyFunc, ...],
-    mamba_group_ids: list[int],
-    src_block_idx: int,
-    dest_block_idx: int,
-    accept_token_bias: int,
-    req_state: CachedRequestState,
-    forward_context: dict[str, Any],
-) -> None:
-    if src_block_idx == dest_block_idx and accept_token_bias == 0:
-        return
-
-    src_ptrs_np = copy_bufs.src_ptrs.np
-    dst_ptrs_np = copy_bufs.dst_ptrs.np
-    sizes_np = copy_bufs.sizes.np
-    offset = copy_bufs.offset
-
-    for mamba_group_id in mamba_group_ids:
-        block_ids = req_state.block_ids[mamba_group_id]
-        dest_block_id = block_ids[dest_block_idx]
-        layer_names = kv_cache_config.kv_cache_groups[mamba_group_id].layer_names
-        for layer_name in layer_names:
-            attention = forward_context[layer_name]
-            kv_caches: list[torch.Tensor] = attention.kv_cache
-            for state, state_copy_func in zip(kv_caches, mamba_state_copy_funcs):
-                copy_spec = state_copy_func(
-                    state, block_ids, src_block_idx, accept_token_bias + 1
-                )
-
-                src_ptrs_np[offset] = copy_spec.start_addr
-                dst_ptrs_np[offset] = state[dest_block_id].data_ptr()
-                sizes_np[offset] = copy_spec.num_elements * state.element_size()
-                offset += 1
-
-    copy_bufs.offset = offset
-
-
-def do_mamba_copy_block(copy_bufs: MambaCopyBuffers):
-    n = copy_bufs.offset
-    if n == 0:
-        return
-    batch_memcpy(
-        copy_bufs.src_ptrs.copy_to_gpu(n),
-        copy_bufs.dst_ptrs.copy_to_gpu(n),
-        copy_bufs.sizes.copy_to_gpu(n),
+    Upstream allocates ``uint64`` pointers and ``int32`` sizes
+    (mamba_utils.py:449-451); the xspeedgate op is specified for int64.
+    """
+    mamba_group_ids, mamba_spec = _up.get_mamba_groups(kv_cache_config)
+    entries_per_req = sum(
+        len(kv_cache_config.kv_cache_groups[gid].layer_names) for gid in mamba_group_ids
+    ) * len(copy_funcs)
+    n = max_num_reqs * entries_per_req
+    return cls(
+        src_ptrs=make_buffer(n, dtype=torch.int64),
+        dst_ptrs=make_buffer(n, dtype=torch.int64),
+        sizes=make_buffer(n, dtype=torch.int64),
+        mamba_group_ids=mamba_group_ids,
+        mamba_spec=mamba_spec,
     )
 
 
-def preprocess_mamba(
-    scheduler_output: SchedulerOutput,
-    kv_cache_config: KVCacheConfig,
-    cache_config: CacheConfig,
-    mamba_state_idx: dict[str, int],
-    input_batch: GPUInputBatch,
-    requests: dict[str, CachedRequestState],
-    forward_context: dict[str, Any],
-    mamba_state_copy_funcs: tuple[MambaStateCopyFunc, ...],
-    copy_bufs: MambaCopyBuffers,
-):
-    """
-    Copy the mamba state of previous step to the last
-    (1 + num_speculative_blocks) block.
-    """
-    mamba_group_ids = copy_bufs.mamba_group_ids
-    mamba_spec = copy_bufs.mamba_spec
-    num_speculative_blocks = mamba_spec.num_speculative_blocks
-    # TODO(Chen): we need to optimize this function a lot
-    assert cache_config.enable_prefix_caching
-    block_size = mamba_spec.block_size
-    finished_req_ids = scheduler_output.finished_req_ids
-    preempted_req_ids = scheduler_output.preempted_req_ids or set()
-    # We need to clear mamba_state_idx for resumed requests. When requests are
-    # force-preempted (e.g., during reset_prefix_cache / KV cache flush),
-    # they appear in resumed_req_ids without a corresponding entry in
-    # preempted_req_ids, leaving stale mamba_state_idx entries that can
-    # point to block indices beyond the new (smaller) block allocation.
-    resumed_req_ids = scheduler_output.scheduled_cached_reqs.resumed_req_ids
-    for req_id in itertools.chain(finished_req_ids, preempted_req_ids, resumed_req_ids):
-        mamba_state_idx.pop(req_id, None)
-
-    copy_bufs.offset = 0
-    for i, req_id in enumerate(input_batch.req_ids):
-        req_state = requests[req_id]
-        prev_state_idx = mamba_state_idx.get(req_id)
-        if prev_state_idx is None:
-            # new / resumed request, no previous state
-            # if num_computed_tokens is 0, prev_state_idx will be -1
-            prev_state_idx = (req_state.num_computed_tokens - 1) // block_size
-
-        num_scheduled_tokens = scheduler_output.num_scheduled_tokens[req_id]
-        num_blocks: int = (
-            cdiv(req_state.num_computed_tokens + num_scheduled_tokens, block_size)
-            + num_speculative_blocks
-        )
-
-        # We always save the current running state at the last
-        # (1 + num_speculative_blocks) block.
-        # A corner case worth mention here: assume we have block_size = 4 and
-        # num_speculative_tokens = 2. The request is [A, B, C] and contains 2 draft
-        # tokens [draft 1, draft 2]. Then we will have:
-        # Block 0: [A, B, C, draft 1]
-        # Block 1: [draft 2, TOFILL, TOFILL, TOFILL]
-        # Block 2: speculative block
-        # Block 3: speculative block
-        # And use block 1 to save the running state.
-        curr_state_idx = num_blocks - 1 - num_speculative_blocks
-        mamba_state_idx[req_id] = curr_state_idx
-        if prev_state_idx != -1 and prev_state_idx != curr_state_idx:
-            collect_mamba_copy_meta(
-                copy_bufs,
-                kv_cache_config,
-                mamba_state_copy_funcs,
-                mamba_group_ids,
-                prev_state_idx,
-                curr_state_idx,
-                input_batch.num_accepted_tokens_cpu[i] - 1,
-                req_state,
-                forward_context,
-            )
-            input_batch.num_accepted_tokens_cpu[i] = 1
-    do_mamba_copy_block(copy_bufs)
-
-
-@dataclasses.dataclass
-class MambaBuffers:
-    """Single owner for all mamba-specific runner buffers.
-
-    On Kunlun XPU, speculative decoding with hybrid models is not supported,
-    so postprocess_align is always None.
-    """
-
-    preprocess: MambaCopyBuffers
-    # TODO(kunlun): MambaSpecDecodeGPUContext is not implemented on Kunlun XPU.
-    # postprocess_align is required when running speculative decoding on a hybrid
-    # model (e.g. DeepSeek V4 flash). When that use case is needed, implement
-    # MambaSpecDecodeGPUContext in this file (referencing vllm 0.25.1 upstream)
-    # and replace the None stub below.
-    postprocess_align: None = None
-
-    @classmethod
-    def create(
-        cls,
-        max_num_reqs: int,
-        kv_cache_config: KVCacheConfig,
-        copy_funcs: tuple[MambaStateCopyFunc, ...],
-        make_buffer: Callable[..., CpuGpuBuffer],
-        device=None,
-        with_postprocess_align: bool = False,
-    ) -> "MambaBuffers":
-        if with_postprocess_align:
-            # TODO(kunlun): implement MambaSpecDecodeGPUContext for spec-decode
-            # + hybrid model support (e.g. DeepSeek V4 flash).
-            raise NotImplementedError(
-                "Speculative decoding on hybrid Mamba models is not yet "
-                "supported on Kunlun XPU. Need to implement "
-                "MambaSpecDecodeGPUContext."
-            )
-        return cls(
-            preprocess=MambaCopyBuffers.create(
-                max_num_reqs, kv_cache_config, copy_funcs, make_buffer
-            ),
-            postprocess_align=None,
-        )
-
-
-def get_hybrid_attention_mamba_layout(
-    kv_cache_shape: tuple[int, ...],
-    kv_cache_stride: tuple[int, ...],
-    kv_cache_spec: AttentionSpec,
-    block_dim: int,
-    layer_idx: int,
-    kernel_block_size: int,
-) -> tuple[tuple[int, ...], int]:
-    """
-    Compute the stride and storage offset for the hybrid attention+mamba layout.
-
-    Args:
-        kv_cache_shape: The shape of the KV cache tensor.
-        kv_cache_stride: The stride of the KV cache tensor.
-        kv_cache_spec: The specification of the KV cache.
-        layer_idx: The index of the layer.
-        kernel_num_blocks: The number of kernel blocks.
-        kernel_block_size: The size of the kernel block.
-    Returns:
-        A tuple containing the target stride and storage offset.
-    """
-    target_stride_list = list(kv_cache_stride)
-    storage_offset = 0
-
-    attn_pack_size = kv_cache_spec.pack_size
-    # block_dim: 0 means (num_blocks, 2, ...); 1 means (2, num_blocks, ...).
-    if block_dim != 0:
-        # Hybrid attention+mamba uses (2, num_blocks, ...) logical shape but
-        # (num_blocks, 2, ...) physical layout.
-        assert kv_cache_shape[0] == 2, (
-            "Fail to determine whether the layout is "
-            "(2, num_blocks, ...) or (num_blocks, 2, ...) for "
-            f"a tensor of shape {kv_cache_shape}"
-        )
-        assert block_dim == 1
-        hidden_size = prod(kv_cache_shape[2:])
-        target_stride_list[0] = hidden_size
-        target_stride_list[1] = 2 * hidden_size
-    # When multiple attention layers share one physical KV cache block
-    # (attn_pack_size > 1), scale the block-dim stride by attn_pack_size
-    # and compute this layer's element offset within the shared block.
-    if attn_pack_size > 1:
-        target_stride_list[block_dim] *= attn_pack_size
-        dtype_size = get_dtype_size(kv_cache_spec.dtype)
-        num_element_per_page = kv_cache_spec.page_size_bytes // dtype_size
-        num_blocks_per_kv_block = kv_cache_spec.block_size // kernel_block_size
-        num_element_per_attn_pack = (
-            num_element_per_page // num_blocks_per_kv_block // attn_pack_size
-        )
-        attn_pack_idx = layer_idx % attn_pack_size
-        storage_offset = attn_pack_idx * num_element_per_attn_pack
-    return tuple(target_stride_list), storage_offset
-
-
-def postprocess_mamba(
-    scheduler_output: SchedulerOutput,
-    kv_cache_config: KVCacheConfig,
-    input_batch: GPUInputBatch,
-    requests: dict[str, CachedRequestState],
-    mamba_state_idx: dict[str, int],
-    forward_context: dict[str, Any],
-    mamba_state_copy_funcs: tuple[MambaStateCopyFunc, ...],
-    copy_bufs: MambaCopyBuffers,
-):
-    """
-    If a blocks is converted from partial block to full block in this step, copy the
-    state from the block for running state to the new full block.
-    """
-    num_scheduled_tokens_dict = scheduler_output.num_scheduled_tokens
-    scheduled_spec_decode_tokens_dict = scheduler_output.scheduled_spec_decode_tokens
-    num_accepted_tokens_cpu = input_batch.num_accepted_tokens_cpu
-    mamba_group_ids = copy_bufs.mamba_group_ids
-    mamba_spec = copy_bufs.mamba_spec
-    copy_bufs.offset = 0
-    for i, req_id in enumerate(input_batch.req_ids):
-        req_state = requests[req_id]
-        num_computed_tokens = req_state.num_computed_tokens
-        num_draft_tokens = len(scheduled_spec_decode_tokens_dict.get(req_id, []))
-        num_scheduled_tokens = num_scheduled_tokens_dict[req_id]
-        num_accepted_tokens = num_accepted_tokens_cpu[i]
-        num_tokens_running_state = (
-            num_computed_tokens + num_scheduled_tokens - num_draft_tokens
-        )
-        new_num_computed_tokens = num_tokens_running_state + num_accepted_tokens - 1
-        aligned_new_computed_tokens = (
-            new_num_computed_tokens // mamba_spec.block_size * mamba_spec.block_size
-        )
-        # TODO: how to ensure all blocks that cache_blocks called are cached here?
-        if aligned_new_computed_tokens >= num_tokens_running_state:
-            accept_token_bias = aligned_new_computed_tokens - num_tokens_running_state
-            src_block_idx = mamba_state_idx[req_id]
-            dest_block_idx = aligned_new_computed_tokens // mamba_spec.block_size - 1
-            collect_mamba_copy_meta(
-                copy_bufs,
-                kv_cache_config,
-                mamba_state_copy_funcs,
-                mamba_group_ids,
-                src_block_idx,
-                dest_block_idx,
-                accept_token_bias,
-                req_state,
-                forward_context,
-            )
-            if src_block_idx == dest_block_idx:
-                num_accepted_tokens_cpu[i] = 1
-    do_mamba_copy_block(copy_bufs)
+# ``do_mamba_copy_block`` and friends resolve ``batch_memcpy`` from the
+# *upstream* module globals, so the override has to land on ``_up`` too -- not
+# just in this module's namespace.
+if not getattr(_up, "_kunlun_v2_patched", False):
+    _up.batch_memcpy = batch_memcpy
+    _up.MambaCopyBuffers.create = classmethod(_mamba_copy_buffers_create)
+    MambaCopyBuffers = _up.MambaCopyBuffers
+    _up._kunlun_v2_patched = True
+    logger.info(
+        "[KunlunPlugin] mamba_utils patched (xspeedgate batch_memcpy, int64 "
+        "copy buffers; %d upstream symbols re-exported)",
+        len([k for k in vars(_up) if not k.startswith("__")]),
+    )


### PR DESCRIPTION
## PR Description

> **Status: work in progress — opened early for design feedback.** The path described
> below runs end to end and passes accuracy checks on the models listed under
> [Testing](#testing), but two milestones (spec decode, context parallelism) are
> deliberately out of scope and unit tests are not yet written. Please review the
> **approach** first; I would rather correct the mechanism now than after adding
> tests on top of it. Details in [Not in this PR](#not-in-this-pr).

### What problem does it solve?

vLLM's **Model Runner V2** cannot run on Kunlun XPU today. Upstream gates V2 on Triton
availability, and Kunlun has no usable Triton — so every Kunlun deployment is pinned to
the V1 runner and cannot follow upstream's V2 work.

This PR enables the V2 runner on Kunlun by replacing **every Triton launch site the V2
runner actually reaches** with a torch-native (or `kunlun_ops` / `xspeedgate_ops`)
equivalent, wired in through the plugin's existing `sys.modules` swap mechanism. No
upstream file is modified.

### Why is gating on `HAS_TRITON` not enough?

This is the core constraint that shapes the whole design, so it is worth stating
precisely:

- In the **engine process**, `HAS_TRITON` is `False`, so upstream's own guards behave as
  expected.
- In the **worker process**, once `torch_xmlir` initialises, Triton finds an active
  driver and `HAS_TRITON` becomes effectively true. Kernel *loading* then fails at
  runtime with `Triton Error [CUDA]: CUDA_ERROR_NOT_SUPPORTED`.

So a Kunlun replacement module cannot branch on `HAS_TRITON` and fall through to the
upstream Triton path — the fallback would be taken in exactly the process where it
breaks. Each launch site has to be replaced **unconditionally**.

### Overall approach

**1. Open the gate, but do not force the choice.** `platforms/kunlun.py` sets
`vllm.config.vllm.HAS_TRITON = True` in `check_and_update_config`. That symbol is read
only by the two V2 checks (`use_v2_model_runner`, which returns `False` when
`not HAS_TRITON`, and `_validate_v2_model_runner`, which hard-raises
*"Model Runner V2 requires Triton."*), so forcing it has no other side effects.

`VLLM_USE_V2_MODEL_RUNNER` is **deliberately left unset**. Upstream's own selection
logic is more trustworthy than a model table maintained here — in particular
`_is_default_v2_model_runner_model` excludes hybrid models. Defaulting the env var to
`"1"` made `use_v2_model_runner` early-return `True` and skip all of those filters,
which is how a hybrid model (Qwen3.5) reached V2 and died importing
`vllm.v1.worker.gpu.model_states.mamba_hybrid`. Users opt in or out explicitly.

**2. Reuse upstream, override only the launch sites.** Each replacement module executes
the *genuine* upstream module through a small helper (`_upstream.load_upstream`), copies
its entire public surface into its own namespace (`_upstream.reexport`), and then defines
only the overrides. Two consequences worth flagging to reviewers:

- `load_upstream` is needed because a plain `import vllm.v1.worker.gpu.<leaf>` resolves
  to the *swapped* module — i.e. itself — and recurses. It loads the real file by path
  under a private `sys.modules` name.
- `reexport` copies the whole `__dict__` rather than a hand-written list. A
  `sys.modules` swap is a *whole module* replacement: the replacement must provide every
  name any upstream consumer might `from <module> import X`, including features Kunlun
  never intends to support. Hand-maintained lists drift silently whenever upstream adds a
  symbol — that is exactly how `mamba_hybrid` failed to import
  `MambaSpecDecodeGPUContext`.

This keeps upstream state classes, dataclasses, buffer sizing and constants **verbatim**,
which is what makes the diff reviewable and keeps future rebases cheap.

**3. Keep torch-only kernels testable without hardware.** `_kernels.py` holds the
torch stand-ins for kernel *objects* that are swapped in place (via a small `TorchKernel`
shim supporting `obj[grid](...)`, so the surrounding upstream method is left untouched).
It imports `torch` only — no `vllm`, no `kunlun_ops` — so it is unit-testable on CPU
without XPU hardware.

### Changes

| Area | Change |
|---|---|
| `platforms/kunlun.py` | Open the V2 Triton gate (idempotent, logged). Upstream still decides whether V2 is used. |
| `__init__.py` | 13 new `_MODULE_MAPPINGS` entries for `vllm.v1.worker.gpu.*`. |
| `gpu/_upstream.py` | `load_upstream` / `reexport` — the swap-safe reuse helper described above. |
| `gpu/_kernels.py` | torch-only stand-ins for in-place-swapped kernel objects (`scatter_num_accepted`, `prepare_rope_positions`). |
| `gpu/buffer_utils.py` | torch-native `StagedWriteTensor.apply_write`. `FusedStagedWriter.apply` raises loudly (raw-pointer fan-out is not expressible in torch; Kunlun loops per group instead). Includes a device-tensor fallback for when UVA is unavailable, since upstream `UvaBuffer` hard-raises. |
| `gpu/block_table.py` | `apply_staged_writes` (per-group loop), `gather_block_tables` (`index_select` + zero padded rows), `compute_slot_mappings` — **reuses the native `kunlun_ops.compute_slot_mappings`**, the same op the V1 Kunlun path uses, fed pre-gathered block tables so its per-token request lookup matches V2 semantics. |
| `gpu/input_batch.py` | seven Triton module functions reimplemented in torch over the jagged per-request segments. |
| `gpu/structured_outputs.py` | `StructuredOutputsWorker.apply_grammar_bitmask`. This is a *separate* kernel from the V1 path already patched in `v1/structured_output/utils.py`. The upstream side copy-stream is dropped; H2D copies go on the current stream, which keeps ordering trivially correct on XPU. |
| `gpu/mm/rope.py` | `RopeState.prepare_positions` only. Live for every mrope / XD-RoPE model — the whole Qwen3-VL family, plus Qwen3.5 VL since `MambaHybridModelState` extends `DefaultModelState`. The rest of the module is plain torch and reused as-is. |
| `gpu/model_states/mamba_hybrid.py` | torch-native `_scatter_num_accepted_kernel`. The other two launch sites are align-mode only, which requires prefix caching (`models/config.py` forces `mamba_cache_mode="none"` otherwise), so the scatter is the only one live in a prefix-caching-off configuration. |
| `gpu/sample/*` | `gumbel`, `min_p`, `penalties`, `logit_bias`, `bad_words`, `logprob`, `prompt_logprob`. |
| `v1/worker/mamba_utils.py` | **−369 lines.** Replaces a full copy of the upstream module with `load_upstream` + `reexport`, keeping only the two real Kunlun deltas (`xspeedgate` `batch_memcpy`, int64 pointer/size buffers). Included here because the V2 work produced the helper that makes the copy unnecessary. |

### Testing

Verified on Kunlun XPU under the V2 runner, with **response accuracy normal** (no
garbled or degraded output vs. the V1 baseline):

| Model | Result |
|---|---|
| Qwen3-8B | ✅ runs under MRV2, output precision normal |
| Qwen3.5-27B | ✅ runs under MRV2, output precision normal |

Qwen3.5-27B is hybrid, so upstream's default selection excludes it; it was exercised with
an explicit `VLLM_USE_V2_MODEL_RUNNER=1` opt-in. That is precisely the case that
motivated leaving the env var unset by default.

Functional surface covered by the replacements: normal generation (greedy and random
sampling, `top_k`/`top_p`, `min_p`, repetition/frequency/presence penalties,
`logit_bias`, `bad_words`), logprobs and prompt logprobs, structured outputs, multimodal
M-RoPE/XD-RoPE position preparation, and mamba-hybrid model state.

**Not yet done — I am asking for review before investing in these:** no unit tests are
added in this PR. `_kernels.py` is intentionally torch-only so the CPU tests can be
written without XPU hardware, and the sampler replacements are all comparable against a
reference implementation on CPU. I will add them under `tests/` once the approach is
agreed. Code style (`black`, `isort --profile black`) passes on all changed files.

### How to enable / disable

```bash
# Default: upstream decides (V2 for the models it selects, V1 otherwise)
# Force V2 (needed for hybrid models, which upstream excludes by default)
VLLM_USE_V2_MODEL_RUNNER=1
# Force the V1 runner
VLLM_USE_V2_MODEL_RUNNER=0
```

V1 remains fully available and unchanged; this PR adds a path rather than switching the
default.

### Known limitations

1. **Random sampling is not seed-reproducible.** Greedy (`temperature == 0`) reduces to
   `argmax` and is bit-exact vs. upstream. Random sampling uses torch-native Gumbel-max
   noise — distributionally equivalent, but not bit-reproducible against the upstream
   Philox kernel, so per-request seeds do not reproduce. A seeded `kunlun_ops` gumbel
   kernel is the planned follow-up.
2. **Correctness-first per-request loops.** `input_batch`, `logit_bias`, `bad_words` and
   `logprob` loop per request in Python and pull small metadata index tensors to host
   once per call. `num_reqs` is small and the sampler tensors are sized by sampled
   positions (≈ request count), so this is not a throughput cliff — but the hot ones
   should move to `kunlun_ops`. Not yet benchmarked against V1; I plan to profile before
   proposing any default change.
3. `compute_slot_mappings` and `scatter_num_accepted` each need one small D2H sync — the
   same order of cost as the `.item()` already accepted in the V1 Kunlun path.

### Not in this PR

- **Spec decode.** `spec_decode/rejection_sampler_utils` is not mapped. It imports two
  Triton *device* functions from `sample.gumbel` at module scope and is imported
  unconditionally by the V2 runner via `kernel_warmup`, so the names must exist or the
  worker will not start — they are provided as stubs that raise if ever called. The
  draft-token accumulation paths in `penalties` and `bad_words` are likewise omitted;
  both are no-ops here because `expanded_local_pos` is all zeros without spec decode.
- **Context parallelism.**
- **Align mode** for mamba-hybrid (requires prefix caching; see the table above).
- **Unit tests**, as described under Testing.

### Review guidance

If you have limited time, the two files that decide whether this design is right are
`gpu/_upstream.py` (the reuse mechanism everything else depends on) and
`platforms/kunlun.py` (the gate policy — specifically the decision not to set
`VLLM_USE_V2_MODEL_RUNNER`). Everything under `gpu/sample/` is mechanical by comparison.

Happy to split this into smaller PRs (helper + gate first, then samplers, then
multimodal/hybrid) if that would be easier to review — please say which you prefer.

---

## Checklist (Required)

- [x] All code changes pass the [`pre-commit`](https://github.com/baidu/vLLM-Kunlun/blob/main/CONTRIBUTING.md) checks. (`black` and `isort --profile black` verified clean on all 22 changed files.)
- [x] Commits are signed off using `git commit -s`.
- [x] The PR title is properly classified.

---

## PR Type

`[ModelRunner]` — new feature in the model runner, plus `[Platform]` for the
`check_and_update_config` gate.
