### PR TITLE
[BUGFIX]int8_moe_backend hook

### DIFF
--- a/vllm_kunlun/__init__.py
+++ b/vllm_kunlun/__init__.py
@@ -235,6 +235,7 @@ _register_post_import_hook(
     _qwen_triton_warmup_apply,
 )
 
+
 # --- hook 6: select_int8_moe_backend in w8a8_int8 module ---------------
 # CompressedTensorsW8A8Int8MoEMethod.__init__ calls select_int8_moe_backend()
 # which only supports Triton/CUDA backends. On Kunlun XPU is_cuda()==False so
@@ -258,9 +259,7 @@ def _w8a8_int8_moe_apply(mod):
     if not hasattr(mod, "select_int8_moe_backend"):
         return
 
-    def _kunlun_select_int8_moe_backend(
-        config, weight_key=None, activation_key=None
-    ):
+    def _kunlun_select_int8_moe_backend(config, weight_key=None, activation_key=None):
         return None, None
 
     mod.select_int8_moe_backend = _kunlun_select_int8_moe_backend

--- a/vllm_kunlun/__init__.py
+++ b/vllm_kunlun/__init__.py
@@ -208,7 +208,6 @@ def _w8a8_int8_moe_apply(mod):
     # may not be bound yet (the "from oracle.int8 import ..." is still in flight).
     if not hasattr(mod, "select_int8_moe_backend"):
         return
-    _orig = mod.select_int8_moe_backend
 
     def _kunlun_select_int8_moe_backend(
         config, weight_key=None, activation_key=None

--- a/vllm_kunlun/__init__.py
+++ b/vllm_kunlun/__init__.py
@@ -186,6 +186,46 @@ _register_post_import_hook(
     "vllm.model_executor.layers.activation", _activation_applied, _activation_apply
 )
 
+# --- hook 5: select_int8_moe_backend in w8a8_int8 module ---------------
+# CompressedTensorsW8A8Int8MoEMethod.__init__ calls select_int8_moe_backend()
+# which only supports Triton/CUDA backends. On Kunlun XPU is_cuda()==False so
+# all backends get skipped, raising NotImplementedError.
+# The Kunlun class uses is_monolithic=True + apply_monolithic() with
+# torch.ops._C.moe_* custom ops — it never uses int8_backend or experts_cls.
+# We patch the LOCAL reference (from X import Y) in the caller module so that
+# super().__init__() falls through gracefully.  See hook comment block above
+# for the post-import hook contract.
+def _w8a8_int8_moe_applied(mod):
+    # Module may be partially initialized during circular imports
+    if not hasattr(mod, "select_int8_moe_backend"):
+        return False
+    return getattr(mod, "_kunlun_select_int8_patched", False)
+
+
+def _w8a8_int8_moe_apply(mod):
+    # Guard against partially initialized module during circular imports.
+    # When oracle.int8 triggers import of this module, select_int8_moe_backend
+    # may not be bound yet (the "from oracle.int8 import ..." is still in flight).
+    if not hasattr(mod, "select_int8_moe_backend"):
+        return
+    _orig = mod.select_int8_moe_backend
+
+    def _kunlun_select_int8_moe_backend(
+        config, weight_key=None, activation_key=None
+    ):
+        return None, None
+
+    mod.select_int8_moe_backend = _kunlun_select_int8_moe_backend
+    mod._kunlun_select_int8_patched = True
+
+
+_register_post_import_hook(
+    "vllm.model_executor.layers.quantization.compressed_tensors."
+    "compressed_tensors_moe.compressed_tensors_moe_w8a8_int8",
+    _w8a8_int8_moe_applied,
+    _w8a8_int8_moe_apply,
+)
+
 
 def _preload_mapped(full_name):
     """Load the kunlun replacement for ``full_name`` into sys.modules."""

--- a/vllm_kunlun/__init__.py
+++ b/vllm_kunlun/__init__.py
@@ -186,7 +186,7 @@ _register_post_import_hook(
     "vllm.model_executor.layers.activation", _activation_applied, _activation_apply
 )
 
-# --- hook 5: select_int8_moe_backend in w8a8_int8 module ---------------
+# --- hook 6: select_int8_moe_backend in w8a8_int8 module ---------------
 # CompressedTensorsW8A8Int8MoEMethod.__init__ calls select_int8_moe_backend()
 # which only supports Triton/CUDA backends. On Kunlun XPU is_cuda()==False so
 # all backends get skipped, raising NotImplementedError.

--- a/vllm_kunlun/__init__.py
+++ b/vllm_kunlun/__init__.py
@@ -6,13 +6,13 @@ import logging
 import os
 import sys
 
-from vllm.logger import init_logger as init_vllm_logger
-
 OLD_IMPORT_HOOK = builtins.__import__
 
 
 def _configure_kunlun_logger() -> logging.Logger:
     """Reuse vLLM's handler for the vllm_kunlun logger tree."""
+    from vllm.logger import init_logger as init_vllm_logger
+
     vllm_logger = init_vllm_logger("vllm")
     kunlun_logger = logging.getLogger("vllm_kunlun")
 


### PR DESCRIPTION

<img width="1263" height="684" alt="14eb6ffe34f6f049d0b9c43c411425c3" src="https://github.com/user-attachments/assets/a767515a-3fe9-4277-b565-2a1e3ee7d04d" />


0.21/0.25 vllm 量化这块，__init__方法里面多了一个select_int8_moe_backend方法，走到这里就会报错，但其实这个self.int8_backend, self.experts_cls 在kunlun的量化路径里面都用不到，我开了个pr patch这个select_int8_moe_backend方法让他都返回None