### PR TITLE
[Misc] Fix Qwen3.5 / MiniMax-M2 / InternVL3.5 for vLLM 0.25.1 on Kunlun XPU

### DIFF
--- a/vllm_kunlun/models/qwen3_5.py
+++ b/vllm_kunlun/models/qwen3_5.py
@@ -746,6 +746,7 @@ class Qwen3_5ForConditionalGeneration(Qwen3VLForConditionalGeneration, IsHybrid)
         return MambaStateDtypeCalculator.gated_delta_net_state_dtype(
             vllm_config.model_config.dtype,
             vllm_config.cache_config.mamba_cache_dtype,
+            vllm_config.cache_config.mamba_ssm_cache_dtype,
         )
 
     @classmethod

--- a/vllm_kunlun/models/qwen3_next.py
+++ b/vllm_kunlun/models/qwen3_next.py
@@ -1420,7 +1420,9 @@ class Qwen3NextForCausalLM(
         vllm_config: "VllmConfig",
     ) -> tuple[torch.dtype, torch.dtype]:
         return MambaStateDtypeCalculator.gated_delta_net_state_dtype(
-            vllm_config.model_config.dtype, vllm_config.cache_config.mamba_cache_dtype
+            vllm_config.model_config.dtype,
+            vllm_config.cache_config.mamba_cache_dtype,
+            vllm_config.cache_config.mamba_ssm_cache_dtype,
         )
 
     @classmethod

--- a/vllm_kunlun/quantization/compressed_tensors/compressed_tensors.py
+++ b/vllm_kunlun/quantization/compressed_tensors/compressed_tensors.py
@@ -19,7 +19,7 @@
 from typing import Optional
 
 import torch
-from vllm.model_executor.layers.fused_moe import FusedMoE
+from vllm.model_executor.layers.fused_moe import RoutedExperts
 from vllm.model_executor.layers.linear import (
     LinearBase,
     LinearMethodBase,
@@ -79,6 +79,6 @@ class KunlunCompressedTensorsConfig(CompressedTensorsConfig):
 
         if isinstance(layer, Attention):
             return CompressedTensorsKVCacheMethod(self)
-        if isinstance(layer, FusedMoE):
+        if isinstance(layer, RoutedExperts):
             return KunlunCompressedTensorsMoEMethod.get_moe_method(self, layer, prefix)
         return None

--- a/vllm_kunlun/quantization/compressed_tensors/compressed_tensors_moe.py
+++ b/vllm_kunlun/quantization/compressed_tensors/compressed_tensors_moe.py
@@ -22,6 +22,7 @@ import torch
 from compressed_tensors import CompressionFormat
 from vllm.logger import init_logger
 from vllm.model_executor.layers.fused_moe import (
+    FusedMoEConfig,
     FusedMoEMethodBase,
     UnquantizedFusedMoEMethod,
 )
@@ -51,9 +52,16 @@ class KunlunCompressedTensorsMoEMethod(FusedMoEMethodBase):
         # FusedMoE was made by combining multiple Linears so need to
         # make sure quantization config for Linear can target it
         quant_config._add_fused_moe_to_target_scheme_map()
+
+        # Determine projection names from the layer's checkpoint naming
+        # (e.g., MiniMax M2 uses "w1", "w2", "w3" instead of "gate_proj", etc.)
+        ckpt_gate = getattr(layer, "ckpt_gate_proj_name", "gate_proj")
+        ckpt_down = getattr(layer, "ckpt_down_proj_name", "down_proj")
+        ckpt_up = getattr(layer, "ckpt_up_proj_name", "up_proj")
+
         unfused_names = [
-            layer_name + proj_name
-            for proj_name in [".0.gate_proj", ".0.up_proj", ".0.down_proj"]
+            layer_name + f".0.{proj_name}"
+            for proj_name in [ckpt_gate, ckpt_up, ckpt_down]
         ]
         # TODO: refactor this to use expert_mapping and check all layer numbers
         all_scheme_dicts = [
@@ -76,7 +84,6 @@ class KunlunCompressedTensorsMoEMethod(FusedMoEMethodBase):
         format = scheme_dict.get("format")
 
         if quant_config._is_wNa16_group_channel(weight_quant, input_quant):
-
             valid_format_and_bits = (
                 weight_quant.num_bits in WNA16_SUPPORTED_BITS
                 and format == CompressionFormat.pack_quantized.value
@@ -111,6 +118,24 @@ class KunlunCompressedTensorsMoEMethod(FusedMoEMethodBase):
 
 
 class KunlunCompressedTensorsW8A8Int8MoEMethod(CompressedTensorsW8A8Int8MoEMethod):
+    def __init__(
+        self,
+        weight_quant,
+        input_quant,
+        moe: "FusedMoEConfig",
+        layer_name: str | None = None,
+    ):
+        # Skip the parent __init__ which calls select_int8_moe_backend
+        # (not applicable on Kunlun XPU). Instead, directly init FusedMoEMethodBase.
+        from vllm.model_executor.layers.fused_moe import FusedMoEMethodBase
+
+        FusedMoEMethodBase.__init__(self, moe)
+        self.weight_quant = weight_quant
+        self.input_quant = input_quant
+        self.static_input_scales = not self.input_quant.dynamic
+        self.int8_backend = None
+        self.experts_cls = None
+
     @property
     def is_monolithic(self) -> bool:
         return True
@@ -199,14 +224,16 @@ class KunlunCompressedTensorsW8A8Int8MoEMethod(CompressedTensorsW8A8Int8MoEMetho
             )
             del expert_m
         else:
-            sorted_tokens_idx, sorted_tokens_num_lod, moe_expand = (
-                torch.ops.xspeedgate_ops.moe_pre_small(
-                    topk_ids,
-                    global_num_experts,
-                    index_have_neg=False,
-                    sort_mode=True,
-                    x=hidden_states,
-                )
+            (
+                sorted_tokens_idx,
+                sorted_tokens_num_lod,
+                moe_expand,
+            ) = torch.ops.xspeedgate_ops.moe_pre_small(
+                topk_ids,
+                global_num_experts,
+                index_have_neg=False,
+                sort_mode=True,
+                x=hidden_states,
             )
 
         y = torch.empty(
@@ -295,7 +322,6 @@ class KunlunCompressedTensorsW8A8Int8MoEMethod(CompressedTensorsW8A8Int8MoEMetho
 
 
 class KunlunCompressedTensorsWNA16MoEMethod(CompressedTensorsWNA16MoEMethod):
-
     def apply(
         self,
         layer: torch.nn.Module,


### PR DESCRIPTION
## Overview

Adapt to vLLM 0.25.1 API changes and fix startup failures on Kunlun XPU
(vllm_kunlun) for three models: Qwen3.5-35B-A3B, MiniMax-M2 (W8A8-INT8),
and InternVL3.5-30B-A3B. Split into 3 independent commits, one per model.

## Details

### 1. Qwen3.5: fix mamba SSM cache dtype causing a startup crash
**Files**: `vllm_kunlun/models/qwen3_5.py`, `vllm_kunlun/models/qwen3_next.py`

`get_mamba_state_dtype_from_config` passed only 2 args to
`gated_delta_net_state_dtype`, omitting `mamba_ssm_cache_dtype`, which then
defaulted to `"auto"` (resolved to float16). Since the runtime actually uses
float32, `_align_hybrid_block_size` under-computed the mamba page size and
tripped `assert page_size_padded >= page_size` in `kv_cache_interface.py`
at startup.

Fix: pass `cache_config.mamba_ssm_cache_dtype` through.

> Note: the Kunlun GDN kernel does not support mixed precision (fp16 compute
> with an fp32 state cache), so startup requires `--mamba-ssm-cache-dtype float16`.

### 2. MiniMax-M2: adapt to the 0.25.1 RoutedExperts / MoERunner refactor
**Files**: `vllm_kunlun/quantization/compressed_tensors/compressed_tensors.py`,
`.../compressed_tensors_moe.py`

vLLM 0.25.1 turned `FusedMoE` from a class into a factory function and split
it into `RoutedExperts` + `MoERunner`, breaking the Kunlun W8A8-INT8 MoE path.

- `compressed_tensors.py`: match `RoutedExperts` instead of `FusedMoE` in the
  `isinstance` check.
- `compressed_tensors_moe.py`:
  - Derive expert projection names from the layer's `ckpt_*_proj_name`
    attributes so models using `w1/w2/w3` naming (MiniMax M2) map correctly,
    instead of hardcoding `gate_proj/up_proj/down_proj` (which caused the
    ignore regex to mismatch).
  - Override `KunlunCompressedTensorsW8A8Int8MoEMethod.__init__` to skip
    `select_int8_moe_backend` (no suitable backend on Kunlun XPU) and init
    `FusedMoEMethodBase` directly, so `create_weights` registers the scale
    parameters properly.

### 3. InternVL3.5: adapt to 0.25.1 multimodal API changes
**File**: `vllm_kunlun/models/internvl.py`

- `merge_multimodal_embeddings` → `_merge_multimodal_embeddings` (signature
  changed to an `is_multimodal` mask); add a compatibility shim.
- `MultiModalDataDict` moved to `vllm.multimodal.parse`.
- `BaseDummyInputsBuilder` moved to `vllm.multimodal.processing`.
- `set_default_torch_num_threads` moved to `vllm.utils.torch_utils`.
- Add the `mm_options` parameter to `get_dummy_mm_data` overrides.
- Drop the `use_data_parallel` argument passed to `InternVisionModel` (the new
  version decides internally).
- Add an `embed_multimodal` method (proxying to `get_multimodal_embeddings`)
  to match the v1 engine's call path.
- Remove unnecessary `flatten_bn` calls in image/video input parsing.

## Verification

- **Qwen3.5-35B-A3B**: starts successfully with `--mamba-ssm-cache-dtype float16`;
  block_size auto-aligns to 1056 tokens; inference works.
- **MiniMax-M2-W8A8-INT8-Dynamic**: loads successfully with 8-way TP
  (125/125 shards) and returns inference results. MoE forward routing under
  the new MoERunner dispatch still needs further validation.
- **InternVL3.5-30B-A3B**: starts with TP=1 and performs inference correctly
  (including image + text).