### PR TITLE
V0.21.0 qwen36 suffix v2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,6 @@ msgspec==0.19.0
 numba==0.61.2
 openai==2.24.0
 openai-harmony==0.0.4
-opencv-contrib-python==4.12.0.88
 partial-json-parser==0.2.1.1.post6
 prometheus_client==0.22.1
 pybase64==1.4.1

--- a/vllm_kunlun/__init__.py
+++ b/vllm_kunlun/__init__.py
@@ -206,6 +206,66 @@ def _eagle_apply(mod):
 _register_post_import_hook("vllm.v1.spec_decode.eagle", _eagle_applied, _eagle_apply)
 
 
+# --- hook 7: SuffixDecodingProposer draft padding -------------------------
+# Suffix decoding proposes a dynamic number of draft tokens, which keeps the
+# verify batch non-uniform and therefore off the FULL cudagraph path. The
+# patch pads each draft to the speculation budget (enabled by default; disable
+# via VLLM_KUNLUN_SUFFIX_PAD_DRAFT=0). See
+# ``vllm_kunlun/v1/sample/spec_decode/suffix_decoding.py``.
+def _suffix_decoding_applied(mod):
+    cls = getattr(mod, "SuffixDecodingProposer", None)
+    if cls is None:
+        return True
+    fn = getattr(cls, "propose", None)
+    return fn is not None and getattr(fn, "__module__", "").startswith("vllm_kunlun")
+
+
+def _suffix_decoding_apply(mod):
+    if not hasattr(mod, "SuffixDecodingProposer"):
+        return
+    import vllm_kunlun.v1.sample.spec_decode.suffix_decoding  # noqa: F401
+
+
+_register_post_import_hook(
+    "vllm.v1.spec_decode.suffix_decoding",
+    _suffix_decoding_applied,
+    _suffix_decoding_apply,
+)
+
+
+# --- hook 8: speculative Mamba state re-anchor ----------------------------
+# Use worker consumers as triggers instead of gpu_model_runner itself. A hook
+# targeting gpu_model_runner can run while that module is still being defined,
+# allowing its later class body to overwrite the patched method.
+def _gpu_model_runner_applied(_consumer_mod):
+    runner_mod = sys.modules.get("vllm.v1.worker.gpu_model_runner")
+    cls = getattr(runner_mod, "GPUModelRunner", None)
+    if cls is None:
+        return False
+    fn = getattr(cls, "_prepare_inputs", None)
+    return fn is not None and getattr(fn, "_kunlun_spec_reanchor_patched", False)
+
+
+def _gpu_model_runner_apply(_consumer_mod):
+    runner_mod = sys.modules.get("vllm.v1.worker.gpu_model_runner")
+    if runner_mod is None or not hasattr(runner_mod, "GPUModelRunner"):
+        return
+    from vllm_kunlun.v1.worker.mamba_utils import patch_gpu_model_runner
+
+    patch_gpu_model_runner(runner_mod)
+
+
+for _runner_consumer in (
+    "vllm.v1.worker.gpu_worker",
+    "vllm.v1.worker.xpu_model_runner",
+):
+    _register_post_import_hook(
+        _runner_consumer,
+        _gpu_model_runner_applied,
+        _gpu_model_runner_apply,
+    )
+
+
 def _preload_mapped(full_name):
     """Load the kunlun replacement for ``full_name`` into sys.modules."""
     if full_name in sys.modules:

--- a/vllm_kunlun/__init__.py
+++ b/vllm_kunlun/__init__.py
@@ -40,8 +40,7 @@ _MODULE_MAPPINGS = {
     "vllm.v1.sample.ops.logprobs": "vllm_kunlun.v1.sample.ops.logprobs",
     "vllm.v1.sample.rejection_sampler": "vllm_kunlun.v1.sample.rejection_sampler",
     "vllm.attention.ops.merge_attn_states": "vllm_kunlun.ops.attention.merge_attn_states",
-    # "vllm.model_executor.models.config": "vllm_kunlun.models.config",
-    # "vllm.v1.worker.mamba_utils": "vllm_kunlun.v1.worker.mamba_utils",
+    "vllm.v1.worker.mamba_utils": "vllm_kunlun.v1.worker.mamba_utils",
     # "vllm.v1.worker.gpu_model_runner": "vllm_kunlun.v1.worker.gpu_model_runner",
 }
 
@@ -185,6 +184,26 @@ def _activation_apply(mod):
 _register_post_import_hook(
     "vllm.model_executor.layers.activation", _activation_applied, _activation_apply
 )
+
+
+# --- hook 6: EagleProposer padded-batch helpers ---------------------------
+# EagleProposer 的 prepare_next_token_ids_padded / prepare_inputs_padded /
+# _update_positions_dependent_metadata
+def _eagle_applied(mod):
+    cls = getattr(mod, "EagleProposer", None)
+    if cls is None:
+        return True
+    fn = getattr(cls, "prepare_next_token_ids_padded", None)
+    return fn is not None and getattr(fn, "__module__", "").startswith("vllm_kunlun")
+
+
+def _eagle_apply(mod):
+    if not hasattr(mod, "EagleProposer"):
+        return
+    import vllm_kunlun.v1.sample.spec_decode.eagle  # noqa: F401  (self-applies on import)
+
+
+_register_post_import_hook("vllm.v1.spec_decode.eagle", _eagle_applied, _eagle_apply)
 
 
 def _preload_mapped(full_name):

--- a/vllm_kunlun/models/__init__.py
+++ b/vllm_kunlun/models/__init__.py
@@ -112,6 +112,16 @@ def register_model():
         "vllm_kunlun.models.gemma4_mm:Gemma4ForConditionalGeneration",
     )
 
+    ModelRegistry.register_model(
+        "Qwen3_5MTP",
+        "vllm_kunlun.models.qwen3_5_mtp:Qwen3_5MTP",
+    )
+
+    ModelRegistry.register_model(
+        "Qwen3_5MoeMTP",
+        "vllm_kunlun.models.qwen3_5_mtp:Qwen3_5MoeMTP",
+    )
+
 
 def register_quant_method():
     """to do"""

--- a/vllm_kunlun/models/qwen3_5.py
+++ b/vllm_kunlun/models/qwen3_5.py
@@ -56,6 +56,7 @@ from vllm.model_executor.models.interfaces import (
     IsHybrid,
     MixtureOfExperts,
     MultiModalEmbeddings,
+    SupportsEagle3,
     SupportsLoRA,
     SupportsPP,
     _require_is_multimodal,
@@ -190,7 +191,7 @@ class Qwen3_5GatedDeltaNet(Qwen3NextGatedDeltaNet):
         z = z.reshape(-1, z.shape[-1])
         core_attn_out = self.norm(core_attn_out, z)
         core_attn_out = core_attn_out.reshape(z_shape_og)
-        core_attn_out = core_attn_out = core_attn_out.flatten(-2)
+        core_attn_out = core_attn_out.flatten(-2)
         output[:num_tokens], _ = self.out_proj(core_attn_out)
 
 
@@ -510,6 +511,7 @@ class Qwen3_5Model(Qwen3NextModel):
 class Qwen3_5ForCausalLMBase(
     nn.Module,
     HasInnerState,
+    SupportsEagle3,
     SupportsLoRA,
     SupportsPP,
 ):
@@ -748,6 +750,7 @@ class Qwen3_5ForConditionalGeneration(Qwen3VLForConditionalGeneration, IsHybrid)
         return MambaStateDtypeCalculator.gated_delta_net_state_dtype(
             vllm_config.model_config.dtype,
             vllm_config.cache_config.mamba_cache_dtype,
+            vllm_config.cache_config.mamba_ssm_cache_dtype,
         )
 
     @classmethod

--- a/vllm_kunlun/models/qwen3_5_mtp.py
+++ b/vllm_kunlun/models/qwen3_5_mtp.py
@@ -1,0 +1,454 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Inference-only Qwen3_5 MTP model."""
+
+import typing
+from collections.abc import Callable, Iterable
+
+import torch
+from torch import nn
+from vllm.compilation.decorators import support_torch_compile
+from vllm.config import VllmConfig
+from vllm.distributed.parallel_state import get_pp_group
+from vllm.logger import init_logger
+from vllm.model_executor.layers.fused_moe import fused_moe_make_expert_params_mapping
+from vllm.model_executor.layers.linear import ColumnParallelLinear
+from vllm.model_executor.layers.logits_processor import LogitsProcessor
+from vllm.model_executor.layers.vocab_parallel_embedding import (
+    ParallelLMHead,
+    VocabParallelEmbedding,
+)
+from vllm.model_executor.model_loader.weight_utils import default_weight_loader
+from vllm.model_executor.models.interfaces import (
+    MultiModalEmbeddings,
+    SupportsMultiModal,
+    _require_is_multimodal,
+)
+from vllm.model_executor.models.utils import (
+    AutoWeightsLoader,
+    PPMissingLayer,
+    _merge_multimodal_embeddings,
+    is_pp_missing_parameter,
+    make_empty_intermediate_tensors_factory,
+    maybe_prefix,
+)
+from vllm.sequence import IntermediateTensors
+from vllm.transformers_utils.configs.qwen3_5 import Qwen3_5TextConfig
+from vllm.transformers_utils.configs.qwen3_5_moe import Qwen3_5MoeTextConfig
+
+from .qwen3_5 import Qwen3_5DecoderLayer, Qwen3_5RMSNorm
+from .qwen3_next import QwenNextMixtureOfExperts
+
+logger = init_logger(__name__)
+
+
+@support_torch_compile(
+    dynamic_arg_dims={
+        "input_ids": 0,
+        # positions is of shape (3, seq_len) if mrope is enabled for qwen2-vl,
+        # otherwise (seq_len, ).
+        "positions": -1,
+        "intermediate_tensors": 0,
+        "inputs_embeds": 0,
+        "hidden_states": 0,
+    }
+)
+class Qwen3_5MultiTokenPredictor(nn.Module):
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
+        super().__init__()
+
+        model_config = vllm_config.model_config
+        quant_config = vllm_config.quant_config
+
+        config: Qwen3_5TextConfig | Qwen3_5MoeTextConfig = model_config.hf_text_config
+
+        self.config = config
+
+        self.vocab_size = config.vocab_size
+
+        self.mtp_start_layer_idx = config.num_hidden_layers
+        self.num_mtp_layers = getattr(config, "mtp_num_hidden_layers", 1)
+
+        self.embed_tokens = VocabParallelEmbedding(
+            self.vocab_size,
+            config.hidden_size,
+        )
+
+        # Workaround: mtp.fc is stored as BF16 in NVFP4 checkpoints but is
+        # missing from hf_quant_config.json exclude_modules. Force unquantized.
+        # Ref: https://github.com/vllm-project/vllm/pull/38650
+        # Ref: https://github.com/NVIDIA/Model-Optimizer/pull/1124
+        fc_quant = (
+            None
+            if (quant_config and quant_config.get_name() == "modelopt_fp4")
+            else quant_config
+        )
+        self.fc = ColumnParallelLinear(
+            self.config.hidden_size * 2,
+            self.config.hidden_size,
+            gather_output=True,
+            bias=False,
+            return_bias=False,
+            quant_config=fc_quant,
+            prefix=f"{prefix}.fc",
+        )
+
+        self.layers = torch.nn.ModuleList(
+            Qwen3_5DecoderLayer(
+                vllm_config,
+                layer_type="full_attention",
+                prefix=f"{prefix}.layers.{idx}",
+            )
+            for idx in range(self.num_mtp_layers)
+        )
+
+        self.make_empty_intermediate_tensors = make_empty_intermediate_tensors_factory(
+            ["hidden_states", "residual"], config.hidden_size
+        )
+
+        self.norm = Qwen3_5RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.pre_fc_norm_hidden = Qwen3_5RMSNorm(
+            config.hidden_size, eps=config.rms_norm_eps
+        )
+        self.pre_fc_norm_embedding = Qwen3_5RMSNorm(
+            config.hidden_size, eps=config.rms_norm_eps
+        )
+
+    def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
+        return self.embed_tokens(input_ids)
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        intermediate_tensors: IntermediateTensors | None = None,
+        inputs_embeds: torch.Tensor | None = None,
+        spec_step_idx: int = 0,
+    ) -> torch.Tensor:
+        if get_pp_group().is_first_rank:
+            if inputs_embeds is None:
+                inputs_embeds = self.embed_input_ids(input_ids)
+            assert hidden_states.shape[-1] == inputs_embeds.shape[-1]
+            inputs_embeds = self.pre_fc_norm_embedding(inputs_embeds)
+            hidden_states = self.pre_fc_norm_hidden(hidden_states)
+            hidden_states = torch.cat([inputs_embeds, hidden_states], dim=-1)
+            hidden_states = self.fc(hidden_states)
+            residual = None
+        else:
+            assert intermediate_tensors is not None
+            hidden_states = intermediate_tensors["hidden_states"]
+            residual = intermediate_tensors["residual"]
+
+        current_step_idx = spec_step_idx % self.num_mtp_layers
+        hidden_states, residual = self.layers[current_step_idx](
+            positions=positions,
+            hidden_states=hidden_states,
+            residual=residual,
+        )
+
+        if not get_pp_group().is_last_rank:
+            return IntermediateTensors(
+                {"hidden_states": hidden_states, "residual": residual}
+            )
+
+        hidden_states, _ = self.norm(hidden_states, residual)
+        return hidden_states
+
+    def load_fused_expert_weights(
+        self,
+        name: str,
+        params_dict: dict,
+        loaded_weight: torch.Tensor,
+        shard_id: str,
+        num_experts: int,
+    ) -> bool:
+        param = params_dict[name]
+        weight_loader = typing.cast(Callable[..., bool], param.weight_loader)
+        loaded_local_expert = False
+        for expert_id in range(num_experts):
+            curr_expert_weight = loaded_weight[expert_id]
+            success = weight_loader(
+                param,
+                curr_expert_weight,
+                name,
+                shard_id,
+                expert_id,
+                return_success=True,
+            )
+            if success:
+                loaded_local_expert = True
+
+        return loaded_local_expert
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        stacked_params_mapping = [
+            # (param_name, shard_name, shard_id)
+            ("qkv_proj", "q_proj", "q"),
+            ("qkv_proj", "k_proj", "k"),
+            ("qkv_proj", "v_proj", "v"),
+            ("gate_up_proj", "gate_proj", 0),
+            ("gate_up_proj", "up_proj", 1),
+        ]
+
+        # Params for weights, fp8 weight scales, fp8 activation scales
+        # (param_name, weight_name, expert_id, shard_id)
+        expert_params_mapping = fused_moe_make_expert_params_mapping(
+            self,
+            ckpt_gate_proj_name="gate_proj",
+            ckpt_down_proj_name="down_proj",
+            ckpt_up_proj_name="up_proj",
+            num_experts=(
+                self.config.num_experts if hasattr(self.config, "num_experts") else 0
+            ),
+        )
+
+        params_dict = dict(self.named_parameters())
+        loaded_params: set[str] = set()
+        is_fused_expert = False
+        base_layer = (
+            "base_layer." if any(".base_layer." in name for name in params_dict) else ""
+        )
+        fused_expert_params_mapping = [
+            (f"experts.{base_layer}w13_weight", "experts.gate_up_proj", 0, "w1"),
+            (f"experts.{base_layer}w2_weight", "experts.down_proj", 0, "w2"),
+        ]
+        num_experts = (
+            self.config.num_experts if hasattr(self.config, "num_experts") else 0
+        )
+        for name, loaded_weight in weights:
+            if "rotary_emb.inv_freq" in name:
+                continue
+
+            for param_name, weight_name, shard_id in stacked_params_mapping:
+                if "experts.gate_up_proj" in name or "experts.down_proj" in name:
+                    is_fused_expert = True
+                    expert_params_mapping = fused_expert_params_mapping
+
+                if weight_name not in name:
+                    continue
+
+                if "mlp.experts" in name:
+                    continue
+
+                name = name.replace(weight_name, param_name)
+                # Skip loading extra bias for GPTQ models.
+                if name.endswith(".bias") and name not in params_dict:
+                    continue
+                # Skip layers on other devices.
+                if is_pp_missing_parameter(name, self):
+                    continue
+                if name not in params_dict:
+                    continue
+                param = params_dict[name]
+                weight_loader = param.weight_loader
+                weight_loader(param, loaded_weight, shard_id)
+                break
+            else:
+                is_expert_weight = False
+                for mapping in expert_params_mapping:
+                    param_name, weight_name, expert_id, shard_id = mapping
+                    if weight_name not in name:
+                        continue
+                    is_expert_weight = True
+                    name_mapped = name.replace(weight_name, param_name)
+                    # Skip layers on other devices.
+                    if is_pp_missing_parameter(name_mapped, self):
+                        continue
+                    if is_fused_expert:
+                        # qwen3.5 no need to transpose
+                        # loaded_weight = loaded_weight.transpose(-1, -2)
+                        if "experts.gate_up_proj" in name:
+                            loaded_weight = loaded_weight.chunk(2, dim=-2)
+                            success_w1 = self.load_fused_expert_weights(
+                                name_mapped,
+                                params_dict,
+                                loaded_weight[0],
+                                "w1",
+                                num_experts,
+                            )
+                            success_w3 = self.load_fused_expert_weights(
+                                name_mapped,
+                                params_dict,
+                                loaded_weight[1],
+                                "w3",
+                                num_experts,
+                            )
+                            success = success_w1 and success_w3
+                        else:
+                            # down_proj
+                            success = self.load_fused_expert_weights(
+                                name_mapped,
+                                params_dict,
+                                loaded_weight,
+                                shard_id,
+                                num_experts,
+                            )
+                        if success:
+                            name = name_mapped
+                            break
+                    else:
+                        # Skip loading extra bias for GPTQ models.
+                        if (
+                            name_mapped.endswith(".bias")
+                            or name_mapped.endswith("_bias")
+                        ) and name_mapped not in params_dict:
+                            continue
+                        param = params_dict[name_mapped]
+                        weight_loader = param.weight_loader
+                        success = weight_loader(
+                            param,
+                            loaded_weight,
+                            name_mapped,
+                            shard_id=shard_id,
+                            expert_id=expert_id,
+                            return_success=True,
+                        )
+                    if success:
+                        name = name_mapped
+                        break
+                else:
+                    if is_expert_weight:
+                        # We've checked that this is an expert weight
+                        # However it's not mapped locally to this rank
+                        # So we simply skip it
+                        continue
+                    # Skip loading extra bias for GPTQ models.
+                    if name.endswith(".bias") and name not in params_dict:
+                        continue
+                    if is_pp_missing_parameter(name, self):
+                        continue
+                    if name not in params_dict:
+                        logger.warning_once(
+                            f"Parameter {name} not found in params_dict, skip loading"
+                        )
+                        continue
+                    param = params_dict[name]
+                    weight_loader = getattr(
+                        param, "weight_loader", default_weight_loader
+                    )
+                    weight_loader(param, loaded_weight)
+            loaded_params.add(name)
+        return loaded_params
+
+
+@support_torch_compile(
+    dynamic_arg_dims={
+        "input_ids": 0,
+        # positions is of shape (3, seq_len) if mrope is enabled for qwen2-vl,
+        # otherwise (seq_len, ).
+        "positions": -1,
+        "intermediate_tensors": 0,
+        "inputs_embeds": 0,
+        "hidden_states": 0,
+    }
+)
+class Qwen3_5MTP(nn.Module, SupportsMultiModal):
+    packed_modules_mapping = {
+        "qkv_proj": [
+            "q_proj",
+            "k_proj",
+            "v_proj",
+        ],
+        "gate_up_proj": ["gate_proj", "up_proj"],
+    }
+
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
+        config = vllm_config.model_config.hf_text_config
+        self.vllm_config = vllm_config
+        cache_config = vllm_config.cache_config
+        if cache_config.mamba_cache_mode == "all":
+            raise NotImplementedError(
+                "Qwen3_5MTP currently does not support 'all' prefix caching, "
+                "please use '--mamba-cache-mode=align' instead"
+            )
+
+        self.quant_config = vllm_config.quant_config
+
+        super().__init__()
+        self.config = config
+        self.model = Qwen3_5MultiTokenPredictor(
+            vllm_config=vllm_config, prefix=maybe_prefix(prefix, "mtp")
+        )
+
+        if get_pp_group().is_last_rank:
+            if config.tie_word_embeddings:
+                self.lm_head = self.model.embed_tokens
+            else:
+                self.lm_head = ParallelLMHead(
+                    config.vocab_size,
+                    config.hidden_size,
+                    prefix=maybe_prefix(prefix, "lm_head"),
+                )
+        else:
+            self.lm_head = PPMissingLayer()
+
+        self.logits_processor = LogitsProcessor(config.vocab_size)
+
+    def embed_input_ids(
+        self,
+        input_ids: torch.Tensor,
+        multimodal_embeddings: MultiModalEmbeddings | None = None,
+        *,
+        is_multimodal: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        inputs_embeds = self._embed_text_input_ids(
+            input_ids,
+            self.model.embed_input_ids,
+            is_multimodal=is_multimodal,
+        )
+
+        if multimodal_embeddings is None or len(multimodal_embeddings) == 0:
+            return inputs_embeds
+
+        is_multimodal = _require_is_multimodal(is_multimodal)
+
+        inputs_embeds = _merge_multimodal_embeddings(
+            inputs_embeds=inputs_embeds,
+            multimodal_embeddings=multimodal_embeddings,
+            is_multimodal=is_multimodal,
+        )
+
+        return inputs_embeds
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        intermediate_tensors: IntermediateTensors | None = None,
+        inputs_embeds: torch.Tensor | None = None,
+        **kwargs: object,
+    ):
+        hidden_states = self.model(
+            input_ids, positions, hidden_states, intermediate_tensors, inputs_embeds
+        )
+        return hidden_states
+
+    def compute_logits(
+        self,
+        hidden_states: torch.Tensor,
+        spec_step_idx: int = 0,
+    ) -> torch.Tensor | None:
+        return self.logits_processor(self.lm_head, hidden_states)
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        def remap_weight_names(weights):
+            for name, weight in weights:
+                if name.startswith("mtp."):
+                    name = name.replace("mtp.", "model.")
+                elif any(key in name for key in ["embed_tokens", "lm_head"]):
+                    if "embed_tokens" in name:
+                        name = name.replace("language_model.", "")
+                else:
+                    continue
+                yield name, weight
+
+        loader = AutoWeightsLoader(self)
+        return loader.load_weights(remap_weight_names(weights))
+
+
+class Qwen3_5MoeMTP(Qwen3_5MTP, QwenNextMixtureOfExperts):
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
+        super().__init__(vllm_config=vllm_config, prefix=prefix)
+        self.set_moe_parameters()

--- a/vllm_kunlun/models/qwen3_next.py
+++ b/vllm_kunlun/models/qwen3_next.py
@@ -109,7 +109,6 @@ logger = init_logger(__name__)
 KVCache = tuple[torch.Tensor, torch.Tensor]
 
 
-
 @torch.compile(dynamic=True, backend="aot_eager")
 def get_masked_input_and_mask_kunlun(
     input_: torch.Tensor,
@@ -587,6 +586,8 @@ class Qwen3NextGatedDeltaNet(nn.Module, MambaBase):
         ssm_state = self_kv_cache[1]
         num_actual_tokens = attn_metadata.num_actual_tokens
         num_accepted_tokens = attn_metadata.num_accepted_tokens
+        spec_pad_gather_idx = attn_metadata.spec_pad_gather_idx
+        spec_unpad_idx = attn_metadata.spec_unpad_idx
         mixed_qkv = mixed_qkv[:num_actual_tokens]
         b = b[:num_actual_tokens]
         a = a[:num_actual_tokens]
@@ -613,19 +614,24 @@ class Qwen3NextGatedDeltaNet(nn.Module, MambaBase):
         if spec_sequence_masks is not None:
             assert spec_state_indices_tensor is not None
             actual_num = attn_metadata.num_spec_decodes * spec_state_indices_tensor.size(-1)
+            if spec_pad_gather_idx is not None:
+                mixed_qkv_spec = mixed_qkv_spec.index_select(0, spec_pad_gather_idx)
             mixed_qkv_spec = causal_conv1d_update(
                 mixed_qkv_spec[:actual_num],
                 conv_state,
                 conv_weights,
                 self.conv1d.bias,
                 self.activation,
-                conv_state_indices=spec_conv_state_indices_tensor
-                [:attn_metadata.num_spec_decodes],
+                conv_state_indices=spec_conv_state_indices_tensor[
+                    :attn_metadata.num_spec_decodes
+                ],
                 num_accepted_tokens=num_accepted_tokens[:attn_metadata.num_spec_decodes],
                 query_start_loc=spec_query_start_loc,
                 max_query_len=spec_state_indices_tensor.size(-1),
                 validate_data=False,
             )
+            if spec_unpad_idx is not None:
+                mixed_qkv_spec = mixed_qkv_spec.index_select(0, spec_unpad_idx)
         if attn_metadata.num_prefills > 0:
             mixed_qkv_non_spec = causal_conv1d_fn(
                 mixed_qkv_non_spec,
@@ -694,13 +700,18 @@ class Qwen3NextGatedDeltaNet(nn.Module, MambaBase):
 
         # 2.1: Process the multi-query part
         if spec_sequence_masks is not None:
+            spec_len = (
+                attn_metadata.num_spec_decode_tokens
+                if spec_unpad_idx is not None
+                else actual_num
+            )
             core_attn_out_spec, last_recurrent_state = (
                 fused_recurrent_gated_delta_rule(
-                    q=query_spec[:, :actual_num],
-                    k=key_spec[:, :actual_num],
-                    v=value_spec[:, :actual_num],
-                    g=g_spec[:, :actual_num],
-                    beta=beta_spec[:, :actual_num],
+                    q=query_spec[:, :spec_len],
+                    k=key_spec[:, :spec_len],
+                    v=value_spec[:, :spec_len],
+                    g=g_spec[:, :spec_len],
+                    beta=beta_spec[:, :spec_len],
                     initial_state=ssm_state,
                     inplace_final_state=True,
                     cu_seqlens=spec_query_start_loc[  # type: ignore[index]
@@ -808,7 +819,8 @@ class Qwen3NextGatedDeltaNet(nn.Module, MambaBase):
             merged_out.index_copy_(1, non_spec_token_indx, core_attn_out_non_spec)
             core_attn_out[:num_actual_tokens] = merged_out.squeeze(0)
         elif spec_sequence_masks is not None:
-            core_attn_out[:num_actual_tokens] = core_attn_out_spec.squeeze(0)
+            spec_out = core_attn_out_spec.squeeze(0)
+            core_attn_out[: spec_out.shape[0]] = spec_out
         else:
             core_attn_out[:num_actual_tokens] = core_attn_out_non_spec.squeeze(0)
 

--- a/vllm_kunlun/models/qwen3_next.py
+++ b/vllm_kunlun/models/qwen3_next.py
@@ -67,6 +67,7 @@ from vllm.model_executor.model_loader.weight_utils import (
     sharded_weight_loader,
 )
 from vllm.model_executor.models.interfaces import (
+    EagleModelMixin,
     HasInnerState,
     IsHybrid,
     MixtureOfExperts,
@@ -266,7 +267,9 @@ class Qwen3NextGatedDeltaNet(nn.Module, MambaBase):
 
     def get_state_dtype(self) -> tuple[torch.dtype, torch.dtype]:
         return MambaStateDtypeCalculator.gated_delta_net_state_dtype(
-            self.model_config.dtype, self.cache_config.mamba_cache_dtype, self.cache_config.mamba_ssm_cache_dtype
+            self.model_config.dtype,
+            self.cache_config.mamba_cache_dtype,
+            # self.cache_config.mamba_ssm_cache_dtype
         )
 
     def get_state_shape(self) -> tuple[tuple[int, ...], tuple[int, ...]]:
@@ -562,7 +565,6 @@ class Qwen3NextGatedDeltaNet(nn.Module, MambaBase):
         if attn_metadata is None:
             # V1 profile run
             return
-
         assert isinstance(attn_metadata, dict)
         attn_metadata = attn_metadata[self.prefix]
         assert isinstance(attn_metadata, GDNAttentionMetadata)
@@ -572,8 +574,8 @@ class Qwen3NextGatedDeltaNet(nn.Module, MambaBase):
         non_spec_query_start_loc = attn_metadata.non_spec_query_start_loc
         non_spec_query_start_loc_cpu = attn_metadata.non_spec_query_start_loc_cpu
         spec_sequence_masks = attn_metadata.spec_sequence_masks
-        spec_token_masks = attn_metadata.spec_token_masks
         spec_token_indx = attn_metadata.spec_token_indx
+        spec_state_indices_tensor_cpu = attn_metadata.spec_state_indices_tensor_cpu
         non_spec_token_indx = attn_metadata.non_spec_token_indx
         spec_state_indices_tensor = attn_metadata.spec_state_indices_tensor  # noqa: E501
         non_spec_state_indices_tensor = attn_metadata.non_spec_state_indices_tensor  # noqa: E501
@@ -585,7 +587,7 @@ class Qwen3NextGatedDeltaNet(nn.Module, MambaBase):
         ssm_state = self_kv_cache[1]
         num_actual_tokens = attn_metadata.num_actual_tokens
         num_accepted_tokens = attn_metadata.num_accepted_tokens
-
+        num_accepted_tokens_cpu = attn_metadata.num_accepted_tokens_cpu
         mixed_qkv = mixed_qkv[:num_actual_tokens]
         b = b[:num_actual_tokens]
         a = a[:num_actual_tokens]
@@ -600,41 +602,43 @@ class Qwen3NextGatedDeltaNet(nn.Module, MambaBase):
                 mixed_qkv_spec = mixed_qkv
                 mixed_qkv_non_spec = None
             else:
-                mixed_qkv_spec = mixed_qkv[spec_token_masks]
-                mixed_qkv_non_spec = mixed_qkv[~spec_token_masks]
+                # mixed_qkv_spec = mixed_qkv[spec_token_masks]
+                # mixed_qkv_non_spec = mixed_qkv[~spec_token_masks]
+                mixed_qkv_spec = mixed_qkv.index_select(0, spec_token_indx)
+                mixed_qkv_non_spec = mixed_qkv.index_select(0, non_spec_token_indx)
         else:
             mixed_qkv_spec = None
             mixed_qkv_non_spec = mixed_qkv
 
         # 1.1: Process the multi-query part
         if spec_sequence_masks is not None:
+            assert spec_state_indices_tensor is not None
+            actual_num = attn_metadata.num_spec_decodes * spec_state_indices_tensor.size(-1)
             mixed_qkv_spec = causal_conv1d_update(
-                mixed_qkv_spec,
+                mixed_qkv_spec[:actual_num],
                 conv_state,
                 conv_weights,
                 self.conv1d.bias,
                 self.activation,
-                conv_state_indices=spec_state_indices_tensor[:, 0][
-                    : attn_metadata.num_spec_decodes
-                ],
-                num_accepted_tokens=num_accepted_tokens,
+                conv_state_indices=spec_state_indices_tensor[:, 0]
+                [:attn_metadata.num_spec_decodes],
+                conv_state_indices_cpu=spec_state_indices_tensor_cpu[:, 0]
+                [:attn_metadata.num_spec_decodes],
+                num_accepted_tokens=num_accepted_tokens[:attn_metadata.num_spec_decodes],
+                num_accepted_tokens_cpu=num_accepted_tokens_cpu[:attn_metadata.num_spec_decodes],
                 query_start_loc=spec_query_start_loc,
                 max_query_len=spec_state_indices_tensor.size(-1),
                 validate_data=False,
             )
-
-        # 1.2: Process the remaining part
         if attn_metadata.num_prefills > 0:
-            # - "cache_indices" updates the conv_state cache in positions
-            #   pointed to by "state_indices_tensor"
             mixed_qkv_non_spec = causal_conv1d_fn(
                 mixed_qkv_non_spec,
                 conv_weights,
                 self.conv1d.bias,
                 activation=self.activation,
                 conv_states=conv_state,
-                has_initial_state=has_initial_state,
-                has_initial_state_cpu=has_initial_state_cpu,
+                has_initial_state=has_initial_state.to(torch.int32),
+                has_initial_state_cpu=has_initial_state_cpu.to(torch.int32),
                 cache_indices=non_spec_state_indices_tensor,
                 cache_indices_cpu=non_spec_state_indices_tensor_cpu,
                 query_start_loc=non_spec_query_start_loc,
@@ -649,10 +653,10 @@ class Qwen3NextGatedDeltaNet(nn.Module, MambaBase):
                 self.conv1d.bias,
                 self.activation,
                 conv_state_indices=non_spec_state_indices_tensor[
-                    : attn_metadata.num_decodes
+                    : attn_metadata.num_actual_tokens
                 ],
                 conv_state_indices_cpu=non_spec_state_indices_tensor_cpu[
-                    : attn_metadata.num_decodes
+                    : attn_metadata.num_actual_tokens
                 ],
                 validate_data=True,
             )
@@ -676,10 +680,14 @@ class Qwen3NextGatedDeltaNet(nn.Module, MambaBase):
                 g_non_spec = None
                 beta_non_spec = None
             else:
-                g_spec = g[:, spec_token_masks]
-                beta_spec = beta[:, spec_token_masks]
-                g_non_spec = g[:, ~spec_token_masks]
-                beta_non_spec = beta[:, ~spec_token_masks]
+                # g_spec = g[:, spec_token_masks]
+                # beta_spec = beta[:, spec_token_masks]
+                # g_non_spec = g[:, ~spec_token_masks]
+                # beta_non_spec = beta[:, ~spec_token_masks]
+                g_spec = g.index_select(1, spec_token_indx)
+                beta_spec = beta.index_select(1, spec_token_indx)
+                g_non_spec = g.index_select(1, non_spec_token_indx)
+                beta_non_spec = beta.index_select(1, non_spec_token_indx)
         else:
             g_spec = None
             beta_spec = None
@@ -690,18 +698,23 @@ class Qwen3NextGatedDeltaNet(nn.Module, MambaBase):
 
         # 2.1: Process the multi-query part
         if spec_sequence_masks is not None:
-            core_attn_out_spec, last_recurrent_state = fused_recurrent_gated_delta_rule(
-                q=query_spec,
-                k=key_spec,
-                v=value_spec,
-                g=g_spec,
-                beta=beta_spec,
-                initial_state=ssm_state,
-                inplace_final_state=True,
-                cu_seqlens=spec_query_start_loc[: attn_metadata.num_spec_decodes + 1],
-                ssm_state_indices=spec_state_indices_tensor,
-                num_accepted_tokens=num_accepted_tokens,
-                use_qk_l2norm_in_kernel=True,
+            core_attn_out_spec, last_recurrent_state = (
+                fused_recurrent_gated_delta_rule(
+                    q=query_spec[:, :actual_num],
+                    k=key_spec[:, :actual_num],
+                    v=value_spec[:, :actual_num],
+                    g=g_spec[:, :actual_num],
+                    beta=beta_spec[:, :actual_num],
+                    initial_state=ssm_state,
+                    inplace_final_state=True,
+                    cu_seqlens=spec_query_start_loc[  # type: ignore[index]
+                        : attn_metadata.num_spec_decodes
+                        + 1  # type: ignore[attr-defined]
+                    ],
+                    ssm_state_indices=spec_state_indices_tensor[:attn_metadata.num_spec_decodes],
+                    num_accepted_tokens=num_accepted_tokens[:attn_metadata.num_spec_decodes],
+                    use_qk_l2norm_in_kernel=True,
+                )
             )
         else:
             core_attn_out_spec, last_recurrent_state = None, None
@@ -711,36 +724,23 @@ class Qwen3NextGatedDeltaNet(nn.Module, MambaBase):
             # initial_state = ssm_state[non_spec_state_indices_tensor]
             # initial_state[~has_initial_state] = 0
             # initial_state = initial_state.transpose(-1, -2).contiguous()
-            slot_mapping = torch.full(
-                (ssm_state.shape[0],), -1, dtype=torch.int32, device=ssm_state.device,
-            )
-            slot_mapping[non_spec_state_indices_tensor] = torch.arange(
-                len(non_spec_state_indices_tensor), dtype=torch.int32, device=ssm_state.device,
-            )
 
-            initial_state_shape = (
-                non_spec_state_indices_tensor.shape + ssm_state.shape[1:]
-            )
-            initial_state = torch.empty(
-                initial_state_shape, dtype=ssm_state.dtype, device=ssm_state.device
-            )
-            initial_state = initial_state.view(
-                initial_state.shape[0], 1, -1, initial_state.shape[-1]
-            )
-            cast_ssm_state = ssm_state.view(ssm_state.shape[0], -1, ssm_state.shape[-1])
+            initial_state_shape = non_spec_state_indices_tensor.shape + ssm_state.shape[1: ]
+            initial_state = torch.zeros(initial_state_shape, dtype=ssm_state.dtype, device=ssm_state.device)
+            grep_non_spec_state_indices_tensor = non_spec_state_indices_tensor[has_initial_state]
+            if grep_non_spec_state_indices_tensor.shape[0] != 0:
+                slot_mapping = torch.full((ssm_state.shape[0],), -1, dtype=torch.int32, device="cuda")
+                slot_mapping[grep_non_spec_state_indices_tensor] = torch.arange(len(grep_non_spec_state_indices_tensor),dtype=torch.int32,device="cuda")
+                initial_state = initial_state.view(initial_state.shape[0], 1, -1, initial_state.shape[-1])
+                cast_ssm_state = ssm_state.view(ssm_state.shape[0], -1, ssm_state.shape[-1])
+                kunlun_ops.reshape_and_cache_flash(
+                                    cast_ssm_state,
+                                    cast_ssm_state,
+                                    initial_state,
+                                    initial_state,
+                                    slot_mapping)
+                initial_state = initial_state.view(initial_state_shape)
 
-            kunlun_ops.reshape_and_cache_flash(
-                cast_ssm_state,
-                cast_ssm_state,
-                initial_state,
-                initial_state,
-                slot_mapping,
-            )
-            initial_state = initial_state.view(initial_state_shape)
-
-            initial_state = initial_state * has_initial_state.view(
-                has_initial_state.shape[0], 1, 1, 1
-            )
             initial_state = initial_state.transpose(-1, -2).contiguous()
 
             (
@@ -756,6 +756,7 @@ class Qwen3NextGatedDeltaNet(nn.Module, MambaBase):
                 output_final_state=True,
                 use_qk_l2norm_in_kernel=True,
                 cu_seqlens=non_spec_query_start_loc,
+                cu_seqlens_cpu=non_spec_query_start_loc_cpu,
             )
             # Init cache
             # ssm_state[non_spec_state_indices_tensor] = (
@@ -1124,7 +1125,7 @@ class Qwen3NextDecoderLayer(nn.Module):
 
 
 @support_torch_compile
-class Qwen3NextModel(nn.Module):
+class Qwen3NextModel(nn.Module, EagleModelMixin):
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
         super().__init__()
 
@@ -1171,7 +1172,7 @@ class Qwen3NextModel(nn.Module):
         positions: torch.Tensor,
         intermediate_tensors: IntermediateTensors | None = None,
         inputs_embeds: torch.Tensor | None = None,
-    ) -> torch.Tensor:
+    ) -> torch.Tensor | IntermediateTensors | tuple[torch.Tensor, list[torch.Tensor]]:
         if get_pp_group().is_first_rank:
             if inputs_embeds is not None:
                 hidden_states = inputs_embeds
@@ -1183,11 +1184,18 @@ class Qwen3NextModel(nn.Module):
             hidden_states = intermediate_tensors["hidden_states"]
             residual = intermediate_tensors["residual"]
 
-        for layer in islice(self.layers, self.start_layer, self.end_layer):
+        aux_hidden_states = self._maybe_add_hidden_state([], 0, hidden_states, residual)
+        for layer_idx, layer in enumerate(
+            islice(self.layers, self.start_layer, self.end_layer),
+            start=self.start_layer,
+        ):
             hidden_states, residual = layer(
                 positions=positions,
                 hidden_states=hidden_states,
                 residual=residual,
+            )
+            self._maybe_add_hidden_state(
+                aux_hidden_states, layer_idx + 1, hidden_states, residual
             )
 
         if not get_pp_group().is_last_rank:
@@ -1195,6 +1203,8 @@ class Qwen3NextModel(nn.Module):
                 {"hidden_states": hidden_states, "residual": residual}
             )
         hidden_states, _ = self.norm(hidden_states, residual)
+        if aux_hidden_states:
+            return hidden_states, aux_hidden_states
         return hidden_states
 
     def get_expert_mapping(self) -> list[tuple[str, str, int, str]]:
@@ -1420,7 +1430,9 @@ class Qwen3NextForCausalLM(
         vllm_config: "VllmConfig",
     ) -> tuple[torch.dtype, torch.dtype]:
         return MambaStateDtypeCalculator.gated_delta_net_state_dtype(
-            vllm_config.model_config.dtype, vllm_config.cache_config.mamba_cache_dtype
+            vllm_config.model_config.dtype,
+            vllm_config.cache_config.mamba_cache_dtype,
+            # vllm_config.cache_config.mamba_ssm_cache_dtype,
         )
 
     @classmethod

--- a/vllm_kunlun/models/qwen3_next.py
+++ b/vllm_kunlun/models/qwen3_next.py
@@ -269,7 +269,7 @@ class Qwen3NextGatedDeltaNet(nn.Module, MambaBase):
         return MambaStateDtypeCalculator.gated_delta_net_state_dtype(
             self.model_config.dtype,
             self.cache_config.mamba_cache_dtype,
-            # self.cache_config.mamba_ssm_cache_dtype
+            self.cache_config.mamba_ssm_cache_dtype
         )
 
     def get_state_shape(self) -> tuple[tuple[int, ...], tuple[int, ...]]:
@@ -575,9 +575,9 @@ class Qwen3NextGatedDeltaNet(nn.Module, MambaBase):
         non_spec_query_start_loc_cpu = attn_metadata.non_spec_query_start_loc_cpu
         spec_sequence_masks = attn_metadata.spec_sequence_masks
         spec_token_indx = attn_metadata.spec_token_indx
-        spec_state_indices_tensor_cpu = attn_metadata.spec_state_indices_tensor_cpu
         non_spec_token_indx = attn_metadata.non_spec_token_indx
         spec_state_indices_tensor = attn_metadata.spec_state_indices_tensor  # noqa: E501
+        spec_conv_state_indices_tensor = attn_metadata.spec_conv_state_indices_tensor
         non_spec_state_indices_tensor = attn_metadata.non_spec_state_indices_tensor  # noqa: E501
         non_spec_state_indices_tensor_cpu = (
             attn_metadata.non_spec_state_indices_tensor_cpu
@@ -587,7 +587,6 @@ class Qwen3NextGatedDeltaNet(nn.Module, MambaBase):
         ssm_state = self_kv_cache[1]
         num_actual_tokens = attn_metadata.num_actual_tokens
         num_accepted_tokens = attn_metadata.num_accepted_tokens
-        num_accepted_tokens_cpu = attn_metadata.num_accepted_tokens_cpu
         mixed_qkv = mixed_qkv[:num_actual_tokens]
         b = b[:num_actual_tokens]
         a = a[:num_actual_tokens]
@@ -620,12 +619,9 @@ class Qwen3NextGatedDeltaNet(nn.Module, MambaBase):
                 conv_weights,
                 self.conv1d.bias,
                 self.activation,
-                conv_state_indices=spec_state_indices_tensor[:, 0]
-                [:attn_metadata.num_spec_decodes],
-                conv_state_indices_cpu=spec_state_indices_tensor_cpu[:, 0]
+                conv_state_indices=spec_conv_state_indices_tensor
                 [:attn_metadata.num_spec_decodes],
                 num_accepted_tokens=num_accepted_tokens[:attn_metadata.num_spec_decodes],
-                num_accepted_tokens_cpu=num_accepted_tokens_cpu[:attn_metadata.num_spec_decodes],
                 query_start_loc=spec_query_start_loc,
                 max_query_len=spec_state_indices_tensor.size(-1),
                 validate_data=False,
@@ -1432,7 +1428,7 @@ class Qwen3NextForCausalLM(
         return MambaStateDtypeCalculator.gated_delta_net_state_dtype(
             vllm_config.model_config.dtype,
             vllm_config.cache_config.mamba_cache_dtype,
-            # vllm_config.cache_config.mamba_ssm_cache_dtype,
+            vllm_config.cache_config.mamba_ssm_cache_dtype,
         )
 
     @classmethod

--- a/vllm_kunlun/ops/_kunlun_ops.py
+++ b/vllm_kunlun/ops/_kunlun_ops.py
@@ -416,7 +416,7 @@ class KunlunOps:
                 normed_score=normed_score,
                 topk_index=topk_ids,
                 block_statistic=None,
-                stable=False,
+                stable=True,
             )
         elif scoring_func == "sigmoid":
             torch.ops._C.moe_sigmoid_group_topk_norm(
@@ -578,6 +578,8 @@ class KunlunOps:
                 sorted_tokens_idx=sorted_tokens_idx,
                 moe_topk=moe_top_k,
                 y=y,
+                topk_ids=topk_ids,
+                act=None,
             )
             # Reuse `workspace_a` for `out1` after `moe_expand` is no longer
             # needed.
@@ -599,6 +601,8 @@ class KunlunOps:
                 sorted_tokens_idx=sorted_tokens_idx,
                 moe_topk=moe_top_k,
                 y=out,
+                topk_ids=topk_ids,
+                act=None,
             )
 
             output = torch.empty(

--- a/vllm_kunlun/ops/fla/__init__.py
+++ b/vllm_kunlun/ops/fla/__init__.py
@@ -1,9 +1,13 @@
 from .chunk import chunk_gated_delta_rule
-from .fused_recurrent import fused_recurrent_gated_delta_rule
+from .fused_recurrent import (
+    fused_recurrent_gated_delta_rule,
+    torch_fused_recurrent_gated_delta_rule,
+)
 from .layernorm_guard import RMSNormGated
 
 __all__ = [
     "RMSNormGated",
     "chunk_gated_delta_rule",
     "fused_recurrent_gated_delta_rule",
+    "torch_fused_recurrent_gated_delta_rule",
 ]

--- a/vllm_kunlun/ops/fla/chunk.py
+++ b/vllm_kunlun/ops/fla/chunk.py
@@ -296,6 +296,7 @@ def chunk_gated_delta_rule(
         scale = k.shape[-1] ** -0.5
 
     if cu_seqlens is not None and initial_state is not None:
+        # out_dtype = v.dtype
         q = q.contiguous()
         k = k.contiguous()
         v = v.contiguous()
@@ -325,6 +326,7 @@ def chunk_gated_delta_rule(
             cu_seqlens,
             use_qk_l2norm_in_kernel=True,
         )
+        # o = o.to(out_dtype)
     else:
         o, final_state = ChunkGatedDeltaRuleFunction.apply(
             q,

--- a/vllm_kunlun/ops/fla/chunk.py
+++ b/vllm_kunlun/ops/fla/chunk.py
@@ -296,12 +296,13 @@ def chunk_gated_delta_rule(
         scale = k.shape[-1] ** -0.5
 
     if cu_seqlens is not None and initial_state is not None:
-        # out_dtype = v.dtype
-        q = q.contiguous()
-        k = k.contiguous()
-        v = v.contiguous()
-        g = g.contiguous()
-        beta = beta.contiguous()
+        out_dtype = v.dtype
+        state_dtype = initial_state.dtype
+        q = q.to(state_dtype).contiguous()
+        k = k.to(state_dtype).contiguous()
+        v = v.to(state_dtype).contiguous()
+        g = g.to(state_dtype).contiguous()
+        beta = beta.to(state_dtype).contiguous()
         initial_state = initial_state.contiguous()
 
         o = torch.empty_like(v)
@@ -326,7 +327,7 @@ def chunk_gated_delta_rule(
             cu_seqlens,
             use_qk_l2norm_in_kernel=True,
         )
-        # o = o.to(out_dtype)
+        o = o.to(out_dtype)
     else:
         o, final_state = ChunkGatedDeltaRuleFunction.apply(
             q,

--- a/vllm_kunlun/ops/fla/chunk.py
+++ b/vllm_kunlun/ops/fla/chunk.py
@@ -189,6 +189,7 @@ def chunk_gated_delta_rule(
     initial_state: torch.Tensor = None,
     output_final_state: bool = False,
     cu_seqlens: Optional[torch.LongTensor] = None,
+    cu_seqlens_cpu: Optional[torch.LongTensor] = None,
     head_first: bool = False,
     use_qk_l2norm_in_kernel: bool = False,
 ):
@@ -294,7 +295,7 @@ def chunk_gated_delta_rule(
     if scale is None:
         scale = k.shape[-1] ** -0.5
 
-    if False:
+    if cu_seqlens is not None and initial_state is not None:
         q = q.contiguous()
         k = k.contiguous()
         v = v.contiguous()
@@ -306,18 +307,23 @@ def chunk_gated_delta_rule(
         final_state = torch.empty_like(initial_state)
         import kunlun_ops
 
-        kunlun_ops.chunk_gated_delta_rule(
+        if cu_seqlens_cpu is None:
+            cu_seqlens_cpu = cu_seqlens.cpu()
+        kunlun_ops.gated_delta_rule(
             q,
             k,
             v,
+            initial_state,
             g,
             beta,
-            scale,
-            initial_state,
-            o,
             final_state,
-            cu_seqlens.cpu(),
-            use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
+            o,
+            scale,
+            cu_seqlens_cpu,
+            cu_seqlens,
+            cu_seqlens_cpu,
+            cu_seqlens,
+            use_qk_l2norm_in_kernel=True,
         )
     else:
         o, final_state = ChunkGatedDeltaRuleFunction.apply(

--- a/vllm_kunlun/ops/fla/fused_recurrent.py
+++ b/vllm_kunlun/ops/fla/fused_recurrent.py
@@ -89,3 +89,175 @@ def fused_recurrent_gated_delta_rule(
         use_qk_l2norm_in_kernel,
     )
     return o, final_state
+
+
+@torch.no_grad()
+def torch_fused_recurrent_gated_delta_rule(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor = None,
+    scale: float = None,
+    initial_state: torch.Tensor = None,
+    inplace_final_state: bool = True,
+    cu_seqlens: Optional[torch.LongTensor] = None,
+    ssm_state_indices: Optional[torch.Tensor] = None,
+    num_accepted_tokens: Optional[torch.Tensor] = None,
+    use_qk_l2norm_in_kernel: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Pure-torch reference of ``fused_recurrent_gated_delta_rule`` for the
+    MTP / spec-decode (varlen + continuous-batching) path.
+
+    Faithful re-implementation of the community Triton kernel
+    ``fused_recurrent_gated_delta_rule_fwd_kernel`` with the flags used on the
+    spec path: IS_VARLEN + IS_CONTINUOUS_BATCHING + IS_SPEC_DECODING +
+    INPLACE_FINAL_STATE, IS_KDA=False. Meant as a binary-search substitute for
+    the ``kunlun_ops`` fwdv2 kernel to isolate whether the multi-concurrency
+    NaN originates in that kernel.
+
+    Shapes (matching the qwen3_next spec call):
+      q, k          : (1, T, H,  K)
+      v             : (1, T, HV, V)
+      g             : (1, T, HV)               per-head decay in log space
+      beta          : (1, T, HV) or (1,T,HV,V) scalar / headwise
+      initial_state : (num_lines, HV, V, K)    == ssm_state; physically stored
+                      with V before K, so it is transposed to [K, V] on read
+                      and back to [V, K] on write. Updated in place.
+      cu_seqlens    : (N+1,)                   varlen boundaries
+      ssm_state_indices : (N, num_spec+1) int  per-position cache-block ids
+      num_accepted_tokens : (N,) int           read-slot = num_accepted-1
+
+    State per v-head is kept as S[K, V] during the recurrence. Verified against
+    the kunlun fwdv2 kernel (out/state max|Δ|~1e-4 for accepted counts 1..4,
+    single- and multi-sequence). The recurrence per token is:
+        S     *= exp(g)                       # gated decay
+        u      = (v - k @ S) * beta           # delta correction
+        S     += outer(k, u)                  # rank-1 update
+        o      = q @ S                        # readout
+
+    Rolling-buffer writeback (matches the fwdv2 kernel exactly):
+        column t  <- S_t         for t >= 1   (per draft-token states)
+        column 0  <- S_{acc-1}                (the accepted / base state)
+
+    CUDA-graph-friendly form: this is a fully vectorized rewrite of the earlier
+    per-sequence Python loop. It contains no host synchronization (no ``.item()``
+    / ``.tolist()`` / ``.cpu()``) and no value-dependent control flow. All
+    per-request selection (read slot, candidate blocks, NULL_BLOCK skips) is
+    expressed with on-device gather / scatter / masking, and the only Python loop
+    runs over the *static* padded speculative length ``L`` (a shape, not a tensor
+    value), so the launched work is identical on every graph replay.
+
+    Assumes the padded spec-decode layout, where every request contributes the
+    same number of query tokens ``L = ssm_state_indices.shape[-1]`` and therefore
+    ``T == N * L``. This holds for the padded MTP verify path that calls it.
+    """
+    assert cu_seqlens is not None, "torch spec path requires cu_seqlens"
+    assert ssm_state_indices is not None, "torch spec path requires ssm_state_indices"
+    assert initial_state is not None, "torch spec path requires initial_state"
+
+    out_dtype = v.dtype  # preserve the input dtype for the returned output
+    q = q[0].float()
+    k = k[0].float()
+    v = v[0].float()
+    g = g[0].float()
+    T, H, K = q.shape
+    HV, V = v.shape[1], v.shape[2]
+    if scale is None:
+        scale = K**-0.5
+    if beta is None:
+        beta = torch.ones(T, HV, device=v.device)
+    else:
+        beta = beta[0].float()
+    beta_headwise = beta.dim() == 3  # (T, HV, V)
+
+    if use_qk_l2norm_in_kernel:
+        q = q / (q.pow(2).sum(-1, keepdim=True) + 1e-6).sqrt()
+        k = k / (k.pow(2).sum(-1, keepdim=True) + 1e-6).sqrt()
+    q = q * scale
+
+    # GVA: v-head hv reads q/k head ``hv // (HV // H)`` (kernel line 64).
+    r = HV // H
+    head_index = torch.arange(HV, device=q.device) // r
+    q_hv_all = q[:, head_index, :]  # (T, HV, K)
+    k_hv_all = k[:, head_index, :]  # (T, HV, K)
+
+    is_spec = num_accepted_tokens is not None
+    idx2d = ssm_state_indices.dim() == 2
+    # N and L come from tensor *shapes* (static across a captured graph), never
+    # from tensor values -> no host sync.
+    N = cu_seqlens.shape[0] - 1
+    L = ssm_state_indices.shape[-1] if idx2d else 1
+    assert T == N * L, (
+        "CUDA-graph torch path requires the padded spec layout: "
+        f"T({T}) must equal N({N}) * L({L})."
+    )
+
+    device = q.device
+    idx = ssm_state_indices.long()
+    if not idx2d:
+        idx = idx.view(N, 1)  # (N, L=1)
+
+    # ---- Read: parallel gather of every sequence's initial state (before any
+    # write), reproducing the kernel's parallel h0 load. Read slot is
+    # ``num_accepted - 1`` on the spec path, else column 0. NULL_BLOCK_ID
+    # (block id <= 0) -> the sequence contributes nothing (zero state, zero
+    # output, no writeback), handled via ``valid_read`` masking. ----
+    if is_spec:
+        read_col = (num_accepted_tokens.long() - 1).clamp_(0, L - 1)  # (N,)
+    else:
+        read_col = torch.zeros(N, dtype=torch.long, device=device)
+    read_block = idx.gather(1, read_col.view(N, 1)).squeeze(1)  # (N,)
+    valid_read = read_block > 0  # (N,)
+    safe_read = read_block.clamp(min=0)
+    # ssm_state is physically [.., V, K]; transpose to [K, V] for the math.
+    S = initial_state[safe_read].float().transpose(-2, -1)  # (N, HV, K, V)
+    S = torch.where(valid_read.view(N, 1, 1, 1), S, S.new_zeros(()))
+
+    # ---- Recurrence: L (static) steps, all N sequences in parallel. ----
+    q2 = q_hv_all.reshape(N, L, HV, K)
+    k2 = k_hv_all.reshape(N, L, HV, K)
+    v2 = v.reshape(N, L, HV, V)
+    g2 = g.reshape(N, L, HV)
+    beta2 = beta.reshape(N, L, HV, V) if beta_headwise else beta.reshape(N, L, HV)
+
+    # Writeback rolling-buffer source (column 0 <- state after step
+    # ``num_accepted - 1``; column t <- state after step t for t >= 1). Committed
+    # in-place per step (below) to keep peak memory at ~one step's state instead
+    # of stacking all L states, which OOMs for large concurrency.
+    if inplace_final_state:
+        if is_spec:
+            base = (num_accepted_tokens.long() - 1).clamp_(0, L - 1)  # (N,)
+        else:
+            base = torch.zeros(N, dtype=torch.long, device=device)
+
+    def _commit(state_kv, dest_blocks, wmask):
+        """Scatter state (N, HV, K, V) -> physical [V, K] into ``initial_state``
+        at ``dest_blocks`` for rows where ``wmask`` & block id > 0. Skipped rows
+        are routed to the reserved NULL slot 0 and blended with its current
+        value (a no-op), so duplicate NULL indices are harmless."""
+        vals = state_kv.transpose(-2, -1).contiguous().to(initial_state.dtype)
+        blk = dest_blocks.long()
+        m = wmask & (blk > 0)
+        safe = torch.where(m, blk, blk.new_zeros(())).clamp_(min=0)
+        initial_state[safe] = torch.where(
+            m.view(-1, 1, 1, 1), vals, initial_state[safe]
+        )
+
+    o = q.new_zeros(N, L, HV, V)
+    for t in range(L):
+        S = S * torch.exp(g2[:, t])[:, :, None, None]  # (N, HV, K, V)
+        k_t = k2[:, t]  # (N, HV, K)
+        kv = (S * k_t[:, :, :, None]).sum(2)  # (N, HV, V)
+        u = v2[:, t] - kv  # (N, HV, V)
+        u = u * (beta2[:, t] if beta_headwise else beta2[:, t][:, :, None])
+        S = S + k_t[:, :, :, None] * u[:, :, None, :]  # (N, HV, K, V)
+        o[:, t] = (S * q2[:, t][:, :, :, None]).sum(2)  # (N, HV, V)
+        if inplace_final_state:
+            if t >= 1:
+                _commit(S, idx[:, t], valid_read)  # column t
+            _commit(S, idx[:, 0], valid_read & (base == t))  # column 0 when base==t
+    # Zero the output of skipped (NULL read) sequences, then flatten back.
+    o = (o * valid_read.view(N, 1, 1, 1)).reshape(T, HV, V).to(out_dtype)
+
+    return o.unsqueeze(0), initial_state

--- a/vllm_kunlun/ops/fla/fused_recurrent.py
+++ b/vllm_kunlun/ops/fla/fused_recurrent.py
@@ -136,9 +136,12 @@ def torch_fused_recurrent_gated_delta_rule(
         S     += outer(k, u)                  # rank-1 update
         o      = q @ S                        # readout
 
-    Rolling-buffer writeback (matches the fwdv2 kernel exactly):
-        column t  <- S_t         for t >= 1   (per draft-token states)
-        column 0  <- S_{acc-1}                (the accepted / base state)
+    Rolling-buffer writeback (matches the community Triton kernel):
+        column t  <- S_t         for every t, including t == 0
+    The next forward reads column ``num_accepted - 1``, so all L candidate
+    states must be published. NOTE: the kunlun fwdv2 kernel instead writes
+    ``column 0 <- S_{num_accepted-1}``, which is stale by one step and corrupts
+    the state (see the comment at the writeback below).
 
     CUDA-graph-friendly form: this is a fully vectorized rewrite of the earlier
     per-sequence Python loop. It contains no host synchronization (no ``.item()``
@@ -221,16 +224,6 @@ def torch_fused_recurrent_gated_delta_rule(
     g2 = g.reshape(N, L, HV)
     beta2 = beta.reshape(N, L, HV, V) if beta_headwise else beta.reshape(N, L, HV)
 
-    # Writeback rolling-buffer source (column 0 <- state after step
-    # ``num_accepted - 1``; column t <- state after step t for t >= 1). Committed
-    # in-place per step (below) to keep peak memory at ~one step's state instead
-    # of stacking all L states, which OOMs for large concurrency.
-    if inplace_final_state:
-        if is_spec:
-            base = (num_accepted_tokens.long() - 1).clamp_(0, L - 1)  # (N,)
-        else:
-            base = torch.zeros(N, dtype=torch.long, device=device)
-
     def _commit(state_kv, dest_blocks, wmask):
         """Scatter state (N, HV, K, V) -> physical [V, K] into ``initial_state``
         at ``dest_blocks`` for rows where ``wmask`` & block id > 0. Skipped rows
@@ -254,9 +247,17 @@ def torch_fused_recurrent_gated_delta_rule(
         S = S + k_t[:, :, :, None] * u[:, :, None, :]  # (N, HV, K, V)
         o[:, t] = (S * q2[:, t][:, :, :, None]).sum(2)  # (N, HV, V)
         if inplace_final_state:
-            if t >= 1:
-                _commit(S, idx[:, t], valid_read)  # column t
-            _commit(S, idx[:, 0], valid_read & (base == t))  # column 0 when base==t
+            # Rolling buffer: column t <- state after step t, for EVERY t
+            # (including t == 0). The next forward reads column
+            # ``num_accepted - 1``, i.e. the state after its last accepted
+            # token, so all L candidate states must be published. Writing
+            # column 0 with ``S_{num_accepted-1}`` of *this* call instead (what
+            # the kunlun fwdv2 kernel does) uses the previous step's acceptance
+            # count and leaves column 0 holding a state that is too far ahead
+            # whenever this call was entered with ``num_accepted >= 2``; the
+            # following step then reads it if it accepts exactly 1 token and the
+            # sequence state is corrupted from there on.
+            _commit(S, idx[:, t], valid_read)
     # Zero the output of skipped (NULL read) sequences, then flatten back.
     o = (o * valid_read.view(N, 1, 1, 1)).reshape(T, HV, V).to(out_dtype)
 

--- a/vllm_kunlun/ops/mamba/causal_conv1d.py
+++ b/vllm_kunlun/ops/mamba/causal_conv1d.py
@@ -77,6 +77,8 @@ def torch_causal_conv1d_update_spec(
     conv_state_indices=None,
     num_accepted_tokens=None,
 ):
+    if bias is not None:
+        bias = bias.to(weight.dtype)
     out = torch.empty_like(hidden_states)
     _, seq_len, hidden_size = hidden_states.shape
     for i in range(hidden_states.shape[0]):
@@ -89,7 +91,41 @@ def torch_causal_conv1d_update_spec(
 
         hidden_states_new = hidden_states_new.unsqueeze(0)
 
-        conv_state[conv_state_indices[i]] = hidden_states_new[:, -state_len:, :]
+        width = weight.shape[-1]
+        # The convolution below needs at least ``width`` input rows to produce a
+        # non-negative output length (F.conv1d output len = in_len - width + 1).
+        # On the real spec-decode path the concatenated stream is always long
+        # enough. During the dummy/warmup run (e.g. cudagraph capture) the
+        # constructed ``num_accepted_tokens`` can make ``2 + accepted + seq_len``
+        # shorter than ``width``, which would crash F.conv1d with a negative
+        # dimension. Left-pad (on the oldest side) with zeros to the minimum
+        # required length; this mirrors the community Triton kernel, which reads
+        # conv history through a bounded mask and treats out-of-range history as
+        # zero. The real path never hits this branch, so its numerics are
+        # unchanged.
+        min_len = width - 1 + seq_len
+        if hidden_states_new.shape[1] < min_len:
+            hidden_states_new = F.pad(
+                hidden_states_new, (0, 0, min_len - hidden_states_new.shape[1], 0)
+            )
+
+        # Roll the conv_state in a sliding-window manner, matching the
+        # community Triton kernel (``_causal_conv1d_update_kernel``). That
+        # kernel writes ``new_conv_state`` back with a masked store bounded by
+        # ``idx_tokens < state_len``, i.e. it fills only the leading valid rows
+        # of the cache slot and leaves the rest untouched -- it never requires
+        # the written window to exactly equal the physical ``state_len``.
+        #
+        # Here ``hidden_states_new[:, -state_len:, :]`` is the sliding window
+        # (history tail + new tokens). On the real spec-decode path its length
+        # is exactly ``state_len``; during the dummy/warmup run (seq_len==1,
+        # dummy num_accepted_tokens) it can be shorter. Writing into the front
+        # slice ``[:n]`` reproduces the kernel's masked store for both cases
+        # without zero-padding the cache (left-padding would corrupt the state
+        # with spurious zeros).
+        new_conv_state = hidden_states_new[:, -state_len:, :]
+        n = new_conv_state.shape[1]
+        conv_state[conv_state_indices[i]][:n, :] = new_conv_state[0]
         for j in range(seq_len):
             if j == seq_len - 1:
                 hidden_states_new_j = hidden_states_new
@@ -119,6 +155,7 @@ def causal_conv1d_update(
     conv_state_indices: Optional[torch.Tensor] = None,
     conv_state_indices_cpu: Optional[torch.Tensor] = None,
     num_accepted_tokens: Optional[torch.Tensor] = None,
+    num_accepted_tokens_cpu: Optional[torch.Tensor] = None,
     query_start_loc: torch.Tensor | None = None,
     max_query_len: int = -1,
     pad_slot_id: int = PAD_SLOT_ID,
@@ -187,30 +224,53 @@ def causal_conv1d_update(
         x = x.squeeze(-1).unsqueeze(1)
     else:
         x = x.squeeze(-1).view(-1, max_query_len, dim)
+    # if num_accepted_tokens is None:
+    # New ``causal_conv1d_update`` writes its output in-place into x.
+    # Drop the legacy ``state_seq_stride`` / ``act="SWISH"`` / paired
+    # ``*_cpu`` + ``*_xpu`` arguments.
+    silu_activation = activation in ("silu", "swish")
+    kunlun_ops.causal_conv1d_update(
+        x,
+        conv_state,
+        weight,
+        bias=bias,
+        silu_activation=silu_activation,
+        cache_seqlens=None,
+        conv_state_indices=conv_state_indices,
+        is_ncw=False,
+        pad_slot_id=pad_slot_id,
+        num_accepted_tokens=num_accepted_tokens,
+    )
+    # if (
+    #     num_accepted_tokens is not None
+    # ):
+    #     # Binary-search: route the spec conv through the pure-torch reference.
+    #     x = torch_causal_conv1d_update_spec(
+    #         hidden_states=x,
+    #         conv_state=conv_state,
+    #         weight=weight,
+    #         bias=bias,
+    #         activation="silu" if silu_activation else None,
+    #         conv_state_indices=conv_state_indices,
+    #         num_accepted_tokens=num_accepted_tokens,
+    #     )
+    # else:
+    #     kunlun_ops.causal_conv1d_update(
+    #         x,
+    #         conv_state,
+    #         weight,
+    #         bias=bias,
+    #         silu_activation=silu_activation,
+    #         cache_seqlens=None,
+    #         conv_state_indices=conv_state_indices,
+    #         is_ncw=False,
+    #         pad_slot_id=pad_slot_id,
+    #         num_accepted_tokens=num_accepted_tokens,
+    #     )
     if num_accepted_tokens is None:
-        # New ``causal_conv1d_update`` writes its output in-place into x.
-        # Drop the legacy ``state_seq_stride`` / ``act="SWISH"`` / paired
-        # ``*_cpu`` + ``*_xpu`` arguments.
-        silu_activation = activation in ("silu", "swish")
-        kunlun_ops.causal_conv1d_update(
-            x,
-            conv_state,
-            weight,
-            bias=bias,
-            silu_activation=silu_activation,
-            cache_seqlens=None,
-            conv_state_indices=conv_state_indices,
-            is_ncw=False,
-            pad_slot_id=pad_slot_id,
-        )
+        # non-spec decode: x is [batch, 1, dim] -> [batch, dim]
         return x.squeeze(1)
-    else:
-        return torch_causal_conv1d_update_spec(
-            x,
-            conv_state,
-            weight,
-            bias,
-            activation,
-            conv_state_indices=conv_state_indices,
-            num_accepted_tokens=num_accepted_tokens,
-        )
+    # spec (MTP) decode: x is [num_spec_decodes, max_query_len, dim];
+    # flatten back to [num_tokens, dim] to match the caller's layout
+    # (mixed_qkv_spec[:actual_num] = <return>).
+    return x.reshape(-1, dim)

--- a/vllm_kunlun/ops/mamba/causal_conv1d.py
+++ b/vllm_kunlun/ops/mamba/causal_conv1d.py
@@ -77,72 +77,64 @@ def torch_causal_conv1d_update_spec(
     conv_state_indices=None,
     num_accepted_tokens=None,
 ):
-    if bias is not None:
-        bias = bias.to(weight.dtype)
-    out = torch.empty_like(hidden_states)
-    _, seq_len, hidden_size = hidden_states.shape
-    for i in range(hidden_states.shape[0]):
-        tmp_conv_state = conv_state[conv_state_indices[i]]
-        state_len = tmp_conv_state.shape[-2]
-        hidden_states_i = hidden_states[i]
-        hidden_states_new = torch.cat(
-            [tmp_conv_state[: (2 + num_accepted_tokens[i]), :], hidden_states_i], dim=0
-        ).to(weight.dtype)
+    """CUDA/XPU-graph-safe pure-torch reference for the spec (MTP) conv update.
 
-        hidden_states_new = hidden_states_new.unsqueeze(0)
+    hidden_states: (batch, seq_len, dim)
+    conv_state:    (num_cache_lines, state_len, dim)  [is_ncw=False layout]
+    weight:        (dim, width), bias: (dim,)
 
-        width = weight.shape[-1]
-        # The convolution below needs at least ``width`` input rows to produce a
-        # non-negative output length (F.conv1d output len = in_len - width + 1).
-        # On the real spec-decode path the concatenated stream is always long
-        # enough. During the dummy/warmup run (e.g. cudagraph capture) the
-        # constructed ``num_accepted_tokens`` can make ``2 + accepted + seq_len``
-        # shorter than ``width``, which would crash F.conv1d with a negative
-        # dimension. Left-pad (on the oldest side) with zeros to the minimum
-        # required length; this mirrors the community Triton kernel, which reads
-        # conv history through a bounded mask and treats out-of-range history as
-        # zero. The real path never hits this branch, so its numerics are
-        # unchanged.
-        min_len = width - 1 + seq_len
-        if hidden_states_new.shape[1] < min_len:
-            hidden_states_new = F.pad(
-                hidden_states_new, (0, 0, min_len - hidden_states_new.shape[1], 0)
-            )
+    ``num_accepted_tokens`` is only ever used to build *gather indices* and a
+    *mask* -- never a Python slice bound, an ``if`` condition or a tensor
+    shape. Every shape below is a function of (batch, seq_len, dim, width)
+    only, so the traced graph stays valid for any accepted-token count and
+    there is no device->host sync.
+    """
+    batch, seq_len, dim = hidden_states.shape
+    state_len = conv_state.shape[-2]
+    width = weight.shape[-1]
+    # The caller guarantees a sliding window that exactly fits the cache slot
+    # (state_len == conv_kernel_size - 1 + num_spec, seq_len == num_spec + 1).
+    assert state_len == width - 2 + seq_len, (
+        f"spec conv expects state_len == width - 2 + seq_len, got "
+        f"state_len={state_len}, width={width}, seq_len={seq_len}"
+    )
 
-        # Roll the conv_state in a sliding-window manner, matching the
-        # community Triton kernel (``_causal_conv1d_update_kernel``). That
-        # kernel writes ``new_conv_state`` back with a masked store bounded by
-        # ``idx_tokens < state_len``, i.e. it fills only the leading valid rows
-        # of the cache slot and leaves the rest untouched -- it never requires
-        # the written window to exactly equal the physical ``state_len``.
-        #
-        # Here ``hidden_states_new[:, -state_len:, :]`` is the sliding window
-        # (history tail + new tokens). On the real spec-decode path its length
-        # is exactly ``state_len``; during the dummy/warmup run (seq_len==1,
-        # dummy num_accepted_tokens) it can be shorter. Writing into the front
-        # slice ``[:n]`` reproduces the kernel's masked store for both cases
-        # without zero-padding the cache (left-padding would corrupt the state
-        # with spurious zeros).
-        new_conv_state = hidden_states_new[:, -state_len:, :]
-        n = new_conv_state.shape[1]
-        conv_state[conv_state_indices[i]][:n, :] = new_conv_state[0]
-        for j in range(seq_len):
-            if j == seq_len - 1:
-                hidden_states_new_j = hidden_states_new
-            else:
-                hidden_states_new_j = hidden_states_new[:, : (1 - seq_len + j)]
-            hidden_states_new_j = hidden_states_new_j.transpose(-1, -2).contiguous()
-            out_i = F.conv1d(
-                hidden_states_new_j,
-                weight.unsqueeze(1),
-                bias,
-                padding=0,
-                groups=hidden_size,
-            )
-            out_i = F.silu(out_i[:, :, -1:])
-            out_i = out_i.to(hidden_states.dtype).squeeze(-1).unsqueeze(0)
-            out[i, j] = out_i
-    return out.view(-1, hidden_size)
+    idx = conv_state_indices.long()
+    # Read the selected cache lines *before* the write-back below.
+    hist = conv_state.index_select(0, idx)  # (batch, state_len, dim)
+
+    # Request i has ``2 + accepted_i`` valid history rows, so the ``width - 1``
+    # rows the convolution needs start at ``2 + accepted_i - (width - 1)``.
+    # Negative rows lie outside the history -- only reachable on the
+    # dummy/warmup run where accepted can be 0. They are clamped for the gather
+    # and then zeroed by ``row_ok``, which reproduces the zero-padded history of
+    # the community Triton kernel (it reads history through a bounded mask).
+    rows = num_accepted_tokens.long().view(batch, 1) + (3 - width)
+    rows = rows + torch.arange(width - 1, device=hidden_states.device).view(1, -1)
+    row_ok = (rows >= 0) & (rows < state_len)
+    rows = rows.clamp_(0, state_len - 1)
+    hist_tail = hist.gather(1, rows.unsqueeze(-1).expand(batch, width - 1, dim))
+    hist_tail = hist_tail * row_ok.unsqueeze(-1).to(hist_tail.dtype)
+
+    # (batch, width - 1 + seq_len, dim): history tail followed by the new
+    # tokens. Output token j is the conv over the fixed window [j, j + width).
+    stream = torch.cat([hist_tail, hidden_states], dim=1).to(weight.dtype)
+
+    out = F.conv1d(
+        stream.transpose(1, 2).contiguous(),
+        weight.unsqueeze(1),
+        bias.to(weight.dtype) if bias is not None else None,
+        padding=0,
+        groups=dim,
+    )  # (batch, dim, seq_len)
+    # Unconditional silu, matching the previous reference and the GDN caller,
+    # which always requests silu.
+    out = F.silu(out).transpose(1, 2).to(hidden_states.dtype)
+
+    # Slide the cache window: drop the oldest row of the stream, keeping the
+    # newest ``state_len`` rows.
+    conv_state.index_copy_(0, idx, stream[:, 1:, :].to(conv_state.dtype).contiguous())
+    return out.reshape(-1, dim)
 
 
 def causal_conv1d_update(
@@ -229,9 +221,13 @@ def causal_conv1d_update(
     # Drop the legacy ``state_seq_stride`` / ``act="SWISH"`` / paired
     # ``*_cpu`` + ``*_xpu`` arguments.
     silu_activation = activation in ("silu", "swish")
+    if num_accepted_tokens is not None:
+        state_len = width - 1 + (max_query_len - 1)  # spec
+    else:
+        state_len = width - 1
     kunlun_ops.causal_conv1d_update(
         x,
-        conv_state,
+        conv_state[:, :state_len, :],
         weight,
         bias=bias,
         silu_activation=silu_activation,
@@ -241,32 +237,6 @@ def causal_conv1d_update(
         pad_slot_id=pad_slot_id,
         num_accepted_tokens=num_accepted_tokens,
     )
-    # if (
-    #     num_accepted_tokens is not None
-    # ):
-    #     # Binary-search: route the spec conv through the pure-torch reference.
-    #     x = torch_causal_conv1d_update_spec(
-    #         hidden_states=x,
-    #         conv_state=conv_state,
-    #         weight=weight,
-    #         bias=bias,
-    #         activation="silu" if silu_activation else None,
-    #         conv_state_indices=conv_state_indices,
-    #         num_accepted_tokens=num_accepted_tokens,
-    #     )
-    # else:
-    #     kunlun_ops.causal_conv1d_update(
-    #         x,
-    #         conv_state,
-    #         weight,
-    #         bias=bias,
-    #         silu_activation=silu_activation,
-    #         cache_seqlens=None,
-    #         conv_state_indices=conv_state_indices,
-    #         is_ncw=False,
-    #         pad_slot_id=pad_slot_id,
-    #         num_accepted_tokens=num_accepted_tokens,
-    #     )
     if num_accepted_tokens is None:
         # non-spec decode: x is [batch, 1, dim] -> [batch, dim]
         return x.squeeze(1)

--- a/vllm_kunlun/patches/eval_frame.py
+++ b/vllm_kunlun/patches/eval_frame.py
@@ -1,40 +1,48 @@
-# mypy: allow-untyped-defs
 # mypy: disable-error-code="method-assign"
 
 """
-Functions in this file are responsible for modifying the eval frame
-handler at RUNTIME.  Therefore, all functions in this file are hot.
-Functions that only execute at compile time should be placed
-in torch._dynamo.convert_frame.
+This module implements the core frame evaluation handler for TorchDynamo's compilation system.
+The eval frame handler intercepts Python bytecode execution at runtime to enable dynamic
+compilation and optimization of PyTorch code.
+
+Key components defined here:
+- Frame evaluation handlers that intercept and analyze Python execution frames
+- Guards management for tracking dependencies and invalidating compiled code
+- Optimization contexts and decorators (optimize, run_once, disable, etc.)
+- Export functionality for saving optimized graphs
+- Backend compiler integrations and callback management
+
+Functions in this file are responsible for modifying the eval frame handler at RUNTIME.
+Therefore, all functions in this file are hot and performance-critical. Functions that
+only execute at compile time should be placed in torch._dynamo.convert_frame.
+
+The eval frame handler is the core mechanism that enables TorchDynamo to dynamically
+intercept, analyze and optimize PyTorch code during execution. It works by registering
+a custom frame evaluation function that gets called for every Python frame, allowing
+us to detect PyTorch operations and trigger compilation as needed.
 """
 
 from __future__ import annotations
 
+import atexit
 import contextlib
 import functools
 import inspect
 import logging
 import os
 import sys
+import sysconfig
 import textwrap
+import threading
 import traceback
 import types
+import unittest
 import warnings
 import weakref
+from dataclasses import dataclass
 from enum import Enum
 from os.path import dirname, join
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Callable,
-    Dict,
-    List,
-    NamedTuple,
-    Optional,
-    Set,
-    Tuple,
-    Union,
-)
+from typing import TYPE_CHECKING, Any, Callable, NamedTuple, Optional, Union
 from unittest.mock import patch
 
 import sympy
@@ -47,15 +55,32 @@ from torch import _guards
 # see discussion at https://github.com/pytorch/pytorch/issues/120699
 from torch._C._dynamo.eval_frame import (  # noqa: F401
     reset_code,
+    set_code_exec_strategy,
+    set_eval_frame,
+    set_guard_complete_hook,
     set_guard_error_hook,
-    skip_code,
+    set_skip_guard_eval_unsafe,
     unsupported,
 )
 from torch._dispatch.python import enable_python_dispatcher
+from torch._dynamo.types import ConvertFrameReturn, FrameAction, FrameExecStrategy
+from torch._export.utils import _compiling_state_context
 from torch._subclasses.fake_tensor import unset_fake_temporarily
 from torch._utils_internal import justknobs_check, log_export_usage
-from torch.export.dynamic_shapes import _combine_args, _process_dynamic_shapes
+from torch.export.dynamic_shapes import (
+    Constraint,
+    _combine_args,
+    _DimHint,
+    _DimHintType,
+    _IntWrapper,
+    _process_dynamic_shapes,
+    _RelaxedConstraint,
+)
 from torch.fx import GraphModule
+from torch.fx.experimental._dynamism import (
+    clone_and_convert_to_meta,
+    track_dynamism_across_examples,
+)
 from torch.fx.experimental.proxy_tensor import make_fx
 from torch.fx.experimental.symbolic_shapes import (
     ConstraintViolationError,
@@ -65,18 +90,40 @@ from torch.fx.experimental.symbolic_shapes import (
 )
 from torch.fx.graph import _PyTreeCodeGen, _PyTreeInfo
 
-from . import config, convert_frame, external_utils, trace_rules, utils
+from . import config, convert_frame, distributed, external_utils, trace_rules, utils
 from .backends.registry import CompilerFn, lookup_backend
 from .code_context import code_context
-from .exc import CondOpArgsMismatchError, UserError, UserErrorType
+from .exc import (
+    CondOpArgsMismatchError,
+    ShortenTraceback,
+    Unsupported,
+    UserError,
+    UserErrorType,
+)
 from .hooks import Hooks
 from .mutation_guard import install_generation_tagging_init
-from .utils import common_constant_types, compile_times
+from .utils import (
+    _get_error_on_graph_break,
+    _set_error_on_graph_break,
+    common_constant_types,
+    compile_times,
+)
 
 if TYPE_CHECKING:
-    from torch._subclasses import fake_tensor
+    from collections.abc import Iterable, Sequence
 
-    from .types import CacheEntry, DynamoCallback
+    from torch._dynamo.package import CompilePackage
+    from torch._dynamo.repro.after_dynamo import WrapBackendDebug
+    from torch._subclasses import fake_tensor
+    from torch.fx.node import Argument, Node, Target
+
+    from .types import (
+        CacheEntry,
+        DynamoCallback,
+        DynamoFrameType,
+        GuardFail,
+        GuardFilterEntry,
+    )
 
 
 log = logging.getLogger(__name__)
@@ -91,18 +138,14 @@ class Unset(Enum):
     token = 0
 
 
-cached_backends: Dict[int, CompilerFn] = {}
+cached_backends: dict[int, CompilerFn] = {}
 
 unset = Unset.token
 
-from torch._C._dynamo.eval_frame import set_eval_frame  # noqa
 
-
-def _maybe_set_eval_frame(callback: DynamoCallback):
+def _maybe_set_eval_frame(callback: DynamoCallback) -> DynamoCallback:
     # A wrapper on set_eval_frame that is guarded by a Justknob.
     # Users can disable torchDynamo by setting the JK to False.
-    # from torch._C._dynamo.eval_frame import set_eval_frame
-
     if not justknobs_check("pytorch/compiler:enable_compiler_set_eval_frame"):
         torch._dynamo.utils.warn_once(
             "Dynamo disabled by Justknob: enable_compiler_set_eval_frame, skipping set_eval_frame"
@@ -112,7 +155,160 @@ def _maybe_set_eval_frame(callback: DynamoCallback):
         return set_eval_frame(callback)
 
 
-def _reset_guarded_backend_cache():
+@dataclass
+class DynamoStance:
+    stance: str = "default"
+    skip_guard_eval_unsafe: bool = False
+    backend: Union[str, Callable[..., Any], None] = None
+
+
+_stance = DynamoStance()
+
+
+def _set_stance(stance: DynamoStance) -> DynamoStance:
+    global _stance
+
+    from torch._C._dynamo.eval_frame import get_eval_frame_callback
+
+    callback = get_eval_frame_callback()
+
+    if callback is not False and callback is not None:
+        raise RuntimeError("attempted to set_stance in a torch.compile region")
+
+    prior = _stance
+    _stance = stance
+    return prior
+
+
+_set_stance._dynamo_forbidden = True  # type: ignore[attr-defined]
+
+_EXAMPLE_INPUTS: Optional[dict[str, list[Any]]] = None
+
+
+def get_example_inputs(key: str) -> list[Any]:
+    global _EXAMPLE_INPUTS
+    if _EXAMPLE_INPUTS is None:
+        _EXAMPLE_INPUTS = {}
+
+    if key not in _EXAMPLE_INPUTS:
+        _EXAMPLE_INPUTS[key] = []
+
+    return _EXAMPLE_INPUTS[key]
+
+
+def _callback_from_stance(callback: DynamoCallback) -> DynamoCallback:
+    if _stance.stance == "default":
+        # force_backend
+        if _stance.backend is not None and callback not in (False, None):
+            callback = _create_wrapped_callback(get_compiler_fn(_stance.backend))
+
+        return callback
+    elif _stance.stance == "eager_then_compile":
+        if callback not in (False, None):
+            return _create_delayed_compile_callback(callback, _stance.stance)
+        return callback
+    elif _stance.stance == "aot_eager_then_compile":
+        if callback not in (False, None):
+            return _create_delayed_compile_callback(callback, _stance.stance)
+        return callback
+    elif _stance.stance == "force_eager":
+        # disable
+        return None
+    elif _stance.stance == "eager_on_recompile":
+        # run mode
+        return False
+    elif _stance.stance == "fail_on_recompile":
+        if callback in (False, None):
+            return callback
+
+        def fail_callback(
+            frame: DynamoFrameType, *args: Any, **kwargs: Any
+        ) -> ConvertFrameReturn:
+            if trace_rules.check(frame.f_code):
+                return ConvertFrameReturn()
+            if not convert_frame.has_tensor_in_frame(frame):
+                return ConvertFrameReturn()
+
+            from torch._C._dynamo.eval_frame import _debug_get_precompile_entries
+
+            message = (
+                "Detected recompile when torch.compile stance is 'fail_on_recompile'. "
+                + f"filename: '{frame.f_code.co_filename}', "
+                + f"function name: '{frame.f_code.co_name}', "
+                + f"line number: {frame.f_lineno}"
+            )
+            precompile_entries = _debug_get_precompile_entries(frame.f_code)
+            if len(precompile_entries) > 0:
+                message += "\nFailed on the following precompiled guards: "
+                for entry in precompile_entries:
+                    message += f"\n{entry.guard_manager}{entry.guard_manager.check_verbose(frame.f_locals)}"  # type: ignore[attr-defined]
+            raise RuntimeError(message)
+
+        # to prevent cache miss due to different backend
+        fail_callback._torchdynamo_orig_backend = callback  # type: ignore[attr-defined]
+
+        return fail_callback
+    else:
+        raise RuntimeError(f"invalid torch.compile stance '{_stance}'")
+
+
+def _create_wrapped_callback(
+    compiler_fn: CompilerFn,
+) -> convert_frame.CatchErrorsWrapper:
+    hooks = Hooks()
+    return convert_frame.catch_errors_wrapper(
+        convert_frame.convert_frame(  # type: ignore[arg-type]
+            compiler_fn,
+            hooks,
+        ),
+        hooks,
+    )
+
+
+def _get_or_add_example_inputs(frame: DynamoFrameType) -> list[Any]:
+    key = frame.f_code.co_filename + str(frame.f_code.co_firstlineno)
+    example_inputs = get_example_inputs(key)
+
+    if len(example_inputs) < 2:
+        example_inputs.append(clone_and_convert_to_meta(frame.f_locals))
+
+    return example_inputs
+
+
+def _create_delayed_compile_callback(
+    callback: DynamoCallback, stance: str
+) -> Callable[..., Any]:
+    def callback_fn(*args: Any, **kwargs: Any) -> convert_frame.ConvertFrameReturn:
+        frame = args[0]
+        example_inputs = _get_or_add_example_inputs(frame)
+
+        if len(example_inputs) == 1:
+            if stance == "eager_then_compile":
+                return ConvertFrameReturn(
+                    frame_exec_strategy=FrameExecStrategy(
+                        FrameAction.DEFAULT, FrameAction.DEFAULT
+                    )
+                )
+            elif stance == "aot_eager_then_compile":
+                aot_eager_fn = get_compiler_fn("aot_eager")
+                return _create_wrapped_callback(aot_eager_fn)(*args, **kwargs)
+
+        dynamism = track_dynamism_across_examples(example_inputs)
+        code_context.get_context(frame.f_code)["dynamism"] = dynamism
+        compiler_fn = callback._torchdynamo_orig_backend._torchdynamo_orig_backend  # type: ignore[union-attr]
+        return _create_wrapped_callback(compiler_fn)(*args, **kwargs)
+
+    # to prevent cache miss due to different backend
+    callback_fn._torchdynamo_orig_backend = callback  # type: ignore[attr-defined]
+
+    return callback_fn
+
+
+def _is_skip_guard_eval_unsafe_stance() -> bool:
+    return _stance.skip_guard_eval_unsafe
+
+
+def _reset_guarded_backend_cache() -> None:
     global cached_backends
     for backend in cached_backends.values():
         if hasattr(backend, "reset"):
@@ -129,7 +325,7 @@ DONT_WRAP_FILES = {
 
 def _debug_get_cache_entry_list(
     code: Union[types.CodeType, Callable[..., Any]],
-) -> List[CacheEntry]:
+) -> list[CacheEntry]:
     """
     Given a code object or a callable object, retrieve the cache entries
      stored in this code.
@@ -157,24 +353,38 @@ class OptimizedModule(torch.nn.Module):
         "_forward",
         "__dict__",
         "named_children_walk",
+        "_super_module_initialized",
     }
 
-    def __init__(self, mod: torch.nn.Module, dynamo_ctx) -> None:
+    def __init__(self, mod: torch.nn.Module, dynamo_ctx: _TorchDynamoContext) -> None:
+        # NOTE: this must go first, because attribute reads/writes of `self`
+        # uses `_orig_mod`, and sometimes users override `Module.__init__` to
+        # do attribute reads/writes on `self`.
+        #
+        # We also can't use regular setattr because `super().__setattr__` will
+        # complain for module value before `super().__init__()`
+        object.__setattr__(self, "_orig_mod", mod)
+        self._super_module_initialized = False
         super().__init__()
+        self._super_module_initialized = True
+
         # Installs the params/buffer
-        self._orig_mod = mod
+        self._orig_mod = mod  # `super().__setattr__` will register this module
         self.dynamo_ctx = dynamo_ctx
         self._initialize()
         self.training = self._orig_mod.training
 
-    def _initialize(self):
+    def _initialize(self) -> None:
         # Do this stuff in constructor to lower overhead slightly
         if isinstance(self.dynamo_ctx, DisableContext):
             # No need to check trace rules
             self.forward = self.dynamo_ctx(self._orig_mod.__call__)
-        elif isinstance(self._orig_mod.forward, types.MethodType) and (
-            trace_rules.check(self._orig_mod.forward)
-            or getattr(self._orig_mod, "_is_fsdp_managed_module", False)
+        elif config.wrap_top_frame or (
+            isinstance(self._orig_mod.forward, types.MethodType)
+            and (
+                trace_rules.check(self._orig_mod.forward)
+                or getattr(self._orig_mod, "_is_fsdp_managed_module", False)
+            )
         ):
             # This may be a torch.nn.* instance in trace_rules.py which
             # won't trigger a frame evaluation workaround to add an extra
@@ -188,38 +398,52 @@ class OptimizedModule(torch.nn.Module):
             self._forward = self.forward
             self.forward = self._call_lazy_check
 
-    def __reduce__(self):
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        if torch.nn.modules.module._has_any_global_hook():
+            warnings.warn(
+                "Using `torch.compile(module)` when there are global hooks on "
+                "modules (e.g., from `register_module_forward_hook`); this will"
+                " cause the hooks to fire an extra time for the "
+                "`OptimizedModule` created by `torch.compile(module)`. If this "
+                "causes undesired behavior, please try using `module.compile()`"
+                ", or use the per-module hooks instead",
+                stacklevel=2,
+            )
+        return super().__call__(*args, **kwargs)
+
+    def __reduce__(
+        self,
+    ) -> tuple[type[OptimizedModule], tuple[torch.nn.Module, _TorchDynamoContext]]:
         return (self.__class__, (self._orig_mod, self.dynamo_ctx))
 
-    def __getstate__(self):
+    def __getstate__(self) -> dict[str, Any]:
         state = dict(self.__dict__)
         state.pop("forward", None)
         state.pop("__call__", None)
         return state
 
-    def __setstate__(self, state):
+    def __setstate__(self, state: dict[str, Any]) -> None:
         self.__dict__ = state
         self._initialize()
 
     @property
-    def training(self):
+    def training(self) -> bool:
         return self._orig_mod.training
 
     @training.setter
-    def training(self, value):
-        try:
-            super().__getattr__("_orig_mod")
+    def training(self, value: bool) -> None:
+        # Ignore the `training` mutation in `super().__init__()`, since that's
+        # setting the default on `nn.Module`, but we are mirroring the
+        # `training` attr in `self._orig_mod`.
+        if self._super_module_initialized:
             self._orig_mod.training = value
-        except AttributeError:
-            # still initializing
-            pass
 
-    def __getattr__(self, name):
+    def __getattr__(self, name: str) -> Any:
         if name == "_orig_mod":
             return self._modules["_orig_mod"]
         return getattr(self._orig_mod, name)
 
-    def __setattr__(self, name, val) -> None:
+    def __setattr__(self, name: str, val: Any) -> None:
         # Allow patching over class attributes
         if hasattr(type(self), name):
             return super().__setattr__(name, val)
@@ -228,8 +452,21 @@ class OptimizedModule(torch.nn.Module):
             return super().__setattr__(name, val)
         return setattr(self._orig_mod, name, val)
 
-    def _call_lazy_check(self, *args, **kwargs):
-        if hasattr(self._orig_mod, "_initialize_hook"):
+    def __delattr__(self, name: str) -> None:
+        # This mirrors `__setattr__`
+        if hasattr(type(self), name):
+            return super().__delattr__(name)
+
+        if name in OptimizedModule._opt_mod_attributes:
+            return super().__delattr__(name)
+        return delattr(self._orig_mod, name)
+
+    def _call_lazy_check(self, *args: Any, **kwargs: Any) -> Any:
+        if (
+            hasattr(self._orig_mod, "_initialize_hook")
+            and hasattr(self._orig_mod, "_infer_parameters")
+            and callable(self._orig_mod._infer_parameters)
+        ):
             # In the case of a lazy module, we want to run
             # the pre-hooks which initialize it.
             # Afterwards, lazy module deletes its pre-hooks
@@ -237,14 +474,14 @@ class OptimizedModule(torch.nn.Module):
             self._orig_mod._infer_parameters(self._orig_mod, args, kwargs)
         return self._forward(*args, **kwargs)
 
-    def __dir__(self):
+    def __dir__(self) -> list[str]:
         orig_mod_attrs = self._orig_mod.__dir__()
         return orig_mod_attrs + [
             attr for attr in super().__dir__() if attr not in orig_mod_attrs
         ]
 
 
-def remove_from_cache(f):
+def remove_from_cache(f: Any) -> None:
     """
     Make sure f.__code__ is not cached to force a recompile
     """
@@ -261,28 +498,32 @@ def remove_from_cache(f):
         log.warning("could not determine __code__ for %s", f)
 
 
-def nothing():
+def nothing() -> None:
     pass
 
 
-def always_false():
+def always_false() -> bool:
     return False
 
 
-def innermost_fn(fn):
+def innermost_fn(
+    fn: Callable[..., Any], unaltered_fn_attr: str = "_torchdynamo_orig_callable"
+) -> Callable[..., Any]:
     """
     In case of nesting of _TorchDynamoContext calls, find the innermost
     function. TorchDynamo caches on fn.__code__ object, so its necessary to find
     the innermost function to pass on the optimize, run, disable etc.
     """
     unaltered_fn = fn
-    while hasattr(unaltered_fn, "_torchdynamo_orig_callable"):
-        unaltered_fn = unaltered_fn._torchdynamo_orig_callable
-        assert callable(unaltered_fn)
+    while hasattr(unaltered_fn, unaltered_fn_attr):
+        unaltered_fn = getattr(unaltered_fn, unaltered_fn_attr)
+        assert callable(
+            unaltered_fn
+        ), f"A callable function is expected, but {type(unaltered_fn)} is provided."
     return unaltered_fn
 
 
-def make_set_enable_dynamic(enable: bool):
+def make_set_enable_dynamic(enable: bool) -> Any:
     assert isinstance(enable, bool)
     if enable:
         # Assume everything is dynamic by default
@@ -293,18 +534,75 @@ def make_set_enable_dynamic(enable: bool):
         )
 
 
+# A thread local storage that serves to store information as Dynamo traces
+# through a user provided function.
+class DynamoTLS(threading.local):
+    # Each string is a summary of a frame Dynamo attempted to trace, stored in
+    # temporal order.
+    traced_frame_infos: list[str] = []
+
+
+dynamo_tls = DynamoTLS()
+
+
+def clear_dynamo_tls() -> None:
+    dynamo_tls.traced_frame_infos.clear()
+
+
+@atexit.register
+def _log_traced_frames() -> None:
+    """
+    At program exit, log all of the frames Dynamo has attempted to trace from,
+    excluding the continuation frames generated by Dynamo.
+    """
+    msg = "\n".join(dynamo_tls.traced_frame_infos)
+    msg = textwrap.indent(msg, "  * ")
+    msg = f"TorchDynamo attempted to trace the following frames: [\n{msg}\n]"
+    log.info(msg)
+
+
+def guard_collectives_hook(guard_eval_result: bool) -> bool:
+    import torch.distributed as dist
+    from torch._dynamo.utils import dynamo_timed
+
+    # guard_eval_result == True  ==>  cache hit
+    if pg := distributed.get_guard_pg():
+        with dynamo_timed(
+            "guard_collective", log_pt2_compile_event=False, log_waitcounter=True
+        ):
+            log.debug("guard_collective %s", guard_eval_result)
+            # TODO: a bit awkward to time, this isn't inside of the dynamo compile region
+            all_results = [None] * pg.size()
+            dist.all_gather_object(all_results, guard_eval_result, group=pg)
+            # True = everyone hit, OK to run
+            # False = someone missed, force recompile everywhere
+            res = all(all_results)
+            log.debug("guard_collective %s -> %s", guard_eval_result, res)
+            return res
+    return guard_eval_result
+
+
+_not_set = object()
+
+
 class _TorchDynamoContext:
     def __init__(
         self,
         callback: DynamoCallback,
-        on_enter=nothing,
-        backend_ctx_ctor=null_context,
-        patch_fn=nothing,
-        first_ctx=False,
+        on_enter: Callable[[], Any] = nothing,
+        backend_ctx_ctor: Callable[
+            [], contextlib.AbstractContextManager[Any]
+        ] = null_context,
+        patch_fn: Callable[[], Any] = nothing,
+        first_ctx: bool = False,
         *,
-        export=False,
-        dynamic=None,
-        compiler_config=None,
+        fullgraph: bool = False,
+        error_on_graph_break: Optional[bool] = None,
+        export: bool = False,
+        dynamic: Optional[bool] = None,
+        compiler_config: Optional[Any] = None,
+        package: Optional[CompilePackage] = None,
+        hooks: Optional[Hooks] = None,
     ) -> None:
         super().__init__()
         assert callable(callback) or callback is False or callback is None
@@ -312,23 +610,27 @@ class _TorchDynamoContext:
         self._backend_ctx_ctor = backend_ctx_ctor
         self.prior: Union[Unset, DynamoCallback] = unset
         self.first_ctx = first_ctx
+        self.fullgraph = fullgraph
+        self.error_on_graph_break = error_on_graph_break
         self.export = export
         self._dynamic = dynamic
         self.compiler_config = compiler_config
-        self.cleanup_fns: List[Callable[[], Any]] = []
+        self.cleanup_fns: list[Callable[[], Any]] = []
         self.enter_exit_hooks = []
+        self._package = package
+        self._hooks = hooks
         patch_fn()
 
         # Save the backends so that we can reset them during torch._dynamo.reset
-        backend = innermost_fn(callback)
-        cached_backends.setdefault(id(backend), backend)
+        backend = innermost_fn(callback, unaltered_fn_attr="_torchdynamo_orig_backend")  # type: ignore[arg-type]
+        cached_backends.setdefault(id(backend), backend)  # type: ignore[arg-type]
 
         if dynamic is not None:
             self.enter_exit_hooks.append(make_set_enable_dynamic(dynamic))
 
         if on_enter is not nothing:
             # this case is not common
-            def call_on_enter():
+            def call_on_enter() -> Callable[[], None]:
                 on_enter()
                 return nothing
 
@@ -336,37 +638,90 @@ class _TorchDynamoContext:
 
         if backend_ctx_ctor is not contextlib.nullcontext:
             # this case is not common
-            def call_backend_ctx():
+            def call_backend_ctx() -> functools.partial[Optional[bool]]:
                 ctx = backend_ctx_ctor()
                 ctx.__enter__()
                 return functools.partial(ctx.__exit__, None, None, None)
 
             self.enter_exit_hooks.append(call_backend_ctx)
 
-    def __enter__(self):
+    def __enter__(self) -> None:
         if config.raise_on_ctx_manager_usage:
             raise RuntimeError(
                 "torch._dynamo.optimize(...) is used with a context manager. "
                 "Please refer to https://pytorch.org/tutorials/intermediate/torch_compile_tutorial.html "
                 "to use torch._dynamo.optimize(...) as an annotation/decorator. "
             )
+        self.prior = set_eval_frame(None)
         self.cleanup_fns = [enter() for enter in self.enter_exit_hooks]
-        self.prior = _maybe_set_eval_frame(self.callback)
+        self.prior_skip_guard_eval_unsafe = set_skip_guard_eval_unsafe(
+            _is_skip_guard_eval_unsafe_stance()
+        )
+        _maybe_set_eval_frame(_callback_from_stance(self.callback))
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
+    def __exit__(
+        self,
+        exc_type: Optional[type[BaseException]],
+        exc_val: Optional[BaseException],
+        exc_tb: Optional[types.TracebackType],
+    ) -> Optional[bool]:
         assert self.prior is not unset
-        _maybe_set_eval_frame(self.prior)
-        self.prior = unset
+        set_eval_frame(None)
+        set_skip_guard_eval_unsafe(self.prior_skip_guard_eval_unsafe)
         for cleanup in self.cleanup_fns:
             cleanup()
         self.cleanup_fns.clear()
+        _maybe_set_eval_frame(_callback_from_stance(self.prior))
+        self.prior = unset
+        return None
 
-    def __call__(self, fn):
+    def __call__(self, fn: Any) -> Any:
         # public api for compiler config/options
-        def get_compiler_config():
+        def get_compiler_config() -> Any:
             return self.compiler_config
 
+        from .package import DynamoCache
+
+        # If self._package is lazily initialized, we should check the dynamo cache now
+        if config.caching_precompile:
+            if self._package is not None and not self._package.is_initialized():
+                result = DynamoCache.load(fn)
+                if result is None:
+                    # Create a fresh CompilePackage
+                    self._package.initialize(fn, None, ignore_inlined_sources=False)
+                else:
+                    cache_entry, backends = result
+                    try:
+                        self._package.initialize(
+                            fn, cache_entry, ignore_inlined_sources=False
+                        )
+                        self._package.install(backends)
+                    except RuntimeError as e:
+                        log.warning("Failed to load entry from dynamo cache: %s", e)
+                        self._package.initialize(fn, None, ignore_inlined_sources=False)
+
         fn = innermost_fn(fn)
+
+        def aot_compile(example_inputs: tuple[tuple[Any, ...], dict[str, Any]]) -> Any:
+            from torch._dynamo.aot_compile import aot_compile_fullgraph
+
+            if not self.fullgraph:
+                raise RuntimeError(
+                    "Graph breaks are not supported with aot compile. Please use torch.compile(fullgraph=True)."
+                )
+
+            if not callable(self.callback):
+                raise RuntimeError("aot compile requires a callable dynamo callback.")
+
+            assert self._hooks is not None
+            return aot_compile_fullgraph(
+                fn,
+                example_inputs,
+                hooks=self._hooks,
+                backend=innermost_fn(
+                    self.callback, unaltered_fn_attr="_torchdynamo_orig_backend"
+                ),
+            )
 
         # add context containing GraphModule to any GraphModule forward functions
         if isinstance(fn, GraphModule):
@@ -400,13 +755,17 @@ class _TorchDynamoContext:
                 cls_obj._call_impl = self(cls_obj._call_impl)
             return cls_obj
 
-        assert callable(fn)
+        assert callable(
+            fn
+        ), f"A callable function is expected, but {type(fn)} is provided."
 
         try:
             filename = inspect.getsourcefile(fn)
         except TypeError:
             filename = None
-        if (
+        if config.debug_force_nested_calls:
+            fn = external_utils.wrap_inline(fn)
+        elif config.wrap_top_frame or (
             (filename is None or trace_rules.check(fn))
             and (
                 getattr(fn, "__name__", "")
@@ -417,73 +776,106 @@ class _TorchDynamoContext:
             # call to a builtin without a frame for us to capture
             fn = external_utils.wrap_inline(fn)
 
-        def do_nothing(*arg, **kwargs):
+        def do_nothing(*arg: Any, **kwargs: Any) -> None:
             pass
 
+        callback: Callable[..., Any] = do_nothing
         if hasattr(self, "callback"):
-            callback = self.callback
-        else:
-            callback = do_nothing
+            callback = self.callback  # type: ignore[assignment]
 
         is_jit_tracing = torch._C._is_tracing
-        is_fx_tracing = torch.fx._symbolic_trace.is_fx_tracing
+        is_fx_symbolic_tracing = torch.fx._symbolic_trace.is_fx_symbolic_tracing
 
         @functools.wraps(fn)
-        def _fn(*args, **kwargs):
-            if is_fx_tracing():
-                if config.error_on_nested_fx_trace:
-                    raise RuntimeError(
-                        "Detected that you are using FX to symbolically trace "
-                        "a dynamo-optimized function. This is not supported at the moment."
-                    )
-                else:
-                    return fn(*args, **kwargs)
+        def compile_wrapper(*args: Any, **kwargs: Any) -> Any:
+            prior = set_eval_frame(None)
+            try:
+                if is_fx_symbolic_tracing():
+                    if config.error_on_nested_fx_trace:
+                        raise RuntimeError(
+                            "Detected that you are using FX to symbolically trace "
+                            "a dynamo-optimized function. This is not supported at the moment."
+                        )
+                    else:
+                        return fn(*args, **kwargs)
 
-            if is_jit_tracing():
-                if config.error_on_nested_jit_trace:
+                if is_jit_tracing():
                     raise RuntimeError(
                         "Detected that you are using FX to torch.jit.trace "
                         "a dynamo-optimized function. This is not supported at the moment."
                     )
-                else:
-                    return fn(*args, **kwargs)
 
-            cleanups = [enter() for enter in self.enter_exit_hooks]
-            prior = _maybe_set_eval_frame(callback)
+                cleanups = [enter() for enter in self.enter_exit_hooks]
+                prior_skip_guard_eval_unsafe = set_skip_guard_eval_unsafe(
+                    _is_skip_guard_eval_unsafe_stance()
+                )
+                prior_error_on_graph_break = None
+                if not self.fullgraph and self.error_on_graph_break is not None:
+                    prior_error_on_graph_break = _get_error_on_graph_break()
+                    _set_error_on_graph_break(self.error_on_graph_break)
 
-            # Ensure that if an assertion occurs after graph pushes
-            # something onto the DynamicLayerStack then we pop it off (the
-            # constructed graph code isn't guarded with try/finally).
-            #
-            # This used to be a context but putting a `with` here is a noticible
-            # perf regression (#126293)
-            saved_dynamic_layer_stack_depth = (
-                torch._C._functorch.get_dynamic_layer_stack_depth()
-            )
-
-            try:
-                return fn(*args, **kwargs)
-            finally:
-                # Restore the dynamic layer stack depth if necessary.
-                torch._C._functorch.pop_dynamic_layer_stack_and_undo_to_depth(
-                    saved_dynamic_layer_stack_depth
+                # Ensure that if an assertion occurs after graph pushes
+                # something onto the DynamicLayerStack then we pop it off (the
+                # constructed graph code isn't guarded with try/finally).
+                #
+                # This used to be a context but putting a `with` here is a noticeable
+                # perf regression (#126293)
+                saved_dynamic_layer_stack_depth = (
+                    torch._C._functorch.get_dynamic_layer_stack_depth()
                 )
 
+                _maybe_set_eval_frame(_callback_from_stance(callback))
+
+                try:
+                    return fn(*args, **kwargs)
+                except Unsupported as e:
+                    if config.verbose:
+                        raise
+                    # strip internal tracebacks from causes
+                    cur_exn: BaseException = e
+                    while cur_exn.__cause__ is not None:
+                        cur_exn.__cause__.with_traceback(None)
+                        cur_exn = cur_exn.__cause__
+                    raise e.with_traceback(None) from e.__cause__  # User compiler error
+                except ShortenTraceback as e:
+                    # Failures in the backend likely don't have useful
+                    # data in the TorchDynamo frames, so we strip them out.
+                    raise e.remove_dynamo_frames() from None  # see TORCHDYNAMO_VERBOSE=1
+                finally:
+                    # Restore the dynamic layer stack depth if necessary.
+                    set_eval_frame(None)
+                    if prior_error_on_graph_break is not None:
+                        _set_error_on_graph_break(prior_error_on_graph_break)
+                    torch._C._functorch.pop_dynamic_layer_stack_and_undo_to_depth(
+                        saved_dynamic_layer_stack_depth
+                    )
+
+                    set_skip_guard_eval_unsafe(prior_skip_guard_eval_unsafe)
+                    for cleanup in cleanups:
+                        cleanup()
+            finally:
                 _maybe_set_eval_frame(prior)
-                for cleanup in cleanups:
-                    cleanup()
 
         # hooks to properly handle inlining
-        _fn._torchdynamo_inline = fn  # type: ignore[attr-defined]
+        if self.error_on_graph_break is not None:
+            compile_wrapper._torchdynamo_inline = (  # type: ignore[attr-defined]
+                external_utils.wrap_inline_with_error_on_graph_break(
+                    fn, self.error_on_graph_break
+                )
+            )
+        else:
+            compile_wrapper._torchdynamo_inline = fn  # type: ignore[attr-defined]
 
         # Save the function pointer to find the original callable while nesting
         # of decorators.
-        _fn._torchdynamo_orig_callable = fn  # type: ignore[attr-defined]
+        compile_wrapper._torchdynamo_orig_callable = fn  # type: ignore[attr-defined]
 
         # when compiling user function instead of nn.Module
         # provide public api _fn.get_compiler_config()
-        assert not hasattr(_fn, "get_compiler_config")
-        _fn.get_compiler_config = get_compiler_config  # type: ignore[attr-defined]
+        assert not hasattr(compile_wrapper, "get_compiler_config")
+        compile_wrapper.get_compiler_config = get_compiler_config  # type: ignore[attr-defined]
+        if torch._dynamo.config.enable_aot_compile:
+            compile_wrapper.aot_compile = aot_compile  # type: ignore[attr-defined]
 
         # If the function is called using torch._dynamo.optimize decorator, we
         # should prevent any type of skipping.
@@ -520,24 +912,28 @@ class _TorchDynamoContext:
                         """))
             always_optimize_code_objects[fn.__code__] = True
 
-        return _fn
+        return compile_wrapper
 
 
 class OptimizeContext(_TorchDynamoContext):
     def __init__(
         self,
-        callback,
-        backend_ctx_ctor,
-        first_ctx=False,
+        callback: DynamoCallback,
+        backend_ctx_ctor: Callable[[], contextlib.AbstractContextManager[Any]],
+        first_ctx: bool = False,
         *,
-        export=False,
-        dynamic=None,
-        compiler_config=None,
+        fullgraph: bool = False,
+        error_on_graph_break: Optional[bool] = None,
+        export: bool = False,
+        dynamic: Optional[bool] = None,
+        compiler_config: Optional[Any] = None,
         rebuild_ctx: Optional[
             Callable[[], Union[OptimizeContext, _NullDecorator]]
         ] = None,
+        package: Optional[CompilePackage] = None,
+        hooks: Optional[Hooks] = None,
     ) -> None:
-        def on_enter():
+        def on_enter() -> None:
             install_generation_tagging_init()
 
         super().__init__(
@@ -546,23 +942,34 @@ class OptimizeContext(_TorchDynamoContext):
             backend_ctx_ctor=backend_ctx_ctor,
             patch_fn=TorchPatcher.patch,
             first_ctx=first_ctx,
+            fullgraph=fullgraph,
+            error_on_graph_break=error_on_graph_break,
             export=export,
             dynamic=dynamic,
             compiler_config=compiler_config,
+            package=package,
+            hooks=hooks,
         )
 
         if config.compiled_autograd:
+            _dynamic = self._dynamic
+            if _dynamic is None:
+                _dynamic = not torch._dynamo.config.assume_static_by_default
 
-            def call_compiled_autograd():
+            def call_compiled_autograd() -> functools.partial[Optional[bool]]:
                 assert rebuild_ctx is not None
                 compiler_fn = rebuild_ctx()
-                ctx = torch._dynamo.compiled_autograd.enable(compiler_fn)
+                ctx = torch._dynamo.compiled_autograd._enable(
+                    compiler_fn, dynamic=_dynamic, ignore_active_disable_ctx=False
+                )
                 ctx.__enter__()
                 return functools.partial(ctx.__exit__, None, None, None)
 
             self.enter_exit_hooks.append(call_compiled_autograd)
 
-    def __reduce__(self):
+    def __reduce__(
+        self,
+    ) -> tuple[type[OptimizeContext], tuple[Any, ...], dict[str, Any]]:
         return (
             self.__class__,
             (self.callback, self._backend_ctx_ctor, self.first_ctx),
@@ -577,20 +984,22 @@ class OptimizeContext(_TorchDynamoContext):
 class RunOnlyContext(_TorchDynamoContext):
     def __init__(self) -> None:
         # cudagraph trees relies on generation increment
-        def on_enter():
+        def on_enter() -> None:
             torch._dynamo.mutation_guard.GenerationTracker.generation += 1
 
         super().__init__(callback=False, on_enter=on_enter)
 
-    def __reduce__(self):
+    def __reduce__(self) -> tuple[type[RunOnlyContext], tuple[Any, ...]]:
         return (self.__class__, ())
 
 
 class DisableContext(_TorchDynamoContext):
-    def __init__(self) -> None:
+    def __init__(self, msg: Optional[str] = None, wrapping: bool = True) -> None:
         super().__init__(callback=None)
+        self.msg = msg
+        self.wrapping = wrapping
 
-    def __call__(self, fn):
+    def __call__(self, fn: Callable[..., Any]) -> Callable[..., Any]:
         # Earlier this code was in the base class _TorchDynamoContext. But we
         # moved it here to have better code organization. For disable, we just
         # want the callback to be None. We don't have to check trace_rules or
@@ -603,33 +1012,45 @@ class DisableContext(_TorchDynamoContext):
             new_mod._torchdynamo_orig_callable = mod.forward
             return new_mod
 
-        if inspect.isclass(fn):
+        if isinstance(fn, type):
             # User has wrapped the class with compile/disable decorator. Apply
             # disable to init/call method.
             cls_obj = fn
             # Disable on init is useful for reconstruction of bytecodes where we
             # want to prevent Dynamo from tracing into the init function. Check
             # test_reconstruction in test_model_output.py.
-            cls_obj.__init__ = self(cls_obj.__init__)
+            cls_obj.__init__ = self(cls_obj.__init__)  # type: ignore[misc]
             cls_obj.__call__ = self(cls_obj.__call__)
             if issubclass(cls_obj, torch.nn.Module):
                 # NN module variable tracker directly inlines the _call_impl. Disable it.
                 cls_obj._call_impl = self(cls_obj._call_impl)
             return cls_obj
 
-        assert callable(fn)
+        assert callable(
+            fn
+        ), f"A callable function is expected, but {type(fn)} is provided."
 
-        callback = self.callback
-
-        @functools.wraps(fn)
-        def _fn(*args, **kwargs):
-            prior = _maybe_set_eval_frame(callback)
+        def _fn(*args: Any, **kwargs: Any) -> Any:
+            prior = set_eval_frame(None)
             try:
-                return fn(*args, **kwargs)
+                _maybe_set_eval_frame(_callback_from_stance(self.callback))
+                try:
+                    return fn(*args, **kwargs)
+                finally:
+                    set_eval_frame(None)
             finally:
                 _maybe_set_eval_frame(prior)
 
+        # Under some circumstances (e.g. precompile) we can end up calling @disable
+        # decorator in generated bytecode and trigger recompile. This is due to the
+        # fact that the old callback from torch.compile() is still active and under
+        # this circumstance we will trigger a failure with set_stance("fail_on_recompile").
+        # Therefore we want to skip calling into any frame in this case.
+        if self.wrapping:
+            _fn = functools.wraps(fn)(_fn)
+
         _fn._torchdynamo_disable = True  # type: ignore[attr-defined]
+        _fn._torchdynamo_disable_msg = self.msg  # type: ignore[attr-defined]
 
         # Save the function pointer to find the original callable while nesting
         # of decorators.
@@ -637,55 +1058,164 @@ class DisableContext(_TorchDynamoContext):
 
         return _fn
 
-    def __reduce__(self):
+    def __reduce__(self) -> tuple[type[DisableContext], tuple[Any, ...]]:
         return (self.__class__, ())
 
 
 def _optimize_catch_errors(
-    compile_fn,
+    compile_fn: convert_frame.ConvertFrameProtocol,
     hooks: Hooks,
-    backend_ctx_ctor=null_context,
-    export=False,
-    dynamic=None,
-    compiler_config=None,
-    rebuild_ctx=None,
-):
+    backend_ctx_ctor: Callable[
+        [], contextlib.AbstractContextManager[Any]
+    ] = null_context,
+    fullgraph: bool = False,
+    error_on_graph_break: Optional[bool] = None,
+    export: bool = False,
+    dynamic: Optional[bool] = None,
+    compiler_config: Optional[Any] = None,
+    rebuild_ctx: Optional[Callable[[], Union[OptimizeContext, _NullDecorator]]] = None,
+    package: Optional[CompilePackage] = None,
+) -> OptimizeContext:
     return OptimizeContext(
         convert_frame.catch_errors_wrapper(compile_fn, hooks),
         backend_ctx_ctor=backend_ctx_ctor,
         first_ctx=True,
+        fullgraph=fullgraph,
+        error_on_graph_break=error_on_graph_break,
         export=export,
         dynamic=dynamic,
         compiler_config=compiler_config,
         rebuild_ctx=rebuild_ctx,
+        package=package,
+        hooks=hooks,
     )
 
 
-def get_compiler_fn(compiler_fn):
+def get_compiler_fn(
+    compiler_fn: Union[str, Callable[..., Any], None],
+) -> WrapBackendDebug:
     from .repro.after_dynamo import wrap_backend_debug
 
-    if hasattr(compiler_fn, "compiler_name"):
-        compiler_str = compiler_fn.compiler_name
+    if compiler_fn is None:
+        # Special case None to avoid crashing in hasattr
+        compiler_str = None
+    elif hasattr(compiler_fn, "compiler_name"):
+        compiler_str = compiler_fn.compiler_name  # type: ignore[union-attr]
+        assert isinstance(compiler_str, str)
     elif isinstance(compiler_fn, str):
         compiler_str = compiler_fn
     else:
         compiler_str = None
-    compiler_fn = lookup_backend(compiler_fn)
+    compiler_fn = lookup_backend(compiler_fn)  # type: ignore[arg-type]
     return wrap_backend_debug(compiler_fn, compiler_str)
 
 
 class _NullDecorator(contextlib.nullcontext):  # type: ignore[type-arg]
-    def __call__(self, fn):
-        assert callable(fn)
+    def __call__(self, fn: Callable[..., Any]) -> Callable[..., Any]:
+        assert callable(
+            fn
+        ), f"A callable function is expected, but {type(fn)} is provided."
         return fn
 
 
-def check_if_dynamo_supported():
-    if sys.version_info >= (3, 13):
-        raise RuntimeError("Python 3.13+ not yet supported for torch.compile")
+# Make dynamo graph to have same input/output spec as user code
+def argument_names(
+    f_sig: inspect.Signature, args: list[Any], kwargs: dict[str, Any]
+) -> list[str]:
+    def signature_to_fullargspec(sig: inspect.Signature) -> inspect.FullArgSpec:
+        # Get a list of Parameter objects from the Signature object
+        params = list(sig.parameters.values())
+        # Separate positional arguments, keyword-only arguments and varargs/varkw
+        args = [
+            p.name for p in params if p.kind == inspect.Parameter.POSITIONAL_OR_KEYWORD
+        ]
+        kwonlyargs = [
+            p.name for p in params if p.kind == inspect.Parameter.KEYWORD_ONLY
+        ]
+        varargs = next(
+            (p.name for p in params if p.kind == inspect.Parameter.VAR_POSITIONAL),
+            None,
+        )
+        varkw = next(
+            (p.name for p in params if p.kind == inspect.Parameter.VAR_KEYWORD),
+            None,
+        )
+        # Get default values for positional arguments and keyword-only arguments
+        defaults = tuple(
+            p.default
+            for p in params
+            if p.kind == inspect.Parameter.POSITIONAL_OR_KEYWORD
+            and p.default is not inspect.Parameter.empty
+        )
+        kwonlydefaults = {
+            p.name: p.default
+            for p in params
+            if p.kind == inspect.Parameter.KEYWORD_ONLY
+            and p.default is not inspect.Parameter.empty
+        }
+        # Get annotations for parameters and return value
+        annotations = {}
+        if sig.return_annotation:
+            annotations = {"return": sig.return_annotation}
+        for parameter in params:
+            annotations[parameter.name] = parameter.annotation
+        # Return a FullArgSpec object with the extracted attributes
+        return inspect.FullArgSpec(
+            args, varargs, varkw, defaults, kwonlyargs, kwonlydefaults, annotations
+        )
+
+    fullargspec = signature_to_fullargspec(f_sig)
+
+    # 1. Map `args` 1-to-1 to positional arguments in original signature.
+    input_strs = fullargspec.args[: len(args)]
+
+    if len(args) > len(fullargspec.args):
+        # 2. If there are more arguments left in `args`, they map to varargs in original
+        # signature. Assign names as {varargs}_0, {varargs}_1, ...
+        assert fullargspec.varargs is not None, "More arguments than expected"
+        input_strs += [
+            f"{fullargspec.varargs}_{i}" for i in range(0, len(args) - len(input_strs))
+        ]
+    elif len(args) < len(fullargspec.args):
+        # 3. If there are fewer arguments in `args` than `fullargspec.args`,
+        # it implies these are arguments either with default values, or provided in
+        # `kwargs`. The former can be safely ignored. Because Dynamo.export does not
+        # export them as part of the function signature. The latter will be handled
+        # in the next step.
+        for unprovided_arg in fullargspec.args[
+            len(args) : -len(fullargspec.defaults or [])
+        ]:
+            assert unprovided_arg in kwargs, f"Missing argument {unprovided_arg}"
+
+    # 4. Keyword arguments provided in `kwargs`.
+    input_strs += list(kwargs.keys())
+
+    # 5. Keyword-only arguments with default values if not provided are not exported
+    # as part of the function signature.
+    for kwonly_arg in fullargspec.kwonlyargs:
+        kwonlydefaults = fullargspec.kwonlydefaults or {}
+        assert (
+            kwonly_arg in kwargs or kwonly_arg in kwonlydefaults
+        ), f"Missing keyword only argument {kwonly_arg}"
+
+    return input_strs
 
 
-def is_dynamo_supported():
+def check_if_dynamo_supported() -> None:
+    if sys.version_info >= (3, 14):
+        raise RuntimeError("Python 3.14+ not yet supported for torch.compile")
+    elif sysconfig.get_config_var("Py_GIL_DISABLED") == 1 and sys.version_info < (
+        3,
+        13,
+        3,
+    ):
+        raise RuntimeError(
+            "torch.compile is not supported on Python < 3.13.3 built with GIL disabled. "
+            "Please use Python 3.13.3+."
+        )
+
+
+def is_dynamo_supported() -> bool:
     try:
         check_if_dynamo_supported()
         return True
@@ -693,11 +1223,11 @@ def is_dynamo_supported():
         return False
 
 
-def check_if_inductor_supported():
+def check_if_inductor_supported() -> None:
     check_if_dynamo_supported()
 
 
-def is_inductor_supported():
+def is_inductor_supported() -> bool:
     try:
         check_if_inductor_supported()
         return True
@@ -705,8 +1235,23 @@ def is_inductor_supported():
         return False
 
 
-def optimize(*args, **kwargs):
-    def rebuild_ctx():
+def check_for_incompatible_configs() -> None:
+    # Some of the configs should be mutually exclusive
+    assert not (
+        config.suppress_errors and config.fail_on_recompile_limit_hit
+    ), "Dynamo configs suppress_error and fail_on_recompile_limit_hit can not both be active at the same time."
+
+
+def optimize(*args: Any, **kwargs: Any) -> Union[OptimizeContext, _NullDecorator]:
+    def rebuild_ctx() -> Union[OptimizeContext, _NullDecorator]:
+        ca_kwargs_override = config.compiled_autograd_kwargs_override
+        if ca_kwargs_override:
+            # NOTE: The process of translating other `torch.compile` kwargs to `torch._dynamo.optimize` kwargs
+            # is more complicated, we will add it in the future when needed.
+            assert set(ca_kwargs_override.keys()) == {
+                "fullgraph"
+            }, f"Only `fullgraph` kwarg override is supported for now, but got {ca_kwargs_override.keys()}"
+            kwargs["nopython"] = ca_kwargs_override["fullgraph"]
         return optimize(*args, **kwargs)
 
     return _optimize(rebuild_ctx, *args, **kwargs)
@@ -714,13 +1259,16 @@ def optimize(*args, **kwargs):
 
 def _optimize(
     rebuild_ctx: Callable[[], Union[OptimizeContext, _NullDecorator]],
-    backend="inductor",
+    backend: Union[str, Callable[..., Any]] = "inductor",
     *,
-    nopython=False,
-    guard_export_fn=None,
-    guard_fail_fn=None,
-    disable=False,
-    dynamic=None,
+    nopython: bool = False,
+    error_on_graph_break: Optional[bool] = None,
+    guard_export_fn: Optional[Callable[[_guards.GuardsSet], None]] = None,
+    guard_fail_fn: Optional[Callable[[GuardFail], None]] = None,
+    guard_filter_fn: Optional[Callable[[list[GuardFilterEntry]], list[bool]]] = None,
+    disable: bool = False,
+    dynamic: Optional[bool] = None,
+    package: Optional[CompilePackage] = None,
 ) -> Union[OptimizeContext, _NullDecorator]:
     """
     The main entrypoint of TorchDynamo.  Do graph capture and call
@@ -737,6 +1285,11 @@ def _optimize(
             - Or, a string backend name in `torch._dynamo.list_backends()`
         nopython: If True, graph breaks will be errors and there will
             be a single whole-program graph.
+        error_on_graph_break: If not None, the current `error_on_graph_break` setting is set to the given value.
+            See `torch._dynamo.error_on_graph_break()` for more details on what `error_on_graph_break` means.
+
+            Unlike `nopython=True` (i.e. `fullgraph=True`), there is no guarantee of a single whole-program graph.
+            If `nopython` is True, `error_on_graph_break` does nothing.
         disable: If True, turn this decorator into a no-op
         dynamic: If True, upfront compile as dynamic a kernel as possible.  If False,
             disable all dynamic shapes support (always specialize).  If None, automatically
@@ -745,16 +1298,20 @@ def _optimize(
     Example Usage::
 
         @torch._dynamo.optimize()
-        def toy_example(a, b):
-            ...
+        def toy_example(a, b): ...
     """
     check_if_dynamo_supported()
+    check_for_incompatible_configs()
     # Note: The hooks object could be global instead of passed around, *however* that would make
     # for a confusing API usage and plumbing story wherein we nest multiple .optimize calls.
     # There is some prior art around this, w/r/t nesting backend calls are enforced to be the same
     # compiler, however, this feels onerous for callback and hooks, and it feels better to give our users an
     # easier to understand UX at the cost of a little more plumbing on our end.
-    hooks = Hooks(guard_export_fn=guard_export_fn, guard_fail_fn=guard_fail_fn)
+    hooks = Hooks(
+        guard_export_fn=guard_export_fn,
+        guard_fail_fn=guard_fail_fn,
+        guard_filter_fn=guard_filter_fn,
+    )
     torch._C._log_api_usage_once("torch._dynamo.optimize")
     if (
         disable
@@ -763,25 +1320,42 @@ def _optimize(
     ):
         return _NullDecorator()
 
-    backend = get_compiler_fn(backend)
-
-    # Find if backend has any extra context manager
-    backend_ctx_ctor = getattr(backend, "backend_ctx_ctor", null_context)
-
-    if nopython:
+    if nopython and not config.debug_force_graph_break_on_leaf_return:
         return optimize_assert(
             backend,
             dynamic=dynamic,
             hooks=hooks,
             rebuild_ctx=rebuild_ctx,
+            package=package,
         )
+
+    backend = get_compiler_fn(backend)
+
+    # Find if backend has any extra context manager
+    backend_ctx_ctor = getattr(backend, "backend_ctx_ctor", null_context)
+
     # The backend function is stashed in the callable returned by
-    # _optimize_catch_errors in the field _torchdynamo_orig_callable. This can
+    # _optimize_catch_errors in the field _torchdynamo_orig_backend. This can
     # be used by eval_frame.c to insert a guard on the backend.
+
+    # With CachingPrecompile, instantiate an uninitialized CompilePackage
+    # which gets initialized by _optimize_catch_errors.__call__ once we have a function
+    if config.caching_precompile and package is None:
+        from .package import CompilePackage
+
+        package = CompilePackage(fn=None, dynamo=None, ignore_inlined_sources=False)
+
     return _optimize_catch_errors(
-        convert_frame.convert_frame(backend, hooks=hooks),
+        convert_frame.convert_frame(
+            backend,
+            hooks,
+            package=package,
+        ),
         hooks,
         backend_ctx_ctor,
+        fullgraph=False,
+        error_on_graph_break=error_on_graph_break
+        and not config.debug_force_graph_break_on_leaf_return,
         dynamic=dynamic,
         compiler_config=(
             backend.get_compiler_config()
@@ -789,27 +1363,30 @@ def _optimize(
             else None
         ),
         rebuild_ctx=rebuild_ctx,
+        package=package,
     )
 
 
 # TODO(voz): Consider making "explain" output alongside a run / part of a run
 @patch("torch._dynamo.symbolic_convert.explain", True)
-def explain(f, *extra_args, **extra_kwargs):
-    def inner(*args, **kwargs):
+def explain(f: Callable[..., Any], *extra_args: Any, **extra_kwargs: Any) -> Any:
+    from .backends.debugging import ExplainOutput
+
+    def inner(*args: Any, **kwargs: Any) -> ExplainOutput:
         # TODO(voz): Do we want a decorator for this?
         from . import reset  # type: ignore[attr-defined]
 
         reset()
 
-        graphs: List[torch.fx.GraphModule] = []
-        break_reasons: List[Any] = []
+        graphs: list[torch.fx.GraphModule] = []
+        break_reasons: list[Any] = []
         op_count: int = 0
-        ops_per_graph: List[torch.fx.Node] = []
-        out_guards: List[_guards.Guard] = []
+        ops_per_graph: list[list[Target]] = []
+        out_guards: list[_guards.Guard] = []
 
         def dynamo_graph_accumulating_compiler(
-            gm: torch.fx.GraphModule, example_inputs
-        ):
+            gm: torch.fx.GraphModule, example_inputs: Any
+        ) -> Callable[..., Any]:
             from .backends.debugging import _explain_graph_detail
 
             nonlocal graphs
@@ -823,7 +1400,7 @@ def explain(f, *extra_args, **extra_kwargs):
 
             return gm.forward
 
-        def guard_export_print(guards):
+        def guard_export_print(guards: Iterable[_guards.Guard]) -> None:
             nonlocal out_guards
             out_guards.extend(guards)
 
@@ -841,7 +1418,6 @@ def explain(f, *extra_args, **extra_kwargs):
 
         # TODO(voz): Do we want a decorator for this?
         reset()
-        from .backends.debugging import ExplainOutput
 
         return ExplainOutput(
             graphs,
@@ -867,16 +1443,16 @@ def explain(f, *extra_args, **extra_kwargs):
         return inner
 
 
-class FlattenInputOutputSignature(torch.fx.interpreter.Transformer):
+class FlattenInputOutputSignature(torch.fx.Transformer):
     def __init__(
         self,
         m: torch.fx.GraphModule,
-        flat_args: Tuple[Any],
-        matched_input_elements_positions: List[int],
-        flat_results: List[Any],
-        matched_output_elements_positions: List[int],
-        example_fake_inputs: List[torch.Tensor],
-        flat_args_dynamic_dims: List[Set[int]],
+        flat_args: list[Any],
+        matched_input_elements_positions: list[int],
+        flat_results: Sequence[Any],
+        matched_output_elements_positions: list[int],
+        example_fake_inputs: list[torch.Tensor],
+        flat_args_dynamic_dims: list[set[int]],
         fake_mode: Optional[fake_tensor.FakeTensorMode] = None,
     ) -> None:
         super().__init__(m)
@@ -893,7 +1469,7 @@ class FlattenInputOutputSignature(torch.fx.interpreter.Transformer):
             if i in matched_input_elements_to_fake:
                 arg.node.meta["val"] = matched_input_elements_to_fake[i]
             else:
-                # Fill node.mata["val"] with faketensor from the input,
+                # Fill node.meta["val"] with faketensor from the input,
                 # if it's not found in matched_input_elements_positions
                 if fake_mode is not None and isinstance(flat_args[i], torch.Tensor):
                     # TODO(zhxchen17) Also preserve all the user constraints here.
@@ -911,12 +1487,19 @@ class FlattenInputOutputSignature(torch.fx.interpreter.Transformer):
                             constraint_sizes=[None] * len(flat_args[i].shape),
                         ),
                     )
+                elif isinstance(flat_args[i], _IntWrapper):
+                    arg.node.meta["val"] = flat_args[i].val
+                else:
+                    arg.node.meta["val"] = flat_args[i]
+
             self.new_args.append(arg)
         self.old_args_gen = (self.new_args[i] for i in matched_input_elements_positions)
         self.matched_output_elements_positions = matched_output_elements_positions
         self.flat_results = flat_results
 
-    def placeholder(self, target, args, kwargs):
+    def placeholder(
+        self, target: Target, args: tuple[Argument, ...], kwargs: dict[str, Any]
+    ) -> Any:
         arg = next(self.old_args_gen)
         if "val" in self.current_node.meta:
             arg.node.meta["val"] = self.current_node.meta["val"]
@@ -931,9 +1514,11 @@ class FlattenInputOutputSignature(torch.fx.interpreter.Transformer):
             ]
         return arg
 
-    def output(self, target, args, kwargs):
+    def output(
+        self, target: Target, args: tuple[Argument, ...], kwargs: dict[str, Any]
+    ) -> Any:
         dynamo_result_flat = args[0]
-        lookup = [*dynamo_result_flat, *self.new_args]
+        lookup = [*dynamo_result_flat, *self.new_args]  # type: ignore[misc]
         new_results_flat = []
         for i in range(len(self.flat_results)):
             if self.matched_output_elements_positions[i] is not None:
@@ -946,7 +1531,7 @@ class FlattenInputOutputSignature(torch.fx.interpreter.Transformer):
                 new_results_flat.append(const_val)
         return super().output(target, (new_results_flat,), {})
 
-    def run_node(self, n):
+    def run_node(self, n: Node) -> Any:
         self.current_node = n
         result_proxy = super().run_node(n)
         if "val" in self.current_node.meta:
@@ -966,12 +1551,14 @@ class FlattenInputOutputSignature(torch.fx.interpreter.Transformer):
             )
         return result_proxy
 
-    def transform(self):
+    def transform(self) -> torch.fx.GraphModule:
         result_gm = super().transform()
-        if "dynamo_flat_name_to_original_fqn" in self.module.meta:
-            result_gm.meta["dynamo_flat_name_to_original_fqn"] = self.module.meta[
-                "dynamo_flat_name_to_original_fqn"
+        if "dynamo_flat_name_to_original_fqn" in self.module.meta:  # type: ignore[operator]
+            result_gm.meta["dynamo_flat_name_to_original_fqn"] = self.module.meta[  # type: ignore[index]
+                "dynamo_flat_name_to_original_fqn"  # type: ignore[index]
             ]
+        if "dynamo_compile_id" in self.module.meta:  # type: ignore[operator]
+            result_gm.meta["dynamo_compile_id"] = self.module.meta["dynamo_compile_id"]  # type: ignore[index]
         return result_gm
 
 
@@ -982,12 +1569,18 @@ class ExportResult(NamedTuple):
     # destructuring so it is BC-breaking
 
 
-def check_signature_rewritable(graph):
+# NOTE: this function only supports graphs created by Dynamo's OutputGraph module
+def check_signature_rewritable(graph: torch.fx.GraphModule) -> None:
     input_errors = []
     for node in graph.graph.find_nodes(op="placeholder"):
+        # set in OutputGraph._call_user_compiler
         assert hasattr(node, "_dynamo_source")
-        source = node._dynamo_source
-        user_stacks = graph._source_to_user_stacks.get(source)
+        assert hasattr(graph, "_source_to_user_stacks")
+
+        # NOTE: We can safely ignore these type warnings if and only if
+        # the function is made from OutputGraph (checked in the assertions)
+        source = node._dynamo_source  # type: ignore[attr-defined]
+        user_stacks = graph._source_to_user_stacks.get(source)  # type: ignore[operator, union-attr]
         if user_stacks is None:
             continue
         assert len(user_stacks) > 0
@@ -1024,29 +1617,32 @@ def check_signature_rewritable(graph):
 
 
 def rewrite_signature(
-    f_sig,
-    graph,
-    fake_mode,
-    flat_args,
-    in_spec,
-    example_fake_inputs,
-    graph_captured_input,
-    graph_captured_output,
-    dynamo_traced_result,
-    flat_args_dynamic_dims,
-):
+    f_sig: inspect.Signature,
+    graph: torch.fx.GraphModule,
+    fake_mode: Optional[fake_tensor.FakeTensorMode],
+    flat_args: list[Any],
+    in_spec: pytree.TreeSpec,
+    example_fake_inputs: list[Any],
+    graph_captured_input: Iterable[Any],
+    graph_captured_output: Optional[Iterable[Any]],
+    dynamo_traced_result: Any,
+    flat_args_dynamic_dims: list[set[int]],
+) -> torch.fx.GraphModule:
     orig_args, orig_kwargs = pytree.tree_unflatten(flat_args, in_spec)
 
-    def check_user_input_output(flat_values, error_type):
+    def check_user_input_output(
+        flat_values: list[Any], error_type: UserErrorType
+    ) -> None:
         supported_types = [
             torch.Tensor,
             torch.SymInt,
             torch.SymFloat,
             torch.SymBool,
             torch._C.ScriptObject,
+            _IntWrapper,
         ] + list(common_constant_types)
 
-        def is_supported_type(val):
+        def is_supported_type(val: Any) -> bool:
             return isinstance(val, tuple(supported_types))
 
         value_type = "input" if error_type == UserErrorType.INVALID_INPUT else "output"
@@ -1072,7 +1668,7 @@ def rewrite_signature(
     flat_results_traced, out_spec_traced = pytree.tree_flatten(dynamo_traced_result)
     check_user_input_output(flat_results_traced, UserErrorType.INVALID_OUTPUT)
 
-    def check_optional_input_and_error(f_sig: inspect.Signature):
+    def check_optional_input_and_error(f_sig: inspect.Signature) -> None:
         # Check if function has optional input.
         for name, param in f_sig.parameters.items():
             if param.default is not inspect.Parameter.empty:
@@ -1088,8 +1684,10 @@ def rewrite_signature(
                     case_name="optional_input",
                 )
 
-    def produce_matching(debug_type, sources, candidates):
-        matched_elements_positions: List[Optional[int]] = []
+    def produce_matching(
+        debug_type: str, sources: Iterable[Any], candidates: Iterable[Any]
+    ) -> list[Optional[int]]:
+        matched_elements_positions: list[Optional[int]] = []
         dict_of_source_vals = {}
         for i, val in enumerate(sources):
             dict_of_source_vals[id(val)] = i
@@ -1121,96 +1719,13 @@ def rewrite_signature(
     new_graph = FlattenInputOutputSignature(
         graph,
         flat_args,
-        matched_input_elements_positions,
+        matched_input_elements_positions,  # type: ignore[arg-type]
         flat_results_traced,
-        matched_output_elements_positions,
+        matched_output_elements_positions,  # type: ignore[arg-type]
         example_fake_inputs,
         flat_args_dynamic_dims,
         fake_mode,
     ).transform()
-
-    # Make dynamo graph to have same input/output spec as user code
-    def argument_names(f_sig, args, kwargs) -> List[str]:
-        def signature_to_fullargspec(sig: inspect.Signature):
-            # Get a list of Parameter objects from the Signature object
-            params = list(sig.parameters.values())
-            # Separate positional arguments, keyword-only arguments and varargs/varkw
-            args = [
-                p.name
-                for p in params
-                if p.kind == inspect.Parameter.POSITIONAL_OR_KEYWORD
-            ]
-            kwonlyargs = [
-                p.name for p in params if p.kind == inspect.Parameter.KEYWORD_ONLY
-            ]
-            varargs = next(
-                (p.name for p in params if p.kind == inspect.Parameter.VAR_POSITIONAL),
-                None,
-            )
-            varkw = next(
-                (p.name for p in params if p.kind == inspect.Parameter.VAR_KEYWORD),
-                None,
-            )
-            # Get default values for positional arguments and keyword-only arguments
-            defaults = tuple(
-                p.default
-                for p in params
-                if p.kind == inspect.Parameter.POSITIONAL_OR_KEYWORD
-                and p.default is not inspect.Parameter.empty
-            )
-            kwonlydefaults = {
-                p.name: p.default
-                for p in params
-                if p.kind == inspect.Parameter.KEYWORD_ONLY
-                and p.default is not inspect.Parameter.empty
-            }
-            # Get annotations for parameters and return value
-            annotations = {}
-            if sig.return_annotation:
-                annotations = {"return": sig.return_annotation}
-            for parameter in params:
-                annotations[parameter.name] = parameter.annotation
-            # Return a FullArgSpec object with the extracted attributes
-            return inspect.FullArgSpec(
-                args, varargs, varkw, defaults, kwonlyargs, kwonlydefaults, annotations
-            )
-
-        fullargspec = signature_to_fullargspec(f_sig)
-
-        # 1. Map `args` 1-to-1 to positional arguments in original signature.
-        input_strs = fullargspec.args[: len(args)]
-
-        if len(args) > len(fullargspec.args):
-            # 2. If there are more arguments left in `args`, they map to varargs in original
-            # signature. Assign names as {varargs}_0, {varargs}_1, ...
-            assert fullargspec.varargs is not None, "More arguments than expected"
-            input_strs += [
-                f"{fullargspec.varargs}_{i}"
-                for i in range(0, len(args) - len(input_strs))
-            ]
-        elif len(args) < len(fullargspec.args):
-            # 3. If there are fewer arguments in `args` than `fullargspec.args`,
-            # it implies these are arguments either with default values, or provided in
-            # `kwargs`. The former can be safely ignored. Because Dynamo.export does not
-            # export them as part of the function signature. The latter will be handled
-            # in the next step.
-            for unprovided_arg in fullargspec.args[
-                len(args) : -len(fullargspec.defaults or [])
-            ]:
-                assert unprovided_arg in kwargs, f"Missing argument {unprovided_arg}"
-
-        # 4. Keyword arguments provided in `kwargs`.
-        input_strs += list(kwargs.keys())
-
-        # 5. Keyword-only arguments with default values if not provided are not exported
-        # as part of the function signature.
-        for kwonly_arg in fullargspec.kwonlyargs:
-            kwonlydefaults = fullargspec.kwonlydefaults or {}
-            assert (
-                kwonly_arg in kwargs or kwonly_arg in kwonlydefaults
-            ), f"Missing keyword only argument {kwonly_arg}"
-
-        return input_strs
 
     new_graph.graph._codegen = _PyTreeCodeGen(
         _PyTreeInfo(
@@ -1225,21 +1740,22 @@ def rewrite_signature(
 
 def export(
     f: Callable[..., Any],
-    *extra_args,
+    *extra_args: Any,
     aten_graph: bool = False,
     pre_dispatch: bool = False,
     decomposition_table: Optional[
-        Dict[torch._ops.OpOverload, Callable[..., Any]]
+        dict[torch._ops.OpOverload, Callable[..., Any]]
     ] = None,
     tracing_mode: str = "symbolic",
-    dynamic_shapes: Optional[Union[Dict[str, Any], Tuple[Any], List[Any]]] = None,
+    dynamic_shapes: Optional[Union[dict[str, Any], tuple[Any], list[Any]]] = None,
+    specialize_float: bool = True,
     assume_static_by_default: bool = False,
     same_signature: bool = True,
     disable_constraint_solver: bool = False,
     prefer_deferred_runtime_asserts_over_guards: bool = False,
-    allow_complex_guards_as_runtime_asserts: bool = False,
     _log_export_usage: bool = True,
-    **extra_kwargs,
+    constraints: Optional[list[Constraint]] = None,
+    **extra_kwargs: Any,
 ) -> Callable[..., ExportResult]:
     """
     Export an input function f to a format that can be executed outside of PyTorch using the FX graph.
@@ -1294,17 +1810,27 @@ def export(
 
     Note - this headerdoc was authored by ChatGPT, with slight modifications by the author.
     """
+    if config.debug_force_graph_break_on_leaf_return:
+        raise unittest.SkipTest("Cannot force graph break on export")
+
     if _log_export_usage:
         log_export_usage(event="export.private_api", flags={"_dynamo"})
 
     # Deal with "local variable referenced before assignment"
     _f = f
+    _specialize_float = specialize_float
     _assume_static_by_default = assume_static_by_default
+    _constraints = constraints
 
-    def inner(*args, **kwargs):
-        combined_args = _combine_args(_f, args, kwargs)
-        constraints = _process_dynamic_shapes(combined_args, dynamic_shapes)
+    def inner(*args: Any, **kwargs: Any) -> ExportResult:
+        if not _constraints:
+            combined_args = _combine_args(_f, args, kwargs)
+            constraints = _process_dynamic_shapes(combined_args, dynamic_shapes)
+        else:
+            constraints = _constraints
+
         f = _f
+        specialize_float = _specialize_float
         assume_static_by_default = _assume_static_by_default
         check_if_dynamo_supported()
         torch._C._log_api_usage_once("torch._dynamo.export")
@@ -1316,26 +1842,26 @@ def export(
             assert aten_graph, "pre_dispatch=True can only be used when aten_graph=True"
         f = innermost_fn(f)
         call_to_inspect = f.forward if isinstance(f, torch.nn.Module) else f
-        original_signature = inspect.signature(call_to_inspect)
+        original_signature = inspect.signature(call_to_inspect)  # type: ignore[arg-type]
         graph = None
         out_guards = None
         graph_captured_input = None
-        graph_captured_result: Optional[Tuple[torch.Tensor, ...]] = None
+        graph_captured_result: Optional[tuple[torch.Tensor, ...]] = None
         fake_mode = None
         result_traced = None
 
-        def guard_export_print(guards: _guards.GuardsSet):
+        def guard_export_print(guards: _guards.GuardsSet) -> None:
             nonlocal out_guards
             assert (
                 out_guards is None
             ), "whole graph export entails exactly one guard export"
             out_guards = guards
 
-        example_inputs = []
+        example_inputs: list[Any] = []
 
         def dynamo_normalization_capturing_compiler(
-            gm: torch.fx.GraphModule, inner_example_inputs
-        ):
+            gm: torch.fx.GraphModule, inner_example_inputs: list[Any]
+        ) -> Callable[..., Any]:
             nonlocal graph
             assert (
                 graph is None
@@ -1351,7 +1877,7 @@ def export(
             fake_mode = _guards.detect_fake_mode()
             example_inputs = inner_example_inputs
 
-            def result_capturing_wrapper(*graph_inputs):
+            def result_capturing_wrapper(*graph_inputs: Any) -> Any:
                 nonlocal graph_captured_result
                 nonlocal graph_captured_input
 
@@ -1373,12 +1899,15 @@ def export(
                 # NB: this is wrong if graph_captured_result has
                 # data-dependent output size!
                 ignore_fresh_unbacked = null_context()
+                assert ambient_fake_mode is not None
                 if shape_env := ambient_fake_mode.shape_env:
-                    ignore_fresh_unbacked = shape_env.ignore_fresh_unbacked_symbols()
+                    ignore_fresh_unbacked = shape_env.ignore_fresh_unbacked_symbols()  # type: ignore[assignment]
 
                 with (
-                    ambient_fake_mode
-                ), enable_python_dispatcher(), ignore_fresh_unbacked:
+                    ambient_fake_mode,
+                    enable_python_dispatcher(),
+                    ignore_fresh_unbacked,
+                ):
                     params_and_buffers = {
                         **named_parameters,
                         **named_buffers,
@@ -1390,11 +1919,43 @@ def export(
                             value, static_shapes=True
                         )
 
-                    fake_graph_inputs = pytree.tree_map(
-                        ambient_fake_mode.from_tensor, graph_inputs
+                    from torch._export.non_strict_utils import (
+                        KeyPath,
+                        key_path_to_source,
+                    )
+
+                    def fakify_with_ambient(
+                        path: KeyPath, t: Union[torch.Tensor, _IntWrapper, Any]
+                    ) -> Any:
+                        if isinstance(t, torch.Tensor):
+                            return ambient_fake_mode.from_tensor(t, static_shapes=True)
+                        elif isinstance(t, _IntWrapper):
+                            if (
+                                t.dynamism is not None
+                                and isinstance(t.dynamism, _DimHint)
+                                and t.dynamism.type
+                                in (
+                                    _DimHintType.DYNAMIC,
+                                    _DimHintType.AUTO,
+                                )
+                            ):  # type: ignore[union-attr]
+                                source = key_path_to_source(path)
+                                symint = ambient_fake_mode.shape_env.create_unspecified_symint_and_symbol(  # type: ignore[union-attr]
+                                    t.val, source, DimDynamic.DYNAMIC
+                                )
+                                return symint
+                            else:
+                                return t.val
+                        else:
+                            return t
+
+                    fake_graph_inputs = pytree.tree_map_with_path(
+                        fakify_with_ambient, graph_inputs
                     )
                     graph_captured_result = torch.func.functional_call(
-                        graph, fake_params_buffers, fake_graph_inputs
+                        graph,
+                        fake_params_buffers,  # type: ignore[arg-type]
+                        fake_graph_inputs,  # type: ignore[arg-type]
                     )
 
                 return graph_captured_result
@@ -1409,14 +1970,17 @@ def export(
         constraint_violation_error = None
         if tracing_mode != "symbolic":
             assume_static_by_default = True
-        with config.patch(
-            specialize_int=True,
-            assume_static_by_default=assume_static_by_default,
-            automatic_dynamic_shapes=False,
-            capture_dynamic_output_shape_ops=True,
-            capture_scalar_outputs=True,
-            prefer_deferred_runtime_asserts_over_guards=prefer_deferred_runtime_asserts_over_guards,
-            allow_complex_guards_as_runtime_asserts=allow_complex_guards_as_runtime_asserts,
+        with (
+            config.patch(
+                specialize_int=True,
+                specialize_float=specialize_float,
+                assume_static_by_default=assume_static_by_default,
+                automatic_dynamic_shapes=False,
+                capture_dynamic_output_shape_ops=True,
+                capture_scalar_outputs=True,
+                prefer_deferred_runtime_asserts_over_guards=prefer_deferred_runtime_asserts_over_guards,
+            ),
+            _compiling_state_context(),
         ):
             opt_f = optimize_assert(
                 dynamo_normalization_capturing_compiler,
@@ -1481,7 +2045,7 @@ def export(
                 same_signature
             ), "Failed to produce a graph during tracing as no tensor operations were found and same_signature is False."
             # If the module does not contain any tensor computation, we would create a graph with inputs and outputs.
-            # To be consitant with the graph traced by dynano, `graph` will have only tensor inputs as placeholders
+            # To be consistent with the graph traced by dynano, `graph` will have only tensor inputs as placeholders
             # and tensor outputs as output nodes. non-tensor inputs and outputs will be added when rewriting signature.
             # We will also construct the `example_inputs`, `graph_captured_input`, and `graph_captured_result` corresponding
             # to `graph`.
@@ -1512,7 +2076,6 @@ def export(
                 graph.print_readable(print_output=False, colored=True),
             )
         else:
-            assert hasattr(graph, "_source_to_user_stacks")
             assert out_guards is not None, "Failed to produce guards during tracing"
             assert fake_mode is not None
 
@@ -1527,11 +2090,14 @@ def export(
                 check_signature_rewritable(graph)
 
         # NB: This is mostly hitting the cache; Dynamo already converted these
-        example_fake_inputs = [fake_mode.from_tensor(t) for t in example_inputs]
+        example_fake_inputs = [
+            fake_mode.from_tensor(t) if isinstance(t, torch.Tensor) else t
+            for t in example_inputs
+        ]
 
         if aten_graph:
             # Running graph with interpreter is needed for propagating the stack_trace
-            def graph_with_interpreter(*args):
+            def graph_with_interpreter(*args: Any) -> Any:
                 with torch.fx.traceback.preserve_node_meta():
                     return torch.fx.Interpreter(graph).run(*args)  # type: ignore[arg-type]
 
@@ -1557,7 +2123,8 @@ def export(
             for node in graph.graph.find_nodes(op="get_attr"):
                 if isinstance(getattr(graph, node.target), torch.Tensor):  # type: ignore[arg-type]
                     node.meta["val"] = fake_mode.from_tensor(
-                        getattr(graph, node.target), static_shapes=True  # type: ignore[arg-type]
+                        getattr(graph, node.target),  # type: ignore[arg-type]
+                        static_shapes=True,
                     )
 
         if same_signature:
@@ -1567,6 +2134,7 @@ def export(
                     for c in (constraints or ())
                     if (
                         c.t_id == id(x)
+                        and not isinstance(c, _RelaxedConstraint)
                         and c.constraint_range.vr.lower != c.constraint_range.vr.upper
                     )
                 }
@@ -1579,12 +2147,12 @@ def export(
                 flat_args,
                 in_spec,
                 example_fake_inputs,
-                graph_captured_input,
+                graph_captured_input,  # type: ignore[arg-type]
                 graph_captured_result,
                 result_traced,  # type: ignore[possibly-undefined]
                 flat_args_dynamic_dims,
             )
-        return ExportResult(graph, out_guards)  # type: ignore[arg-type]
+        return ExportResult(graph, out_guards)
 
     if extra_args or extra_kwargs:
         warnings.warn(
@@ -1594,54 +2162,97 @@ def export(
             FutureWarning,
             stacklevel=2,
         )
-        return inner(*extra_args, **extra_kwargs)
+        return inner(*extra_args, **extra_kwargs)  # type: ignore[return-value]
     else:
         return inner
 
 
-def optimize_assert(
-    backend,
+def optimize_assert(*args: Any, **kwargs: Any) -> OptimizeContext:
+    if "rebuild_ctx" in kwargs and kwargs["rebuild_ctx"] is not None:
+        # called from optimize
+        rebuild_ctx = kwargs["rebuild_ctx"]
+        del kwargs["rebuild_ctx"]
+    else:
+
+        def rebuild_ctx() -> OptimizeContext:
+            return optimize_assert(*args, **kwargs)
+
+    return _optimize_assert(rebuild_ctx, *args, **kwargs)
+
+
+def _optimize_assert(
+    rebuild_ctx: Callable[[], OptimizeContext],
+    backend: Union[str, Callable[..., Any], None],
     *,
-    hooks=Hooks(None, None),
-    export=False,
-    export_constraints=None,
-    dynamic=None,
-    rebuild_ctx=None,
-):
+    hooks: Hooks = Hooks(None, None, None),
+    export: bool = False,
+    export_constraints: Optional[Any] = None,
+    dynamic: Optional[bool] = None,
+    package: Optional[CompilePackage] = None,
+) -> OptimizeContext:
     """
-    The same as `torch._dynamo.optimize(backend, nopython=True)`
+    Guarantees single-graph capture.
+    The same as `torch._dynamo.optimize(backend)` but ignores
+    symbolic_convert.error_on_graph_break setting.
+
+    Used for fullgraph=True and export, since we must always error on graph breaks and ignore
+    symbolic_convert.error_on_graph_break. Can also be used for testing.
     """
     backend = get_compiler_fn(backend)
 
     # Find if backend has any extra context manager
     backend_ctx_ctor = getattr(backend, "backend_ctx_ctor", null_context)
 
+    if config.caching_precompile and package is None:
+        # Create an uninitialized package that will be set/filled by
+        # _OptimizeContext.__call__
+        # We need to instantiate the object here because the same CompilePackage
+        # needs to be shared between convert_frame_assert
+        # and OptimizeContext.
+        from .package import CompilePackage
+
+        package = CompilePackage(fn=None, dynamo=None, ignore_inlined_sources=False)
+
     return _optimize_catch_errors(
         convert_frame.convert_frame_assert(
-            backend, export=export, export_constraints=export_constraints
+            backend,
+            export=export,
+            export_constraints=export_constraints,
+            package=package,
         ),
         hooks,
         backend_ctx_ctor,
+        fullgraph=True,
         export=export,
         dynamic=dynamic,
         rebuild_ctx=rebuild_ctx,
+        package=package,
     )
 
 
 class TorchPatcher:
     @staticmethod
-    @functools.lru_cache(None)
-    def patch():
+    @functools.cache
+    def patch() -> None:
         # A better way to disable the following would be decorate the source
         # functions with @torch._disable_dynamo. However, this causes issues
         # with torch.deploy internally.
         from .decorators import disable
 
-        torch.jit.trace = disable(torch.jit.trace)
-        torch.jit.trace_module = disable(torch.jit.trace_module)
-        torch.jit._get_trace_graph = disable(torch.jit._get_trace_graph)
+        torch.jit.trace = disable(
+            torch.jit.trace, reason="tracing into TorchScript not fully supported"
+        )
+        torch.jit.trace_module = disable(
+            torch.jit.trace_module,
+            reason="tracing into TorchScript not fully supported",
+        )
+        torch.jit._get_trace_graph = disable(
+            torch.jit._get_trace_graph,
+            reason="tracing into TorchScript not fully supported",
+        )
         torch.fx._symbolic_trace.Tracer.trace = disable(
-            torch.fx._symbolic_trace.Tracer.trace
+            torch.fx._symbolic_trace.Tracer.trace,
+            reason="tracing into FX not fully supported",
         )
         torch.distributions.Distribution.set_default_validate_args(False)
 
@@ -1680,11 +2291,15 @@ class TorchPatcher:
         for opt_mod in optimizer_modules:
             opt_name = opt_mod.__name__.split(".")[-1]
             fused_fn_name = f"_fused_{opt_name}"
-            # single_tensor_fn_name = f"_single_tensor_{opt_name}"
 
             if hasattr(opt_mod, fused_fn_name):
                 setattr(
-                    opt_mod, fused_fn_name, disable(getattr(opt_mod, fused_fn_name))
+                    opt_mod,
+                    fused_fn_name,
+                    disable(
+                        getattr(opt_mod, fused_fn_name),
+                        reason="don't trace into fused optimizer",
+                    ),
                 )
 
         optimizer_classes = [
@@ -1701,17 +2316,29 @@ class TorchPatcher:
 
         for opt in optimizer_classes:
             if opt in excluded_optimizer_classes:
-                opt.step = disable(opt.step)
+                opt.step = disable(
+                    opt.step, reason=f"optimizer {opt} step not supported"
+                )
 
             if hasattr(opt, "_init_group"):
-                opt._init_group = disable(opt._init_group)
+                opt._init_group = disable(
+                    opt._init_group, reason=f"optimizer {opt} _init_group not supported"
+                )
 
     @staticmethod
-    def suppress_torch_distributed_warnings(fn):
-        def inner_fn(*args, **kwargs):
-            warnings.filterwarnings(
-                "ignore", category=UserWarning, module="torch.distributed"
-            )
-            return fn(*args, **kwargs)
+    def suppress_torch_distributed_warnings(
+        fn: Callable[..., Any],
+    ) -> Callable[..., Any]:
+        def inner_fn(*args: Any, **kwargs: Any) -> Any:
+            with torch._logging.hide_warnings(
+                torch._logging._internal.user_warning_filter
+            ):
+                return fn(*args, **kwargs)
 
         return inner_fn
+
+
+def skip_code(code: types.CodeType) -> None:
+    set_code_exec_strategy(
+        code, FrameExecStrategy(FrameAction.SKIP, FrameAction.DEFAULT)
+    )

--- a/vllm_kunlun/quantization/compressed_tensors/compressed_tensors_moe.py
+++ b/vllm_kunlun/quantization/compressed_tensors/compressed_tensors_moe.py
@@ -20,6 +20,7 @@ from typing import Callable, Optional, Union
 
 import torch
 from compressed_tensors import CompressionFormat
+from compressed_tensors.quantization import QuantizationArgs, QuantizationStrategy
 from vllm.logger import init_logger
 from vllm.model_executor.layers.fused_moe import (
     FusedMoEMethodBase,
@@ -111,6 +112,49 @@ class KunlunCompressedTensorsMoEMethod(FusedMoEMethodBase):
 
 
 class KunlunCompressedTensorsW8A8Int8MoEMethod(CompressedTensorsW8A8Int8MoEMethod):
+    def __init__(
+        self,
+        weight_quant: QuantizationArgs,
+        input_quant: QuantizationArgs,
+        moe,
+        layer_name: Optional[str] = None,
+    ):
+        # Deliberately skip CompressedTensorsW8A8Int8MoEMethod.__init__: it ends
+        # with ``select_int8_moe_backend()``, whose only registered backend is
+        # TRITON (see vllm .../fused_moe/oracle/int8.py: Int8MoeBackend has a
+        # single member). Triton is unsupported on Kunlun XPU, so the oracle
+        # raises "No Int8 MoE backend supports the deployment configuration."
+        #
+        # This class does not need the oracle: ``is_monolithic`` is True and
+        # ``apply_monolithic`` / ``process_weights_after_loading`` below run the
+        # kunlun int8 MoE ops directly, so ``experts_cls`` / ``moe_kernel`` are
+        # never used. The validation the upstream __init__ performs is kept.
+        super(CompressedTensorsW8A8Int8MoEMethod, self).__init__(moe)
+        self.weight_quant = weight_quant
+        self.input_quant = input_quant
+
+        per_channel = (
+            self.weight_quant.strategy == QuantizationStrategy.CHANNEL
+            and self.input_quant.strategy == QuantizationStrategy.TOKEN
+        )
+        if not per_channel:
+            raise ValueError(
+                "For INT8 Fused MoE layers, we require channelwise, "
+                "dynamic per token quantization. Found "
+                f"{self.weight_quant}, {self.input_quant}"
+            )
+
+        self.static_input_scales = not self.input_quant.dynamic
+        if self.static_input_scales:
+            raise ValueError(
+                "For INT8 Fused MoE layers, we require channelwise, "
+                "dynamic per token quantization. Found static input scales."
+            )
+
+        # Consumed only by the upstream (unused here) modular-kernel path.
+        self.int8_backend = None
+        self.experts_cls = None
+
     @property
     def is_monolithic(self) -> bool:
         return True

--- a/vllm_kunlun/v1/attention/backends/gdn_attn.py
+++ b/vllm_kunlun/v1/attention/backends/gdn_attn.py
@@ -25,6 +25,18 @@ from vllm.v1.kv_cache_interface import AttentionSpec, MambaSpec
 logger = init_logger(__name__)
 
 
+def _to_cpu(t: torch.Tensor | None) -> torch.Tensor | None:
+    """Force a metadata mirror onto the host, no-op if it is already there.
+
+    Several ``*_cpu`` locals in ``build()`` are produced by indexing the *device*
+    block table, so they are not actually on the host despite the name. Their
+    consumers pass them to kunlun ops as host pointers.
+    """
+    if t is None or t.device.type == "cpu":
+        return t
+    return t.to("cpu")
+
+
 class GDNAttentionBackend(AttentionBackend):
     @staticmethod
     def get_name() -> str:
@@ -210,6 +222,10 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
         spec_conv_state_indices_tensor: torch.Tensor | None = None
         spec_conv_state_indices_tensor_cpu: torch.Tensor | None = None
         spec_sequence_masks_cpu: torch.Tensor | None = None
+        # [Kunlun] These CPU mirrors are only produced on some branches below but
+        # are always read when the metadata is built, so default them here.
+        spec_state_indices_tensor_cpu: torch.Tensor | None = None
+        non_spec_state_indices_tensor_cpu: torch.Tensor | None = None
         if (
             not self.use_spec_decode
             or num_decode_draft_tokens_cpu is None
@@ -544,27 +560,31 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
             non_spec_query_start_loc=non_spec_query_start_loc,
             non_spec_query_start_loc_cpu=non_spec_query_start_loc_cpu,
             spec_state_indices_tensor=spec_state_indices_tensor,
-            spec_state_indices_tensor_cpu=(
-                spec_state_indices_tensor.cpu()
-                if spec_state_indices_tensor is not None
-                else None
-            ),
+            # [Kunlun] These locals are named ``*_cpu`` but are produced by
+            # indexing the *device* ``block_table_tensor`` (see the branches
+            # above), so they can still live on the device. The consumers hand
+            # them to kunlun ops as host pointers, so they must be forced to CPU
+            # -- passing a device tensor there faults with
+            # "an illegal memory access was encountered".
+            spec_state_indices_tensor_cpu=_to_cpu(spec_state_indices_tensor_cpu),
             spec_conv_state_indices_tensor=spec_conv_state_indices_tensor,
-            spec_conv_state_indices_tensor_cpu=spec_conv_state_indices_tensor_cpu,
+            spec_conv_state_indices_tensor_cpu=_to_cpu(
+                spec_conv_state_indices_tensor_cpu
+            ),
             non_spec_state_indices_tensor=non_spec_state_indices_tensor,
-            non_spec_state_indices_tensor_cpu=(
-                non_spec_state_indices_tensor.to("cpu", non_blocking=True)
-                if non_spec_state_indices_tensor is not None
-                else None
+            non_spec_state_indices_tensor_cpu=_to_cpu(
+                non_spec_state_indices_tensor_cpu
             ),
             spec_sequence_masks=spec_sequence_masks,
             spec_token_masks=spec_token_masks,
             spec_token_indx=spec_token_indx,
             non_spec_token_indx=non_spec_token_indx,
             num_accepted_tokens=num_accepted_tokens,
-            num_accepted_tokens_cpu=(
-                num_accepted_tokens.cpu() if num_accepted_tokens is not None else None
-            ),
+            # [Kunlun] No consumer reads this: ``causal_conv1d_update`` accepts a
+            # ``num_accepted_tokens_cpu`` argument but never forwards it to the
+            # kernel. Dropping the blocking ``.cpu()`` removes one device sync
+            # per spec-decode step per attention group.
+            num_accepted_tokens_cpu=None,
             nums_dict=nums_dict,
             batch_ptr=batch_ptr,
             token_chunk_offset_ptr=token_chunk_offset_ptr,

--- a/vllm_kunlun/v1/attention/backends/gdn_attn.py
+++ b/vllm_kunlun/v1/attention/backends/gdn_attn.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 
 import torch
 from vllm.config import VllmConfig
+from vllm.logger import init_logger
 from vllm.v1.attention.backend import (
     AttentionBackend,
     AttentionCGSupport,
@@ -20,6 +21,8 @@ from vllm.v1.attention.backends.utils import (
     split_decodes_and_prefills,
 )
 from vllm.v1.kv_cache_interface import AttentionSpec, MambaSpec
+
+logger = init_logger(__name__)
 
 
 class GDNAttentionBackend(AttentionBackend):
@@ -58,6 +61,11 @@ class GDNAttentionMetadata:
     non_spec_query_start_loc_cpu: torch.Tensor | None = None
 
     spec_state_indices_tensor: torch.Tensor | None = None  # shape: [batch, num_spec]
+    spec_state_indices_tensor_cpu: torch.Tensor | None = (
+        None  # shape: [batch, num_spec]
+    )
+    spec_conv_state_indices_tensor: torch.Tensor | None = None  # shape: [batch,]
+    spec_conv_state_indices_tensor_cpu: torch.Tensor | None = None  # shape: [batch,]
     non_spec_state_indices_tensor: torch.Tensor | None = (
         None  # shape: [batch - num_spec_decodes,]
     )
@@ -72,6 +80,7 @@ class GDNAttentionMetadata:
     non_spec_token_indx: torch.Tensor | None = None
 
     num_accepted_tokens: torch.Tensor | None = None  # shape: [batch,]
+    num_accepted_tokens_cpu: torch.Tensor | None = None  # shape: [batch,]
 
     # Pre-computed FLA chunk metadata (avoids GPU->CPU sync in prepare_chunk_indices)
     chunk_indices: torch.Tensor | None = None
@@ -100,6 +109,11 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
         self.compilation_config = vllm_config.compilation_config
         self.speculative_config = vllm_config.speculative_config
         self.kv_cache_spec = kv_cache_spec
+        self.device = device
+        # [Kunlun] Track which capture sizes have had their spec-decode
+        # fused_recurrent kernel eagerly warmed up (see
+        # _maybe_warmup_spec_kernel).
+        self._spec_kernel_warmed: set[int] = set()
 
         if self.speculative_config:
             assert self.speculative_config.num_speculative_tokens is not None
@@ -126,6 +140,16 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
             (self.decode_cudagraph_max_bs, self.num_spec + 1),
             dtype=torch.int32,
             device=device,
+        )
+        self.spec_conv_state_indices_tensor = torch.empty(
+            (self.decode_cudagraph_max_bs,),
+            dtype=torch.int32,
+            device=device,
+        )
+        self.spec_conv_state_indices_tensor_cpu = torch.empty(
+            (self.decode_cudagraph_max_bs,),
+            dtype=torch.int32,
+            device="cpu",
         )
         self.non_spec_state_indices_tensor: torch.Tensor = torch.empty(
             (self.decode_cudagraph_max_bs,),
@@ -183,7 +207,8 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
             self.kv_cache_spec,
             self.vllm_config.cache_config.mamba_cache_mode,
         )
-
+        spec_conv_state_indices_tensor: torch.Tensor | None = None
+        spec_conv_state_indices_tensor_cpu: torch.Tensor | None = None
         spec_sequence_masks_cpu: torch.Tensor | None = None
         if (
             not self.use_spec_decode
@@ -218,7 +243,11 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
             spec_token_masks = None
             non_spec_token_indx = None
             spec_state_indices_tensor = None
+            spec_conv_state_indices_tensor = None
             non_spec_state_indices_tensor = block_table_tensor[:, 0]
+            non_spec_state_indices_tensor_cpu = (
+                block_table_tensor[:, 0] if block_table_tensor is not None else None
+            )
             spec_query_start_loc = None
             non_spec_query_start_loc = query_start_loc
             non_spec_query_start_loc_cpu = query_start_loc_cpu
@@ -275,6 +304,11 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
                 spec_state_indices_tensor = block_table_tensor[
                     spec_sequence_masks_cpu, : self.num_spec + 1
                 ]
+                spec_state_indices_tensor_cpu = (
+                    block_table_tensor[spec_sequence_masks_cpu, : self.num_spec + 1]
+                    if block_table_tensor is not None
+                    else None
+                )
                 non_spec_state_indices_tensor = None
                 # Padded sequences are always at the back, so the first
                 # num_spec_decodes + 1 entries of query_start_loc already
@@ -296,9 +330,19 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
                 spec_state_indices_tensor = block_table_tensor[
                     spec_sequence_masks_cpu, : self.num_spec + 1
                 ]
+                spec_state_indices_tensor_cpu = (
+                    block_table_tensor[spec_sequence_masks_cpu, : self.num_spec + 1]
+                    if block_table_tensor is not None
+                    else None
+                )
                 non_spec_state_indices_tensor = block_table_tensor[
                     ~spec_sequence_masks_cpu, 0
                 ]
+                non_spec_state_indices_tensor_cpu = (
+                    block_table_tensor[~spec_sequence_masks_cpu, 0]
+                    if block_table_tensor is not None
+                    else None
+                )
 
                 spec_query_start_loc = torch.zeros(
                     num_spec_decodes + 1,
@@ -354,7 +398,7 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
             ).to(device=gpu_device, non_blocking=True)
 
         if num_prefills > 0:
-            has_initial_state = (context_lens_tensor > 0).to(torch.int32)
+            has_initial_state = context_lens_tensor > 0
             if spec_sequence_masks_cpu is not None:
                 has_initial_state = has_initial_state[~spec_sequence_masks_cpu]
                 assert non_spec_query_start_loc_cpu is not None
@@ -390,13 +434,29 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
             self.spec_state_indices_tensor[:num_spec_decodes].copy_(
                 spec_state_indices_tensor, non_blocking=True
             )
+            self.spec_conv_state_indices_tensor[:num_spec_decodes].copy_(
+                spec_state_indices_tensor[:, 0], non_blocking=True
+            )
+            self.spec_conv_state_indices_tensor_cpu[:num_spec_decodes].copy_(
+                spec_state_indices_tensor_cpu[:num_spec_decodes, 0]
+                if spec_state_indices_tensor_cpu is not None
+                else spec_state_indices_tensor[:, 0].to(device="cpu", dtype=torch.int32)
+            )
             spec_state_indices_tensor = self.spec_state_indices_tensor[:batch_size]
             spec_state_indices_tensor[num_spec_decodes:].fill_(NULL_BLOCK_ID)
-
+            spec_conv_state_indices_tensor = self.spec_conv_state_indices_tensor[
+                :batch_size
+            ]
+            spec_conv_state_indices_tensor[num_spec_decodes:].fill_(0)
+            spec_conv_state_indices_tensor_cpu = (
+                self.spec_conv_state_indices_tensor_cpu[:batch_size]
+            )
+            spec_conv_state_indices_tensor_cpu[num_spec_decodes:].fill_(0)
             self.spec_sequence_masks[:num_spec_decodes].copy_(
                 spec_sequence_masks[:num_spec_decodes], non_blocking=True
             )
             spec_sequence_masks = self.spec_sequence_masks[:batch_size]
+            spec_sequence_masks[:num_spec_decodes].fill_(True)
             spec_sequence_masks[num_spec_decodes:].fill_(False)
 
             assert non_spec_token_indx is not None and spec_token_indx is not None
@@ -424,6 +484,17 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
             )
             num_accepted_tokens = self.num_accepted_tokens[:batch_size]
             num_accepted_tokens[num_spec_decodes:].fill_(1)
+        elif spec_state_indices_tensor is not None:
+            spec_conv_state_indices_tensor = (
+                spec_state_indices_tensor[:, 0].to(torch.int32).contiguous()
+            )
+            spec_conv_state_indices_tensor_cpu = (
+                spec_state_indices_tensor_cpu[:, 0].contiguous()
+                if spec_state_indices_tensor_cpu is not None
+                else spec_conv_state_indices_tensor.to(device="cpu", dtype=torch.int32)
+            )
+            assert num_accepted_tokens is not None
+            num_accepted_tokens = num_accepted_tokens.to(dtype=torch.int32)
 
         if (
             self.use_full_cuda_graph
@@ -445,6 +516,13 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
             non_spec_num_query_tokens = non_spec_query_start_loc[-1]  # type: ignore[index]
             non_spec_query_start_loc = self.non_spec_query_start_loc[: batch_size + 1]
             non_spec_query_start_loc[num_decodes + 1 :].fill_(non_spec_num_query_tokens)
+        elif (
+            non_spec_state_indices_tensor is not None
+            and non_spec_state_indices_tensor_cpu is None
+        ):
+            non_spec_state_indices_tensor_cpu = non_spec_state_indices_tensor.to(
+                device="cpu", dtype=torch.int32
+            )
 
         attn_metadata = GDNAttentionMetadata(
             num_prefills=num_prefills,
@@ -466,6 +544,13 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
             non_spec_query_start_loc=non_spec_query_start_loc,
             non_spec_query_start_loc_cpu=non_spec_query_start_loc_cpu,
             spec_state_indices_tensor=spec_state_indices_tensor,
+            spec_state_indices_tensor_cpu=(
+                spec_state_indices_tensor.cpu()
+                if spec_state_indices_tensor is not None
+                else None
+            ),
+            spec_conv_state_indices_tensor=spec_conv_state_indices_tensor,
+            spec_conv_state_indices_tensor_cpu=spec_conv_state_indices_tensor_cpu,
             non_spec_state_indices_tensor=non_spec_state_indices_tensor,
             non_spec_state_indices_tensor_cpu=(
                 non_spec_state_indices_tensor.to("cpu", non_blocking=True)
@@ -477,11 +562,132 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
             spec_token_indx=spec_token_indx,
             non_spec_token_indx=non_spec_token_indx,
             num_accepted_tokens=num_accepted_tokens,
+            num_accepted_tokens_cpu=(
+                num_accepted_tokens.cpu() if num_accepted_tokens is not None else None
+            ),
             nums_dict=nums_dict,
             batch_ptr=batch_ptr,
             token_chunk_offset_ptr=token_chunk_offset_ptr,
         )
         return attn_metadata
+
+    def _maybe_warmup_spec_kernel(
+        self, common_attn_metadata: CommonAttentionMetadata
+    ) -> None:
+        """[Kunlun] Eagerly warm up the spec-decode fused_recurrent kernel
+        before it is recorded into a FULL CUDA graph.
+
+        Why: with MTP, the pre-capture warmup pass (_warmup_and_capture ->
+        _dummy_run(cudagraph_runtime_mode=NONE)) builds metadata via the normal
+        ``build()`` path. Because the dummy run never populates
+        ``num_decode_draft_tokens``, ``build()`` takes the *non-spec* branch and
+        the uniform (query_len = 1 + num_spec) requests are treated as prefill
+        (chunk path). The actual capture, however, goes through
+        ``build_for_cudagraph_capture`` which synthesizes *spec* metadata from
+        ``diff(query_start_loc)`` and runs the *spec* ``fused_recurrent``. That
+        spec kernel is therefore launched for the very first time inside the
+        capture region.
+
+        The Kunlun native op does capture-illegal work on its first launch for a
+        new shape (load-based kernel auto-selection, L3 scratch allocation,
+        module setup), which fails during capture with
+        "CUDA error: unrecognized error code" (dump shows l3_size=0). Running it
+        once in eager beforehand moves that first-launch cost outside the graph.
+
+        This is invoked from ``build_for_cudagraph_capture``, which runs *before*
+        the ``torch.cuda.graph`` capture region begins; an
+        ``is_current_stream_capturing()`` guard makes sure we never launch the
+        kernel while a capture is in progress.
+
+        How to apply: only relevant for FULL cudagraph + spec decode; a no-op
+        otherwise. Warms once per capture batch size.
+        """
+        if not (self.use_full_cuda_graph and self.use_spec_decode):
+            return
+        try:
+            if torch.cuda.is_current_stream_capturing():
+                return
+        except Exception:
+            return
+
+        num_reqs = int(common_attn_metadata.num_reqs)
+        if num_reqs <= 0 or num_reqs in self._spec_kernel_warmed:
+            return
+
+        try:
+            from vllm_kunlun.ops.fla.fused_recurrent import (
+                fused_recurrent_gated_delta_rule,
+            )
+
+            hf_config = self.vllm_config.model_config.hf_config
+            tc = getattr(hf_config, "text_config", hf_config)
+            num_k_heads = tc.linear_num_key_heads
+            num_v_heads = tc.linear_num_value_heads
+            head_k_dim = tc.linear_key_head_dim
+            head_v_dim = tc.linear_value_head_dim
+
+            spec_width = self.num_spec + 1
+            total = num_reqs * spec_width
+            dev = self.device
+            # Match the real spec call: fp16 io / g / beta, fp16 state, and a
+            # non-contiguous (transposed) h0 like the page-padded ssm_state view.
+            io_dtype = torch.float16
+            q = torch.zeros(
+                1, total, num_k_heads, head_k_dim, dtype=io_dtype, device=dev
+            )
+            k = torch.zeros_like(q)
+            v = torch.zeros(
+                1, total, num_v_heads, head_v_dim, dtype=io_dtype, device=dev
+            )
+            g = torch.zeros(1, total, num_v_heads, dtype=io_dtype, device=dev)
+            beta = torch.zeros(1, total, num_v_heads, dtype=io_dtype, device=dev)
+            h0 = torch.zeros(
+                num_reqs,
+                num_v_heads,
+                head_v_dim,
+                head_k_dim,
+                dtype=io_dtype,
+                device=dev,
+            ).transpose(-1, -2)
+            cu_seqlens = torch.arange(
+                0, total + 1, spec_width, dtype=torch.int32, device=dev
+            )
+            ssm_state_indices = (
+                torch.arange(total, dtype=torch.int32, device=dev)
+                .remainder(num_reqs)
+                .reshape(num_reqs, spec_width)
+            )
+            num_accepted_tokens = torch.full(
+                (num_reqs,), spec_width, dtype=torch.int32, device=dev
+            )
+
+            fused_recurrent_gated_delta_rule(
+                q=q,
+                k=k,
+                v=v,
+                g=g,
+                beta=beta,
+                initial_state=h0,
+                inplace_final_state=True,
+                cu_seqlens=cu_seqlens,
+                ssm_state_indices=ssm_state_indices,
+                num_accepted_tokens=num_accepted_tokens,
+                use_qk_l2norm_in_kernel=True,
+            )
+            torch.cuda.synchronize()
+            self._spec_kernel_warmed.add(num_reqs)
+            logger.info(
+                "[KunlunPlugin] warmed spec GDN fused_recurrent kernel for "
+                "cudagraph capture (num_reqs=%d, tokens=%d)",
+                num_reqs,
+                total,
+            )
+        except Exception as e:  # warmup must never break startup
+            logger.warning(
+                "[KunlunPlugin] spec GDN kernel warmup failed (num_reqs=%s): %r",
+                num_reqs,
+                e,
+            )
 
     def build_for_cudagraph_capture(
         self, common_attn_metadata: CommonAttentionMetadata
@@ -490,6 +696,10 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
         This method builds the metadata for full cudagraph capture.
         Currently, only decode is supported for full cudagraphs with Mamba.
         """
+        # # [Kunlun] Warm the spec fused_recurrent kernel in eager BEFORE the
+        # # capture region records it (see _maybe_warmup_spec_kernel).
+        self._maybe_warmup_spec_kernel(common_attn_metadata)
+
         m = common_attn_metadata
 
         assert (
@@ -502,6 +712,9 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
             f"and number of tokens ({m.num_actual_tokens}) <= "
             f"cudagraph capture sizes ({self.decode_cudagraph_max_bs})."
         )
+        # if m.query_start_loc.shape[0] > 2 and m.query_start_loc[-1] - m.query_start_loc[-2] < m.query_start_loc[-2] - m.query_start_loc[-3]:
+        #     m.query_start_loc = m.query_start_loc[:-1]
+        #     m.seq_lens_cpu = m.seq_lens_cpu[:-1]
 
         num_accepted_tokens = torch.diff(m.query_start_loc)
         num_decode_draft_tokens_cpu = (num_accepted_tokens - 1).cpu()

--- a/vllm_kunlun/v1/attention/backends/gdn_attn.py
+++ b/vllm_kunlun/v1/attention/backends/gdn_attn.py
@@ -94,6 +94,12 @@ class GDNAttentionMetadata:
     num_accepted_tokens: torch.Tensor | None = None  # shape: [batch,]
     num_accepted_tokens_cpu: torch.Tensor | None = None  # shape: [batch,]
 
+    # Variable-length speculative decode uses a padded layout only for the
+    # fixed-width Kunlun conv kernel, then restores the real token layout before
+    # the recurrent kernel. Both are None for uniform MTP batches.
+    spec_pad_gather_idx: torch.Tensor | None = None
+    spec_unpad_idx: torch.Tensor | None = None
+
     # Pre-computed FLA chunk metadata (avoids GPU->CPU sync in prepare_chunk_indices)
     chunk_indices: torch.Tensor | None = None
     chunk_offsets: torch.Tensor | None = None
@@ -102,6 +108,33 @@ class GDNAttentionMetadata:
     nums_dict: dict | None = None
     batch_ptr: torch.Tensor | None = None
     token_chunk_offset_ptr: torch.Tensor | None = None
+
+
+def build_spec_pad_indices(
+    spec_query_lens_cpu: torch.Tensor,
+    spec_width: int,
+) -> tuple[torch.Tensor, torch.Tensor] | None:
+    """Map variable-length spec tokens to fixed-width rows and back."""
+    num_spec_decodes = spec_query_lens_cpu.size(0)
+    lens = spec_query_lens_cpu.to(torch.int64)
+    if int(lens.sum().item()) == num_spec_decodes * spec_width:
+        return None
+
+    cu = torch.zeros(num_spec_decodes + 1, dtype=torch.int64)
+    torch.cumsum(lens, dim=0, out=cu[1:])
+    starts = cu[:-1].unsqueeze(1)
+    pos = torch.arange(spec_width, dtype=torch.int64).unsqueeze(0)
+    last_real = (lens - 1).clamp_(min=0).unsqueeze(1)
+
+    # Replicate the final real token so the conv input stays finite. These tail
+    # outputs are removed before the recurrent kernel and cannot be accepted.
+    pad_gather_idx = (starts + torch.minimum(pos, last_real)).reshape(-1)
+    real_mask = pos < lens.unsqueeze(1)
+    unpad_idx = (
+        torch.arange(num_spec_decodes, dtype=torch.int64).unsqueeze(1) * spec_width
+        + pos
+    )[real_mask]
+    return pad_gather_idx.to(torch.int32), unpad_idx.to(torch.int32)
 
 
 class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]):
@@ -222,6 +255,8 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
         spec_conv_state_indices_tensor: torch.Tensor | None = None
         spec_conv_state_indices_tensor_cpu: torch.Tensor | None = None
         spec_sequence_masks_cpu: torch.Tensor | None = None
+        spec_pad_gather_idx: torch.Tensor | None = None
+        spec_unpad_idx: torch.Tensor | None = None
         # [Kunlun] These CPU mirrors are only produced on some branches below but
         # are always read when the metadata is built, so default them here.
         spec_state_indices_tensor_cpu: torch.Tensor | None = None
@@ -393,6 +428,21 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
             assert num_accepted_tokens is not None
             num_accepted_tokens = num_accepted_tokens[spec_sequence_masks_cpu]
 
+            pad_indices = build_spec_pad_indices(
+                query_lens_cpu[spec_sequence_masks_cpu], self.num_spec + 1
+            )
+            if pad_indices is not None:
+                logger.warning_once(
+                    "[KunlunPlugin] GDN spec decode hit non-uniform query "
+                    "lengths; using the padded-conv fallback"
+                )
+                spec_pad_gather_idx = pad_indices[0].to(
+                    query_start_loc.device, non_blocking=True
+                )
+                spec_unpad_idx = pad_indices[1].to(
+                    query_start_loc.device, non_blocking=True
+                )
+
         chunk_indices: torch.Tensor | None = None
         chunk_offsets: torch.Tensor | None = None
         if num_prefills > 0:
@@ -441,6 +491,7 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
 
         if (
             self.use_full_cuda_graph
+            and spec_pad_gather_idx is None
             and num_prefills == 0
             and num_decodes == 0
             and num_spec_decodes <= self.decode_cudagraph_max_bs
@@ -585,6 +636,8 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
             # kernel. Dropping the blocking ``.cpu()`` removes one device sync
             # per spec-decode step per attention group.
             num_accepted_tokens_cpu=None,
+            spec_pad_gather_idx=spec_pad_gather_idx,
+            spec_unpad_idx=spec_unpad_idx,
             nums_dict=nums_dict,
             batch_ptr=batch_ptr,
             token_chunk_offset_ptr=token_chunk_offset_ptr,
@@ -716,8 +769,7 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
         This method builds the metadata for full cudagraph capture.
         Currently, only decode is supported for full cudagraphs with Mamba.
         """
-        # # [Kunlun] Warm the spec fused_recurrent kernel in eager BEFORE the
-        # # capture region records it (see _maybe_warmup_spec_kernel).
+        # Warm the spec fused_recurrent kernel before graph capture.
         self._maybe_warmup_spec_kernel(common_attn_metadata)
 
         m = common_attn_metadata
@@ -732,10 +784,6 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
             f"and number of tokens ({m.num_actual_tokens}) <= "
             f"cudagraph capture sizes ({self.decode_cudagraph_max_bs})."
         )
-        # if m.query_start_loc.shape[0] > 2 and m.query_start_loc[-1] - m.query_start_loc[-2] < m.query_start_loc[-2] - m.query_start_loc[-3]:
-        #     m.query_start_loc = m.query_start_loc[:-1]
-        #     m.seq_lens_cpu = m.seq_lens_cpu[:-1]
-
         num_accepted_tokens = torch.diff(m.query_start_loc)
         num_decode_draft_tokens_cpu = (num_accepted_tokens - 1).cpu()
 

--- a/vllm_kunlun/v1/attention/backends/kunlun_attn.py
+++ b/vllm_kunlun/v1/attention/backends/kunlun_attn.py
@@ -16,7 +16,7 @@
 #
 import copy
 from dataclasses import dataclass
-from itertools import accumulate
+from itertools import accumulate  # noqa: F401  (kept: used elsewhere in file)
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -483,6 +483,47 @@ class KunlunAttentionMetadataBuilder:
         self.kv_cache_spec = kv_cache_spec
         self.device = device
 
+        # [Kunlun] Persistent per-step metadata buffers.
+        #
+        # ``build()`` used to allocate every tensor it hands to the kernel on
+        # each call. At batch 1 those allocations + H2D copies are the whole
+        # cost: profiling one MTP step showed this builder issuing 135 eager op
+        # dispatches (~1.6ms) while doing no GPU compute at all, and it runs
+        # once per attention group per forward (target *and* each draft step).
+        # Reusing buffers also makes the metadata addresses stable, which is a
+        # prerequisite for ever capturing the drafter in a cudagraph.
+        self._max_reqs = vllm_config.scheduler_config.max_num_seqs
+        self._buf_cache: dict[tuple[str, torch.dtype, str], torch.Tensor] = {}
+
+    def _staged(
+        self,
+        key: str,
+        src: torch.Tensor,
+        num: int,
+        device: torch.device | str,
+        dtype: torch.dtype | None = None,
+    ) -> torch.Tensor:
+        """Copy ``src[:num]`` into a persistent buffer and return the view.
+
+        Grows on demand; keyed by (name, dtype, device) so a dtype change cannot
+        silently truncate values. Pass ``dtype`` when the *source* dtype is not
+        stable across callers, otherwise one field gets two buffers and two
+        addresses: the drafter's ``query_start_loc_cpu`` is int32 on the first
+        pass (the runner's CpuGpuBuffer) but int64 inside the draft loop, where
+        upstream rebuilds it from an unannotated ``np.arange``
+        (llm_base_proposer.py). ``copy_`` casts, so fixing the dtype here also
+        normalizes what the kernels receive -- they document these lods as int32.
+        """
+        dtype = dtype or src.dtype
+        ck = (key, dtype, str(device))
+        buf = self._buf_cache.get(ck)
+        if buf is None or buf.numel() < num:
+            buf = torch.empty(max(num, self._max_reqs + 1), dtype=dtype, device=device)
+            self._buf_cache[ck] = buf
+        out = buf[:num]
+        out.copy_(src[:num], non_blocking=True)
+        return out
+
     def _init_reorder_batch_threshold(
         self,
         reorder_batch_threshold: int | None = 1,
@@ -588,6 +629,20 @@ class KunlunAttentionMetadataBuilder:
             common_attn_metadata=common_attn_metadata,
         )
 
+    def _staged_kv_lod(self, seq_lens_cpu: torch.Tensor, num_reqs: int) -> torch.Tensor:
+        """``[0, cumsum(seq_lens)]`` on the host, in a persistent int32 buffer."""
+        ck = ("kv_lod_cpu", torch.int32, "cpu")
+        buf = self._buf_cache.get(ck)
+        if buf is None or buf.numel() < num_reqs + 1:
+            buf = torch.zeros(
+                max(num_reqs + 1, self._max_reqs + 1), dtype=torch.int32, device="cpu"
+            )
+            self._buf_cache[ck] = buf
+        out = buf[: num_reqs + 1]
+        out[0] = 0
+        torch.cumsum(seq_lens_cpu[:num_reqs].to(torch.int32), dim=0, out=out[1:])
+        return out
+
     def build(
         self, common_prefix_len: int, common_attn_metadata: CommonAttentionMetadata
     ):
@@ -599,24 +654,46 @@ class KunlunAttentionMetadataBuilder:
         block_table_tensor = common_attn_metadata.block_table_tensor
         slot_mapping = common_attn_metadata.slot_mapping
 
-        query_start_loc_host = common_attn_metadata.query_start_loc_cpu[: num_reqs + 1]
-        query_start_loc = common_attn_metadata.query_start_loc_cpu[: num_reqs + 1].to(
-            self.device, non_blocking=True
+        # The host mirrors go through persistent buffers as well, not just the
+        # device copies: upstream hands the drafter a freshly ``clone()``d
+        # ``query_start_loc_cpu`` on every step (llm_base_proposer.py) and
+        # ``seq_lens_cpu`` is a lazy property that redoes the D2H allocation
+        # whenever ``_seq_lens_cpu`` is None, so both moved every step. The
+        # kernels read these host mirrors directly (``context_qlen_lod_cpu`` /
+        # ``context_lens_cpu``), and stable addresses are a prerequisite for
+        # capturing the drafter in a cudagraph.
+        query_start_loc_host = self._staged(
+            "query_start_loc_host",
+            common_attn_metadata.query_start_loc_cpu,
+            num_reqs + 1,
+            "cpu",
+            torch.int32,
+        )
+        query_start_loc = self._staged(
+            "query_start_loc",
+            query_start_loc_host,
+            num_reqs + 1,
+            self.device,
+            torch.int32,
         )
 
         seq_lens = common_attn_metadata.seq_lens
-        seq_lens_cpu = common_attn_metadata.seq_lens_cpu
-
-        seq_start_loc = list(accumulate(seq_lens, initial=0))
-
-        seq_start_loc_tensor = torch.empty(
-            len(seq_start_loc), dtype=torch.int32, device=self.device
+        seq_lens_cpu = self._staged(
+            "seq_lens_cpu",
+            common_attn_metadata.seq_lens_cpu,
+            num_reqs,
+            "cpu",
+            torch.int32,
         )
-        seq_start_loc_tensor.copy_(torch.as_tensor(seq_start_loc, dtype=torch.int32))
 
-        kv_lod_cpu = torch.zeros(num_reqs + 1, dtype=torch.int32, device="cpu")
-        kv_lod_cpu[1:] = seq_lens_cpu.to(torch.int32).cumsum(dim=0)
-        kv_lod_xpu = kv_lod_cpu.to(self.device)
+        # NOTE: a ``list(accumulate(seq_lens, ...))`` used to be computed here and
+        # dropped on the floor -- ``seq_start_loc`` is not a field this builder
+        # passes to KunlunMetadata. Iterating ``seq_lens`` (a *device* tensor) in
+        # Python cost one device sync per request, so it was the most expensive
+        # line in the builder while producing nothing. kv_lod below is the same
+        # prefix sum, computed on the host mirror.
+        kv_lod_cpu = self._staged_kv_lod(seq_lens_cpu, num_reqs)
+        kv_lod_xpu = self._staged("kv_lod_xpu", kv_lod_cpu, num_reqs + 1, self.device)
 
         self._init_reorder_batch_threshold(1, supports_spec_as_decode=True)
         num_decodes, num_prefills, num_decode_tokens, num_prefill_tokens = (
@@ -627,9 +704,7 @@ class KunlunAttentionMetadataBuilder:
             )
         )
 
-        num_scheduled_tokens = np.diff(
-            common_attn_metadata.query_start_loc_cpu[: num_reqs + 1]
-        )
+        num_scheduled_tokens = np.diff(query_start_loc_host)
         tmp_decode_scheduled_tokens = num_scheduled_tokens[:num_decodes]
 
         if num_decode_tokens == 0:
@@ -926,8 +1001,11 @@ class KunlunAttentionImpl(AttentionImpl[KunlunMetadata]):
                 )
                 setattr(self, "_spec_attn_has_max_window_size", has_max_window_size)
 
-            sig = inspect.signature(kunlun_ops.speculative_attention)
-            if "max_window_size" in sig.parameters:
+            # NOTE: use the cached flag. ``inspect.signature`` on this op costs
+            # ~47us and used to run here on every decode forward of every layer
+            # (the cache above was computed and then ignored), i.e. ~1.3ms per
+            # step at 28 layers, all of it pure host overhead.
+            if has_max_window_size:
                 batch_size = attn_metadata.num_decodes
                 query_seq_len, head_num, head_dim = decode_query.shape
                 if (

--- a/vllm_kunlun/v1/attention/backends/kunlun_attn.py
+++ b/vllm_kunlun/v1/attention/backends/kunlun_attn.py
@@ -16,6 +16,7 @@
 #
 import copy
 from dataclasses import dataclass
+from itertools import accumulate
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -32,6 +33,7 @@ import kunlun_ops
 import numpy as np
 import torch
 from vllm.config import VllmConfig
+from vllm.logger import init_logger
 from vllm.v1.attention.backend import (
     AttentionBackend,
     AttentionCGSupport,
@@ -54,6 +56,8 @@ import inspect
 from vllm.utils.math_utils import cdiv
 from vllm.v1.attention.backends.fa_utils import get_flash_attn_version
 from vllm.v1.kv_cache_interface import AttentionSpec
+
+logger = init_logger(__name__)
 
 
 class KunlunAttentionBackend(AttentionBackend):
@@ -603,6 +607,13 @@ class KunlunAttentionMetadataBuilder:
         seq_lens = common_attn_metadata.seq_lens
         seq_lens_cpu = common_attn_metadata.seq_lens_cpu
 
+        seq_start_loc = list(accumulate(seq_lens, initial=0))
+
+        seq_start_loc_tensor = torch.empty(
+            len(seq_start_loc), dtype=torch.int32, device=self.device
+        )
+        seq_start_loc_tensor.copy_(torch.as_tensor(seq_start_loc, dtype=torch.int32))
+
         kv_lod_cpu = torch.zeros(num_reqs + 1, dtype=torch.int32, device="cpu")
         kv_lod_cpu[1:] = seq_lens_cpu.to(torch.int32).cumsum(dim=0)
         kv_lod_xpu = kv_lod_cpu.to(self.device)
@@ -688,6 +699,26 @@ class KunlunAttentionMetadataBuilder:
 
 class KunlunAttentionImpl(AttentionImpl[KunlunMetadata]):
     """KunlunAttentionImpl"""
+
+    @staticmethod
+    def _get_block_table_scale(key_cache: torch.Tensor) -> int:
+        contiguous_block_stride = (
+            key_cache.shape[1] * key_cache.shape[2] * key_cache.shape[3]
+        )
+        actual_block_stride = key_cache.stride(0)
+        if actual_block_stride == contiguous_block_stride:
+            return 1
+        if actual_block_stride % contiguous_block_stride != 0:
+            logger.warning(
+                "[KunlunAttention] unexpected KV cache block stride: "
+                "actual=%s contiguous=%s shape=%s stride=%s",
+                actual_block_stride,
+                contiguous_block_stride,
+                tuple(key_cache.shape),
+                tuple(key_cache.stride()),
+            )
+            return 1
+        return actual_block_stride // contiguous_block_stride
 
     def __init__(
         self,
@@ -794,7 +825,6 @@ class KunlunAttentionImpl(AttentionImpl[KunlunMetadata]):
                     # and value tensors are not cached. This happens during
                     # the initial memory
                     value = value.contiguous()
-                    key = key.contiguous()
                     kunlun_ops.reshape_and_cache_flash(
                         key[: attn_metadata.num_actual_tokens],
                         value[: attn_metadata.num_actual_tokens],
@@ -822,23 +852,18 @@ class KunlunAttentionImpl(AttentionImpl[KunlunMetadata]):
             #   score = Q @ K^T * (1/sqrt(d)) * alpha
             # We want: score = Q @ K^T * self.scale
             # So: alpha = self.scale * sqrt(d) = self.scale / (1/sqrt(d))
-            import math
+            # import math
 
-            _prefill_alpha = self.scale * math.sqrt(self.head_size)
+            # _prefill_alpha = self.scale * math.sqrt(self.head_size)
 
-            # For hybrid Attention (Qwen3-Next.)
-            if key_cache.is_contiguous():
-                tmp_block_tables = prefill_meta.block_tables
-            else:
-                # For hybrid Attention (Qwen3-Next)
-                tmp_block_tables = prefill_meta.block_tables * 2
+            # For hybrid/packed attention, Kunlun kernels assume contiguous
+            # block stride. Scale logical block ids to match the actual
+            # packed KV-cache block stride (e.g. 2 * attn_pack_size).
+            block_table_scale = self._get_block_table_scale(key_cache)
+            tmp_block_tables = prefill_meta.block_tables * block_table_scale
 
             # Prefix cache or KV sharing layers (must read K/V from cache)
-            is_kv_sharing = self.kv_sharing_target_layer_name is not None
-            if (
-                is_kv_sharing
-                or prefill_meta.query_start_loc_host[-1] != prefill_meta.kv_lod_cpu[-1]
-            ):
+            if prefill_meta.query_start_loc_host[-1] != prefill_meta.kv_lod_cpu[-1]:
                 kunlun_ops.prefill_attention(
                     q=prefill_query,
                     k=key_cache,  # Key Cache [block_num, head, block_size, dim]
@@ -846,7 +871,6 @@ class KunlunAttentionImpl(AttentionImpl[KunlunMetadata]):
                     out=output[num_decode_tokens : attn_metadata.num_actual_tokens],
                     is_causal=True,
                     is_prefix_cache=True,
-                    alpha=_prefill_alpha,
                     block_table=tmp_block_tables,
                     context_qlen_lod_cpu=prefill_meta.query_start_loc_host,
                     context_qlen_lod_xpu=prefill_meta.query_start_loc,
@@ -869,7 +893,6 @@ class KunlunAttentionImpl(AttentionImpl[KunlunMetadata]):
                     v=prefill_value,
                     out=output[num_decode_tokens : attn_metadata.num_actual_tokens],
                     is_causal=True,
-                    alpha=_prefill_alpha,
                     context_qlen_lod_cpu=prefill_meta.query_start_loc_host,
                     context_qlen_lod_xpu=prefill_meta.query_start_loc,
                     alibi_slopes=self.alibi_slopes,
@@ -889,13 +912,11 @@ class KunlunAttentionImpl(AttentionImpl[KunlunMetadata]):
             ), "Encoder-only models should not have decode metadata."
             decode_query = query[:num_decode_tokens]
 
-            # For hybrid Attention (Qwen3-Next
-            if key_cache.is_contiguous():
-                tmp_block_tables = decode_meta.block_tables
-            else:
-                tmp_block_tables = (
-                    decode_meta.block_tables * 2
-                )  # only test in Qwen3-Next
+            # For hybrid/packed attention, Kunlun kernels assume contiguous
+            # block stride. Scale logical block ids to match the actual
+            # packed KV-cache block stride (e.g. 2 * attn_pack_size).
+            block_table_scale = self._get_block_table_scale(key_cache)
+            tmp_block_tables = decode_meta.block_tables * block_table_scale
 
             has_max_window_size = getattr(self, "_spec_attn_has_max_window_size", None)
             if has_max_window_size is None:
@@ -904,35 +925,76 @@ class KunlunAttentionImpl(AttentionImpl[KunlunMetadata]):
                     in inspect.signature(kunlun_ops.speculative_attention).parameters
                 )
                 setattr(self, "_spec_attn_has_max_window_size", has_max_window_size)
-            if has_max_window_size:
-                # kunlun_ops.speculative_attention is not support max_window_size parameter in torch29
-                kunlun_ops.speculative_attention(
-                    out=output[:num_decode_tokens],
-                    # Only MLA support q len > 1 right now
-                    q=decode_query.unsqueeze(0),
-                    k_cache=key_cache,
-                    v_cache=value_cache,
-                    context_lens_cpu=decode_meta.seq_lens_tensor_cpu,
-                    context_lens_xpu=decode_meta.seq_lens_tensor,
-                    batch_num=decode_meta.block_tables.shape[0],
-                    # TODO (@xyDong23): Support MTP(q lens >1)
-                    qlen=1,
-                    # TODO (@xyDong23): Support max_context_len to (262144)
-                    max_context_len=decode_meta.max_model_len,
-                    head_num=self.num_heads,
-                    head_dim=self.head_size,
-                    scale=self.scale,
-                    kv_head_num=self.num_kv_heads,
-                    block_size=key_cache.shape[2],
-                    max_num_blocks_per_seq=decode_meta.block_tables.shape[1],
-                    max_window_size=(
-                        self.sliding_window if self.sliding_window is not None else -1
-                    ),
-                    block_tables=tmp_block_tables,
-                    sink=(
-                        self.sinks.to(torch.float32) if self.sinks is not None else None
-                    ),
-                )
+
+            sig = inspect.signature(kunlun_ops.speculative_attention)
+            if "max_window_size" in sig.parameters:
+                batch_size = attn_metadata.num_decodes
+                query_seq_len, head_num, head_dim = decode_query.shape
+                if (
+                    not attn_metadata.is_speculative
+                    or batch_size == 0
+                    or query_seq_len == batch_size
+                ):
+                    kunlun_ops.speculative_attention(
+                        out=output[:num_decode_tokens],
+                        q=decode_query.unsqueeze(0),
+                        k_cache=key_cache,
+                        v_cache=value_cache,
+                        context_lens_cpu=decode_meta.seq_lens_tensor_cpu,
+                        context_lens_xpu=decode_meta.seq_lens_tensor,
+                        batch_num=decode_meta.block_tables.shape[0],
+                        qlen=1,
+                        max_context_len=decode_meta.max_model_len,
+                        head_num=self.num_heads,
+                        head_dim=self.head_size,
+                        scale=0.0,
+                        kv_head_num=self.num_kv_heads,
+                        block_size=key_cache.shape[2],
+                        max_num_blocks_per_seq=decode_meta.block_tables.shape[1],
+                        max_window_size=(
+                            self.sliding_window
+                            if self.sliding_window is not None
+                            else -1
+                        ),
+                        block_tables=tmp_block_tables,
+                        sink=(
+                            self.sinks.to(torch.float32)
+                            if self.sinks is not None
+                            else None
+                        ),
+                    )
+                else:
+                    assert query_seq_len % batch_size == 0
+                    qlen = query_seq_len // batch_size
+                    out = output[:num_decode_tokens]
+                    kunlun_ops.speculative_attention(
+                        out=out.view(batch_size, qlen, head_num, self.head_size),
+                        q=decode_query.view(batch_size, qlen, head_num, head_dim),
+                        k_cache=key_cache,
+                        v_cache=value_cache,
+                        context_lens_cpu=decode_meta.seq_lens_tensor_cpu,
+                        context_lens_xpu=decode_meta.seq_lens_tensor,
+                        batch_num=batch_size,
+                        qlen=qlen,
+                        max_context_len=decode_meta.max_model_len,
+                        head_num=self.num_heads,
+                        head_dim=self.head_size,
+                        scale=0.0,
+                        kv_head_num=self.num_kv_heads,
+                        block_size=key_cache.shape[2],
+                        max_num_blocks_per_seq=decode_meta.block_tables.shape[1],
+                        max_window_size=(
+                            self.sliding_window
+                            if self.sliding_window is not None
+                            else -1
+                        ),
+                        block_tables=tmp_block_tables,
+                        sink=(
+                            self.sinks.to(torch.float32)
+                            if self.sinks is not None
+                            else None
+                        ),
+                    )
             elif not attn_metadata.is_speculative:
                 kunlun_ops.paged_attention(
                     x=decode_query,
@@ -972,6 +1034,7 @@ class KunlunAttentionImpl(AttentionImpl[KunlunMetadata]):
                     max_num_blocks_per_seq=decode_meta.block_tables.shape[1],
                     block_tables=tmp_block_tables,
                 )
+
         # Reshape the output tensor.
         return output.view(-1, self.num_heads * self.head_size)
 

--- a/vllm_kunlun/v1/sample/ops/topk_topp_sampler.py
+++ b/vllm_kunlun/v1/sample/ops/topk_topp_sampler.py
@@ -113,6 +113,77 @@ def apply_top_k_top_p(
     return logits
 
 
+def apply_top_k_top_p_optimized(
+    logits: torch.Tensor,
+    k: Optional[torch.Tensor],
+    p: Optional[torch.Tensor],
+    max_select_k: int = 8192,
+) -> torch.Tensor:
+    """Sort-free top-k + top-p, mathematically identical to
+    :func:`apply_top_k_top_p` (same surviving token set, bit-identical probs).
+
+    Two strategies, picked by whether a small top-k window is available:
+
+    1. ``k`` given and ``max(k) <= max_select_k``: a single
+       ``topk(select_k)`` (select_k << V) yields a window that provably
+       contains every row's kept set, so top-p only needs a sorted cumsum over
+       that window. Exact, because the softmax over the window equals the
+       softmax over the full vocab once everything outside the top-k is -inf.
+    2. otherwise (``k`` is None, or top-k is effectively disabled -- vLLM
+       encodes that as ``k == vocab_size``): there is no bounded window, so use
+       ``kunlun_ops.top_p_renorm_probs``, which computes the top-p cutoff
+       without sorting.
+
+    NOTE: do NOT approximate case 2 by truncating to a fixed window. Measured
+    on vocab=151936: with ``p=0.9`` the exact kept set is ~6700 tokens/row, a
+    256-wide window keeps 171 (probs error 2e-1) and even a 4096-wide window
+    keeps 1877 (5e-2). For a flatter distribution the exact set is >100k.
+    """
+    if p is None:
+        if k is None:
+            return logits
+        # Avoid sorting vocab for top-k only case.
+        return apply_top_k_only(logits, k)
+
+    if k is not None:
+        select_k = min(int(k.max().item()), logits.shape[1])
+        if select_k <= max_select_k:
+            return _top_k_top_p_partial_sort(logits, k, p, select_k)
+        logits = kunlun_ops.top_k_mask_logits(logits, k)
+
+    renorm = kunlun_ops.top_p_renorm_probs(
+        logits.softmax(dim=-1, dtype=torch.float32), p
+    )
+    return logits.masked_fill_(renorm == 0, float("-inf"))
+
+
+def _top_k_top_p_partial_sort(
+    logits: torch.Tensor,
+    k: torch.Tensor,
+    p: torch.Tensor,
+    select_k: int,
+) -> torch.Tensor:
+    batch, vocab_size = logits.shape
+    # [batch, select_k], descending.
+    topk_vals, topk_idx = logits.topk(select_k, dim=1, largest=True, sorted=True)
+
+    # Apply top-k inside the window (k is a 1-based count).
+    k_thresh = topk_vals.gather(1, (k.to(torch.long) - 1).unsqueeze(1))
+    topk_vals.masked_fill_(topk_vals < k_thresh, -float("inf"))
+
+    # Apply top-p on the window. Descending exclusive cumsum >= p is the same
+    # cut as the ascending ``cumsum <= 1 - p`` used by the sort implementation.
+    probs_sort = topk_vals.softmax(dim=-1)
+    probs_cumsum = probs_sort.cumsum(dim=-1)
+    top_p_mask = (probs_cumsum - probs_sort) >= p.unsqueeze(1)
+    top_p_mask[:, 0] = False  # keep at least one token
+    topk_vals.masked_fill_(top_p_mask, -float("inf"))
+
+    out = logits.new_full((batch, vocab_size), -float("inf"))
+    out.scatter_(1, topk_idx, topk_vals)
+    return out
+
+
 def apply_top_k_only(
     logits: torch.Tensor,
     k: torch.Tensor,

--- a/vllm_kunlun/v1/sample/rejection_sampler.py
+++ b/vllm_kunlun/v1/sample/rejection_sampler.py
@@ -7,18 +7,24 @@ from collections.abc import Sequence
 from dataclasses import replace
 from typing import TYPE_CHECKING, Optional
 
+import kunlun_ops
 import torch
 import torch.nn as nn
+import xspeedgate_ops  # noqa: F401  (registers torch.ops.xspeedgate_ops)
 from vllm.logger import init_logger
 from vllm.v1.outputs import LogprobsLists, LogprobsTensors, SamplerOutput
 from vllm.v1.sample.logits_processor.builtin import MinTokensLogitsProcessor
 from vllm.v1.sample.metadata import SamplingMetadata
 from vllm.v1.sample.ops.bad_words import apply_bad_words_with_drafts
 from vllm.v1.sample.ops.penalties import apply_all_penalties
-from vllm.v1.sample.ops.topk_topp_sampler import apply_top_k_top_p
 from vllm.v1.sample.sampler import Sampler
 from vllm.v1.spec_decode.metadata import SpecDecodeMetadata
 from vllm.v1.spec_decode.utils import unconditional_to_conditional_rates
+
+# NOTE: upstream's ``apply_top_k_top_p`` dispatches to a Triton kernel once
+# ``logits.shape[0] >= 8`` (see vllm .../topk_topp_sampler.py:311), which aborts
+# on XPU with CUDA_ERROR_NOT_SUPPORTED. Use the Kunlun implementation instead.
+from vllm_kunlun.v1.sample.ops.topk_topp_sampler import apply_top_k_top_p_optimized
 
 if TYPE_CHECKING:
     from vllm.config.speculative import SpeculativeConfig
@@ -432,31 +438,23 @@ def rejection_sample(
         is_greedy = None
     else:
         is_greedy = sampling_metadata.temperature == GREEDY_TEMPERATURE
+
+    # The kunlun ops take a 1-D bonus token tensor.
+    bonus_token_ids_1d = (
+        bonus_token_ids.squeeze(1) if bonus_token_ids.ndim == 2 else bonus_token_ids
+    )
     if not sampling_metadata.all_random:
         # Rejection sampling for greedy sampling requests.
         target_argmax = target_logits.argmax(dim=-1)
-        if (
-            min(num_draft_tokens) == 1
-            and max(num_draft_tokens) == 1
-            and sampling_metadata.all_greedy
-        ):
-            rejection_greedy_sample_spec_len_1_pytorch(
-                output_token_ids,
-                draft_token_ids,
-                target_argmax,
-                bonus_token_ids,
-            )
-        else:
-            rejection_greedy_sample_pytorch(
-                output_token_ids,
-                cu_num_draft_tokens,
-                draft_token_ids,
-                target_argmax,
-                bonus_token_ids,
-                num_draft_tokens,
-                max_spec_len,
-                is_greedy,
-            )
+        kunlun_ops.rejection_greedy_sample(
+            output_token_ids,
+            cu_num_draft_tokens,
+            draft_token_ids,
+            target_argmax,
+            bonus_token_ids_1d,
+            is_greedy,
+            max_spec_len,
+        )
         if sampling_metadata.all_greedy:
             return output_token_ids
 
@@ -487,19 +485,21 @@ def rejection_sample(
         device,
     )
 
-    rejection_random_sample_pytorch(
+    kunlun_ops.rejection_random_sample(
         output_token_ids,
         cu_num_draft_tokens,
         draft_token_ids,
         draft_probs,
         target_probs,
-        bonus_token_ids,
+        bonus_token_ids_1d,
         recovered_token_ids,
         uniform_probs,
         is_greedy,
         max_spec_len,
         vocab_size,
-        IS_NGRAM=draft_probs is None,
+        no_draft_probs=draft_probs is None,
+        threshold_single=1.0,
+        draft_prob_val=1.0,
     )
     return output_token_ids
 
@@ -545,7 +545,7 @@ def apply_sampling_constraints(
     top_k = None
     if sampling_metadata.top_k is not None:
         top_k = expand_batch_to_tokens(
-            sampling_metadata.top_k,
+            sampling_metadata.top_k.to(torch.int32),
             cu_num_draft_tokens,
             num_tokens,
         )
@@ -557,9 +557,11 @@ def apply_sampling_constraints(
             num_tokens,
         )
 
-    # NOTE(woosuk): `apply_top_k_top_p` uses sorting to calculate the mask,
-    # which is slow for large vocab sizes. This may cause performance issues.
-    return apply_top_k_top_p(logits, top_k, top_p)
+    # Apply top-k / top-p. The sort-based path is O(T*V*logV) and materializes a
+    # full int64 index tensor; with MTP T is ``batch * (num_spec + 1)``, so it
+    # dominates the step at high concurrency. ``apply_top_k_top_p_optimized``
+    # gives the identical result without a full-vocab sort.
+    return apply_top_k_top_p_optimized(logits, top_k, top_p)
 
 
 def expand_batch_to_tokens(
@@ -591,14 +593,19 @@ def expand_batch_to_tokens(
     batch_size = x.shape[0]
     assert cu_num_tokens.shape[0] == batch_size
     expanded_x = x.new_empty(num_tokens)
-    expand_pytorch(
-        expanded_x,
-        x,
-        cu_num_tokens,
-        replace_from,
-        replace_to,
-        MAX_NUM_TOKENS=MAX_SPEC_LEN,  # To avoid recompilation.
-    )
+    if x.dtype in (torch.int32, torch.float32):
+        kunlun_ops.expand_tokens(expanded_x, x, cu_num_tokens, replace_from, replace_to)
+    else:
+        # ``expand_pytorch`` loops per request on the host; only reachable for
+        # dtypes the kernel does not take.
+        expand_pytorch(
+            expanded_x,
+            x,
+            cu_num_tokens,
+            replace_from,
+            replace_to,
+            MAX_NUM_TOKENS=MAX_SPEC_LEN,  # To avoid recompilation.
+        )
     return expanded_x
 
 
@@ -674,15 +681,15 @@ def sample_recovered_tokens(
         dtype=torch.float32,
         device=device,
     )
-    q.exponential_()
+    torch.ops.xspeedgate_ops.inplace_exponential(q)
     for i, generator in sampling_metadata.generators.items():
         # Do not generate random numbers for requests with no draft tokens.
         # This can be important for reproducibility.
         if num_draft_tokens[i] > 0:
-            q[i].exponential_(generator=generator)
+            torch.ops.xspeedgate_ops.inplace_exponential(q[i], generator=generator)
 
     recovered_token_ids = torch.empty_like(draft_token_ids)
-    sample_recovered_tokens_pytorch(
+    kunlun_ops.sample_recovered_tokens(
         recovered_token_ids,
         cu_num_draft_tokens,
         draft_token_ids,
@@ -690,7 +697,7 @@ def sample_recovered_tokens(
         target_probs,
         q,
         vocab_size,
-        IS_NGRAM=draft_probs is None,
+        no_draft_probs=draft_probs is None,
     )
     return recovered_token_ids
 

--- a/vllm_kunlun/v1/sample/rejection_sampler.py
+++ b/vllm_kunlun/v1/sample/rejection_sampler.py
@@ -1,21 +1,35 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-from typing import Optional
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import replace
+from typing import TYPE_CHECKING, Optional
 
 import torch
 import torch.nn as nn
 from vllm.logger import init_logger
+from vllm.v1.outputs import LogprobsLists, LogprobsTensors, SamplerOutput
+from vllm.v1.sample.logits_processor.builtin import MinTokensLogitsProcessor
 from vllm.v1.sample.metadata import SamplingMetadata
+from vllm.v1.sample.ops.bad_words import apply_bad_words_with_drafts
+from vllm.v1.sample.ops.penalties import apply_all_penalties
 from vllm.v1.sample.ops.topk_topp_sampler import apply_top_k_top_p
+from vllm.v1.sample.sampler import Sampler
 from vllm.v1.spec_decode.metadata import SpecDecodeMetadata
+from vllm.v1.spec_decode.utils import unconditional_to_conditional_rates
+
+if TYPE_CHECKING:
+    from vllm.config.speculative import SpeculativeConfig
 
 logger = init_logger(__name__)
 
 PLACEHOLDER_TOKEN_ID = -1
-GREEDY_TEMPERATURE = -1
+GREEDY_TEMPERATURE = 0
 # Maximum number of speculative draft tokens allowed per request in a single
 # step. This value is chosen to be large enough to handle typical use cases.
-MAX_SPEC_LEN = 32
+MAX_SPEC_LEN = 128
 
 
 class RejectionSampler(nn.Module):
@@ -41,17 +55,47 @@ class RejectionSampler(nn.Module):
         output tokens = accepted tokens + recovered tokens + bonus tokens
     """
 
+    def __init__(
+        self,
+        sampler: Sampler,
+        spec_config: Optional["SpeculativeConfig"] = None,
+        device: Optional[torch.device] = None,
+    ):
+        super().__init__()
+        self.sampler = sampler
+        logprobs_mode = self.sampler.logprobs_mode
+        self.is_processed_logprobs_mode = logprobs_mode.startswith("processed")
+        self.is_logits_logprobs_mode = logprobs_mode.endswith("logits")
+
+        self.synthetic_conditional_rates: Optional[torch.Tensor] = None
+        if (
+            spec_config is not None
+            and getattr(spec_config, "rejection_sample_method", None) == "synthetic"
+        ):
+            assert spec_config.synthetic_acceptance_rates is not None
+            self.synthetic_conditional_rates = torch.tensor(
+                unconditional_to_conditional_rates(
+                    spec_config.synthetic_acceptance_rates
+                ),
+                dtype=torch.float32,
+                device=device,
+            )
+        self.synthetic_mode = self.synthetic_conditional_rates is not None
+        if self.synthetic_mode:
+            raise NotImplementedError(
+                "Synthetic rejection sampling is not supported on the Kunlun "
+                "PyTorch fallback backend."
+            )
+
     def forward(
         self,
         metadata: SpecDecodeMetadata,
         # [num_tokens, vocab_size]
         draft_probs: Optional[torch.Tensor],
-        # [num_tokens, vocab_size]
-        target_logits: torch.Tensor,
-        # [batch_size, 1]
-        bonus_token_ids: torch.Tensor,
+        # [num_tokens + batch_size, vocab_size]
+        logits: torch.Tensor,
         sampling_metadata: SamplingMetadata,
-    ) -> torch.Tensor:
+    ) -> SamplerOutput:
         """
         Args:
             metadata:
@@ -60,32 +104,65 @@ class RejectionSampler(nn.Module):
                 Probability distribution for the draft tokens. Shape is
                 [num_tokens, vocab_size]. Can be None if probabilities are
                 not provided, which is the case for ngram spec decode.
-            target_logits (torch.Tensor):
+            logits (torch.Tensor):
                 Target model's logits probability distribution.
-                Shape is [num_tokens, vocab_size]. Here, probabilities from
-                different requests are flattened into a single tensor because
-                this is the shape of the output logits.
-                NOTE: `target_logits` can be updated in place to save memory.
-            bonus_token_ids_tensor (torch.Tensor):
-                A tensor containing bonus tokens. Shape is [batch_size, 1].
-                Bonus tokens are added to the end of the sequence if all
-                proposed tokens are accepted. We generate the bonus tokens
-                outside of the rejection sampler with the default sampling
-                strategy. It allows for more flexibility in the sampling
-                process such as top_p, top_k sampling.
+                Shape is [num_tokens + batch_size, vocab_size]. Here,
+                probabilities from different requests are flattened into a
+                single tensor because this is the shape of the output logits.
+                NOTE: `logits` can be updated in place to save memory.
             sampling_metadata (vllm.v1.sample.metadata.SamplingMetadata):
                 Additional metadata needed for sampling, such as temperature,
                 top-k/top-p parameters, or other relevant information.
         Returns:
-            output_token_ids (torch.Tensor):
-                A tensor containing the final output token IDs.
+            SamplerOutput:
+                Contains the final output token IDs and their logprobs if
+                requested.
         """
         assert metadata.max_spec_len <= MAX_SPEC_LEN
+
+        bonus_logits_indices = metadata.bonus_logits_indices
+        target_logits_indices = metadata.target_logits_indices
+
+        # When indexing with a tensor (bonus_logits_indices), PyTorch
+        # creates a new tensor with separate storage from the original
+        # logits tensor. This means any in-place operations on bonus_logits
+        # won't affect the original logits tensor.
+        assert logits is not None
+        bonus_logits = logits[bonus_logits_indices]
+        bonus_sampler_output = self.sampler(
+            logits=bonus_logits,
+            sampling_metadata=replace(
+                sampling_metadata,
+                max_num_logprobs=-1,
+            ),
+            predict_bonus_token=True,
+            # Override the logprobs mode to return logits because they are
+            # needed later to compute the accepted token logprobs.
+            logprobs_mode_override=(
+                "processed_logits" if self.is_processed_logprobs_mode else "raw_logits"
+            ),
+        )
+        bonus_token_ids = bonus_sampler_output.sampled_token_ids
+
+        # Just like `bonus_logits`, `target_logits` is a new tensor with
+        # separate storage from the original `logits` tensor. Therefore,
+        # it is safe to update `target_logits` in place.
+        raw_target_logits = logits[target_logits_indices]
+        # Use float32 for the target_logits.
+        raw_target_logits = raw_target_logits.to(torch.float32)
+        target_logits = raw_target_logits
+        if not self.is_processed_logprobs_mode:
+            # Clone raw_target_logits before applying processors to preserve
+            # the original raw logits for logprobs computation, since
+            # apply_logits_processors modifies the tensor in-place.
+            target_logits = target_logits.clone()
+        target_logits = self.apply_logits_processors(
+            target_logits, sampling_metadata, metadata
+        )
         # [num_tokens, vocab_size]
         # NOTE(woosuk): `target_logits` can be updated in place inside the
-        # `compute_probs` function.
-
-        target_probs = compute_probs(
+        # `apply_sampling_constraints` function.
+        target_logits = apply_sampling_constraints(
             target_logits,
             metadata.cu_num_draft_tokens,
             sampling_metadata,
@@ -97,26 +174,92 @@ class RejectionSampler(nn.Module):
             metadata.max_spec_len,
             metadata.cu_num_draft_tokens,
             draft_probs,
-            target_probs,
+            target_logits,
             bonus_token_ids,
             sampling_metadata,
         )
-        return output_token_ids
+
+        logprobs_tensors = None
+        if sampling_metadata.max_num_logprobs is not None:
+            logprobs_tensors = self._get_logprobs_tensors(
+                sampling_metadata.max_num_logprobs,
+                metadata,
+                logits,
+                target_logits if self.is_processed_logprobs_mode else raw_target_logits,
+                bonus_sampler_output.logprobs_tensors.logprobs,
+                output_token_ids,
+            )
+
+        return SamplerOutput(
+            sampled_token_ids=output_token_ids,
+            logprobs_tensors=logprobs_tensors,
+        )
+
+    def _get_logprobs_tensors(
+        self,
+        max_num_logprobs: int,
+        metadata: SpecDecodeMetadata,
+        logits: torch.Tensor,
+        target_logits: torch.Tensor,
+        bonus_logits: torch.Tensor,
+        sampled_token_ids: torch.Tensor,
+    ) -> LogprobsTensors:
+        cu_num_sampled_tokens = torch.zeros_like(metadata.cu_num_sampled_tokens)
+        cu_num_sampled_tokens[1:] = metadata.cu_num_sampled_tokens[:-1]
+
+        # Collect target and bonus logits.
+        bonus_logits_indices = metadata.bonus_logits_indices
+        target_logits_indices = metadata.target_logits_indices
+        final_logits = torch.zeros_like(logits, dtype=torch.float32)
+        final_logits[target_logits_indices] = target_logits.to(torch.float32)
+        final_logits[bonus_logits_indices] = bonus_logits.to(torch.float32)
+
+        # NOTE: To avoid cpu-gpu synchronization, we now simply compute indices
+        # for all draft tokens, including the rejected ones. The rejected tokens
+        # will be filtered out in the `parse_output`.
+        logit_start_indices = cu_num_sampled_tokens
+        offsets = torch.arange(
+            sampled_token_ids.shape[-1],
+            device=logit_start_indices.device,
+            dtype=logit_start_indices.dtype,
+        )
+        accepted_logit_indices = (
+            logit_start_indices.unsqueeze(1) + offsets.unsqueeze(0)
+        ).flatten()
+        accepted_logit_indices.clamp_(max=final_logits.shape[0] - 1)
+        accepted_tokens = sampled_token_ids.clone().flatten()
+        # we replace rejected token ids with 0 to avoid gather_logprobs error
+        accepted_tokens[accepted_tokens == PLACEHOLDER_TOKEN_ID] = 0
+
+        # Compute logprobs for accepted tokens.
+        accepted_logits = final_logits[accepted_logit_indices]
+        accepted_logprobs = (
+            accepted_logits
+            if self.is_logits_logprobs_mode
+            else self.sampler.compute_logprobs(accepted_logits)
+        )
+        return self.sampler.gather_logprobs(
+            accepted_logprobs,
+            max_num_logprobs,
+            accepted_tokens.to(torch.int64),
+        )
 
     @staticmethod
     def parse_output(
         output_token_ids: torch.Tensor,
         vocab_size: int,
-    ) -> list[list[int]]:
+        discard_req_indices: Sequence[int] = (),
+        logprobs_tensors: Optional[LogprobsTensors] = None,
+    ) -> tuple[list[list[int]], Optional[LogprobsLists]]:
         """Parse the output of the rejection sampler.
-
         Args:
             output_token_ids: The sampled token IDs in shape
                 [batch_size, max_spec_len + 1]. The rejected tokens are
                 replaced with `PLACEHOLDER_TOKEN_ID` by the rejection sampler
                 and will be filtered out in this function.
             vocab_size: The size of the vocabulary.
-
+            discard_req_indices: Optional row indices to discard tokens in.
+            logprobs_tensors: Optional logprobs tensors to filter.
         Returns:
             A list of lists of token IDs.
         """
@@ -125,10 +268,126 @@ class RejectionSampler(nn.Module):
         valid_mask = (output_token_ids_np != PLACEHOLDER_TOKEN_ID) & (
             output_token_ids_np < vocab_size
         )
+        output_logprobs = None
+        if logprobs_tensors is not None:
+            cu_num_tokens = [0] + valid_mask.sum(axis=1).cumsum().tolist()
+            filtered_tensors = logprobs_tensors.filter(valid_mask.flatten())
+            output_logprobs = filtered_tensors.tolists(cu_num_tokens)
+
+        if len(discard_req_indices) > 0:
+            valid_mask[discard_req_indices] = False
         outputs = [
             row[valid_mask[i]].tolist() for i, row in enumerate(output_token_ids_np)
         ]
-        return outputs
+        return outputs, output_logprobs
+
+    def apply_logits_processors(
+        self,
+        logits: torch.Tensor,
+        sampling_metadata: SamplingMetadata,
+        metadata: SpecDecodeMetadata,
+    ) -> torch.Tensor:
+        has_penalties = not sampling_metadata.no_penalties
+        any_penalties_or_bad_words = (
+            sampling_metadata.bad_words_token_ids or has_penalties
+        )
+        holder = sampling_metadata.thinking_budget_state_holder
+        needs_thinking = holder is not None and holder.has_tracked_requests()
+
+        output_token_ids = sampling_metadata.output_token_ids
+        if any_penalties_or_bad_words or needs_thinking:
+            output_token_ids = self._combine_outputs_with_spec_tokens(
+                output_token_ids,
+                sampling_metadata.spec_token_ids,
+            )
+
+        # Calculate indices of target logits.
+        repeat_indices: Optional[torch.Tensor] = None
+        need_repeat_indices = (
+            sampling_metadata.allowed_token_ids_mask is not None
+            or has_penalties
+            or needs_thinking
+        )
+        if need_repeat_indices:
+            num_requests = len(metadata.num_draft_tokens)
+            num_draft_tokens = torch.tensor(metadata.num_draft_tokens, device="cpu")
+            original_indices = torch.arange(num_requests, device="cpu")
+            repeat_indices_cpu = original_indices.repeat_interleave(num_draft_tokens)
+            repeat_indices = repeat_indices_cpu.to(
+                device=logits.device, non_blocking=True
+            )
+            logits = self.apply_penalties(
+                logits, sampling_metadata, metadata, repeat_indices, output_token_ids
+            )
+
+            # Apply allowed token ids.
+            if sampling_metadata.allowed_token_ids_mask is not None:
+                token_mask = sampling_metadata.allowed_token_ids_mask[repeat_indices]
+                logits.masked_fill_(token_mask, float("-inf"))
+
+        # Apply bad words exclusion.
+        if bad_words_token_ids := sampling_metadata.bad_words_token_ids:
+            apply_bad_words_with_drafts(
+                logits, bad_words_token_ids, output_token_ids, metadata.num_draft_tokens
+            )
+
+        for processor in sampling_metadata.logitsprocs.non_argmax_invariant:
+            if isinstance(processor, MinTokensLogitsProcessor):
+                logits = processor.apply_with_spec_decode(
+                    logits, metadata.num_draft_tokens
+                )
+        if holder is not None and holder.has_tracked_requests():
+            logits = holder.apply_to_logits(
+                logits,
+                predict_bonus_token=False,
+                spec_token_ids=sampling_metadata.spec_token_ids,
+            )
+        return logits
+
+    @staticmethod
+    def apply_penalties(
+        logits: torch.Tensor,
+        sampling_metadata: SamplingMetadata,
+        metadata: SpecDecodeMetadata,
+        repeat_indices: torch.Tensor,
+        output_token_ids: list[list[int]],
+    ) -> torch.Tensor:
+        if sampling_metadata.no_penalties:
+            return logits
+
+        assert sampling_metadata.prompt_token_ids is not None
+
+        prompt_token_ids = sampling_metadata.prompt_token_ids[repeat_indices]
+        presence_penalties = sampling_metadata.presence_penalties[repeat_indices]
+        frequency_penalties = sampling_metadata.frequency_penalties[repeat_indices]
+        repetition_penalties = sampling_metadata.repetition_penalties[repeat_indices]
+
+        logits = apply_all_penalties(
+            logits,
+            prompt_token_ids,
+            presence_penalties,
+            frequency_penalties,
+            repetition_penalties,
+            output_token_ids,
+        )
+        return logits
+
+    @staticmethod
+    def _combine_outputs_with_spec_tokens(
+        output_token_ids: list[list[int]],
+        spec_token_ids: Optional[list[list[int]]] = None,
+    ) -> list[list[int]]:
+        if spec_token_ids is None:
+            return output_token_ids
+
+        result = []
+        for out, spec in zip(output_token_ids, spec_token_ids):
+            if len(spec) == 0:
+                continue
+            result.append(out)
+            for i in range(len(spec) - 1):
+                result.append([*result[-1], spec[i]])
+        return result
 
 
 def rejection_sample(
@@ -142,7 +401,7 @@ def rejection_sample(
     # [num_tokens, vocab_size]
     draft_probs: Optional[torch.Tensor],
     # [num_tokens, vocab_size]
-    target_probs: torch.Tensor,
+    target_logits: torch.Tensor,
     # [batch_size, 1]
     bonus_token_ids: torch.Tensor,
     sampling_metadata: SamplingMetadata,
@@ -150,17 +409,16 @@ def rejection_sample(
     assert draft_token_ids.ndim == 1
     assert draft_probs is None or draft_probs.ndim == 2
     assert cu_num_draft_tokens.ndim == 1
-    assert target_probs.ndim == 2
+    assert target_logits.ndim == 2
 
     batch_size = len(num_draft_tokens)
     num_tokens = draft_token_ids.shape[0]
-    vocab_size = target_probs.shape[-1]
-    device = target_probs.device
+    vocab_size = target_logits.shape[-1]
+    device = target_logits.device
     assert draft_token_ids.is_contiguous()
     assert draft_probs is None or draft_probs.is_contiguous()
-    assert target_probs.is_contiguous()
     assert bonus_token_ids.is_contiguous()
-    assert target_probs.shape == (num_tokens, vocab_size)
+    assert target_logits.shape == (num_tokens, vocab_size)
 
     # Create output buffer.
     output_token_ids = torch.empty(
@@ -176,7 +434,7 @@ def rejection_sample(
         is_greedy = sampling_metadata.temperature == GREEDY_TEMPERATURE
     if not sampling_metadata.all_random:
         # Rejection sampling for greedy sampling requests.
-        target_argmax = target_probs.argmax(dim=-1)
+        target_argmax = target_logits.argmax(dim=-1)
         if (
             min(num_draft_tokens) == 1
             and max(num_draft_tokens) == 1
@@ -211,6 +469,11 @@ def rejection_sample(
         device,
     )
 
+    # Compute probability distribution from target logits.
+    # [num_tokens, vocab_size]
+    target_probs = target_logits.softmax(dim=-1, dtype=torch.float32)
+    assert target_probs.is_contiguous()
+
     # Sample recovered tokens for each position.
     # [num_tokens]
     recovered_token_ids = sample_recovered_tokens(
@@ -237,32 +500,30 @@ def rejection_sample(
         max_spec_len,
         vocab_size,
         IS_NGRAM=draft_probs is None,
-        # num_warps=1,
     )
     return output_token_ids
 
 
-def compute_probs(
+def apply_sampling_constraints(
     logits: torch.Tensor,  # [num_tokens, vocab_size]
     cu_num_draft_tokens: torch.Tensor,  # [batch_size]
     sampling_metadata: SamplingMetadata,
 ) -> torch.Tensor:
-    """Compute probability distribution from logits based on sampling metadata.
+    """Process logits based on sampling metadata.
 
-    This function applies temperature scaling to the logits and converts
-    them to probabilities using softmax. For greedy decoding, it returns
+    This function applies temperature scaling to the logits,
+    as well as top-k and top-p. For greedy decoding, it returns
     the original logits.
 
     Args:
-        logits: Input logits tensor to be converted to probabilities.
+        logits: Input logits tensor to be processed.
         cu_num_draft_tokens: Cumulative number of draft tokens.
         sampling_metadata: Metadata containing sampling parameters such as
             temperature and whether greedy sampling is used.
 
     Returns:
-        torch.Tensor: Probability distribution (softmax of scaled logits)
-            if non-greedy sampling is used, otherwise returns the
-            original logits.
+        torch.Tensor: Processed logits if non-greedy sampling is used,
+        otherwise returns the original logits.
     """
     assert logits.ndim == 2
     assert cu_num_draft_tokens.ndim == 1
@@ -298,9 +559,7 @@ def compute_probs(
 
     # NOTE(woosuk): `apply_top_k_top_p` uses sorting to calculate the mask,
     # which is slow for large vocab sizes. This may cause performance issues.
-    logits = apply_top_k_top_p(logits, top_k, top_p)
-    output_prob = logits.softmax(dim=-1, dtype=torch.float32)
-    return output_prob
+    return apply_top_k_top_p(logits, top_k, top_p)
 
 
 def expand_batch_to_tokens(

--- a/vllm_kunlun/v1/sample/spec_decode/eagle.py
+++ b/vllm_kunlun/v1/sample/spec_decode/eagle.py
@@ -2,8 +2,16 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Kunlun overrides for the EAGLE / MTP speculative-decode proposer."""
 
+import os
+from dataclasses import replace
+
 import numpy as np
 import torch
+from vllm.compilation import monitor
+from vllm.compilation.cuda_graph import CUDAGraphWrapper
+from vllm.config import CUDAGraphMode
+from vllm.distributed.parallel_state import graph_capture
+from vllm.forward_context import get_forward_context, is_forward_context_available
 from vllm.logger import init_logger
 from vllm.v1.attention.backends.utils import CommonAttentionMetadata
 from vllm.v1.spec_decode.eagle import EagleProposer
@@ -20,6 +28,27 @@ _orig_update_positions_dependent_metadata = (
     EagleProposer._update_positions_dependent_metadata
 )
 _orig_eagle_init = EagleProposer.__init__
+_orig_load_model = EagleProposer.load_model
+
+# NOTE: the drafter is still restricted to PIECEWISE cudagraphs upstream
+# (llm_base_proposer.py::initialize_cudagraph_keys). That was originally a
+# *correctness* requirement: ``CUDAGraphWrapper`` never copies runtime inputs
+# into persistent buffers, and the drafter rebuilt its attention metadata from
+# freshly allocated tensors on every step
+# (``build_per_group_and_layer_attn_metadata``), so a FULL graph baked in those
+# pointers and replays read stale slot mappings / state indices. Measured effect
+# when this was attempted: acceptance rate collapsed from ~60% to 2.95%
+# (acceptance length 1.06) while the step got slower.
+#
+# The metadata addresses are stable now (``KunlunAttentionMetadataBuilder.build``
+# stages every lod / seq-len field, host *and* device, into persistent buffers),
+# and the kernels were measured to be graph-safe: under capture/replay
+# ``speculative_attention`` follows the *device* ``context_lens`` (changing only
+# the host mirror has no effect, and replay is bit-exact across block-count
+# changes in both directions), and ``reshape_and_cache_flash`` follows the
+# runtime slot mapping including the -1 padding. So the opt-in path below exists;
+# it is still off by default and must be validated with the per-position
+# acceptance rate, not just address stability.
 
 
 def _is_qwen35_mtp(self) -> bool:
@@ -184,32 +213,41 @@ def _update_positions_dependent_metadata(
     cad = common_attn_metadata
     positions_1d = positions[0] if self.uses_mrope else positions
 
-    new_position = positions_1d + 1
-    exceeds_max = new_position >= self.max_model_len
-    clamped_position = torch.where(
-        exceeds_max, torch.zeros_like(new_position), new_position
-    )
-
-    n_blocks_per_req = cad.block_table_tensor.shape[1]
-    block_number = (clamped_position // block_size).clamp(max=n_blocks_per_req - 1)
-    block_id = cad.block_table_tensor.gather(
-        dim=1, index=block_number.view(-1, 1)
-    ).view(-1)
-    slot = block_id * block_size + (clamped_position % block_size)
-    slot = torch.where(exceeds_max, torch.full_like(slot, PADDING_SLOT_ID), slot)
-
-    new_seq_lens = torch.where(
-        exceeds_max, torch.ones_like(cad.seq_lens), cad.seq_lens + 1
-    ).clamp(max=self.max_model_len)
-    cad.seq_lens.copy_(new_seq_lens)
-
+    # Pick the destination buffer up front so ``positions + 1`` can be written
+    # straight into it.
+    #
+    # PERF: every op here is a separate dispatch, and the drafter runs this once
+    # per draft step at batch 1, where the tensors are a handful of elements --
+    # so the cost is pure dispatch overhead, not compute. Profiling showed this
+    # function alone issuing 167 of the ~1140 eager ops in one ``propose`` (the
+    # single largest contributor). The in-place / ``out=`` forms below avoid the
+    # ``zeros_like`` / ``full_like`` / ``ones_like`` temporaries and the extra
+    # ``copy_`` that the straightforward version needs.
     if self.uses_mrope:
         out_pos = self.mrope_positions[0, :batch_size]
     elif self.uses_xdrope_dim > 0 and self.draft_uses_xdrope_dim > 0:
         out_pos = self.xdrope_positions[0, :batch_size]
     else:
         out_pos = self.positions[:batch_size]
-    out_pos.copy_(clamped_position)
+
+    # positions + 1, with out-of-range entries folded to 0; their slot is set to
+    # PADDING_SLOT_ID below, so the value itself does not matter.
+    torch.add(positions_1d, 1, out=out_pos)
+    exceeds_max = out_pos >= self.max_model_len
+    out_pos.masked_fill_(exceeds_max, 0)
+    clamped_position = out_pos
+
+    n_blocks_per_req = cad.block_table_tensor.shape[1]
+    block_number = clamped_position.div(block_size, rounding_mode="floor")
+    block_number.clamp_(max=n_blocks_per_req - 1)
+    # gather() returns a fresh tensor, so the slot arithmetic can run in place.
+    slot = cad.block_table_tensor.gather(dim=1, index=block_number.view(-1, 1)).view(-1)
+    slot = slot.mul_(block_size).add_(clamped_position.remainder(block_size))
+    slot.masked_fill_(exceeds_max, PADDING_SLOT_ID)
+
+    # seq_lens += 1, reset to 1 where out of range, then clamp -- in place on
+    # cad.seq_lens instead of building a new tensor and copying it back.
+    cad.seq_lens.add_(1).masked_fill_(exceeds_max, 1).clamp_(max=self.max_model_len)
 
     self._slot_mapping_buffer[:batch_size].copy_(slot)
     if input_batch_size > batch_size:
@@ -217,13 +255,13 @@ def _update_positions_dependent_metadata(
     cad.slot_mapping = self._slot_mapping_buffer[:batch_size]
 
     if self.uses_mrope:
-        self.mrope_positions[1:, :batch_size] = self.mrope_positions[0, :batch_size]
+        self.mrope_positions[1:, :batch_size] = out_pos
         positions = self.mrope_positions[:, :batch_size]
     elif self.uses_xdrope_dim > 0 and self.draft_uses_xdrope_dim > 0:
-        self.xdrope_positions[1:, :batch_size] = self.xdrope_positions[0, :batch_size]
+        self.xdrope_positions[1:, :batch_size] = out_pos
         positions = self.xdrope_positions[0, :batch_size]
     else:
-        positions = self.positions[:batch_size]
+        positions = out_pos
 
     cad.max_seq_len = min(cad.max_seq_len + 1, self.max_model_len)
 
@@ -253,3 +291,152 @@ EagleProposer._update_positions_dependent_metadata = (
     _update_positions_dependent_metadata
 )
 EagleProposer.__init__ = _patched_eagle_init
+
+
+# --------------------------------------------------------------------------
+# Experimental: FULL cudagraphs for the drafter. Off unless
+# ``VLLM_KUNLUN_DRAFTER_FULL_CUDAGRAPH=1``.
+#
+# Upstream gives the drafter no FULL path at all: ``initialize_cudagraph_keys``
+# hardcodes PIECEWISE, and ``CUDAGraphWrapper`` is only ever wrapped around the
+# *target* model (gpu_model_runner.py). Capture also cannot go through the
+# drafter's ``dummy_run``: it calls ``set_forward_context(None, ...)``, so the
+# attention layers take the ``attn_metadata is None`` profiling shortcut and a
+# graph captured there would contain no attention at all. The proposer holds no
+# reference to the runner either, so it cannot synthesize capture-time metadata
+# pointing at the runner's persistent ``seq_lens`` / block table -- and those are
+# handed to the kernels unstaged, so their addresses must match capture time.
+# Hence: capture lazily, on a real drafting step, where the real metadata is.
+# --------------------------------------------------------------------------
+
+
+def _drafter_full_cudagraph_enabled() -> bool:
+    return os.getenv("VLLM_KUNLUN_DRAFTER_FULL_CUDAGRAPH", "0") == "1"
+
+
+def _uniform_decode_num_reqs(attn_metadata) -> int | None:
+    """Request count if every attention group is a query-len-1 decode batch.
+
+    ``None`` means "do not use a graph for this call". The first drafter forward
+    in ``propose`` is a mixed prefill/decode batch, and ``KunlunImpl.forward``
+    picks between the prefill and decode kernels on the host from
+    ``num_prefills`` / ``num_decodes``; baking that choice into a graph would
+    silently attend over the wrong rows on a later step with a different split.
+    """
+    if not attn_metadata:
+        return None
+    groups = (
+        attn_metadata.values() if isinstance(attn_metadata, dict) else [attn_metadata]
+    )
+    num_reqs = None
+    for md in groups:
+        if getattr(md, "num_prefills", 1) != 0:
+            return None
+        if getattr(md, "max_decode_seq_len", 0) != 1:
+            return None
+        block_tables = getattr(md, "block_tables", None)
+        if block_tables is None:
+            return None
+        if num_reqs is not None and block_tables.shape[0] != num_reqs:
+            return None
+        num_reqs = block_tables.shape[0]
+    return num_reqs
+
+
+class _DrafterCUDAGraphWrapper(CUDAGraphWrapper):
+    """FULL cudagraphs for the drafter, captured on the first real step.
+
+    Deliberately does *not* touch the cudagraph dispatcher. The dispatcher only
+    sees a token count and always dispatches with ``uniform_decode=False``
+    (llm_base_proposer::_determine_batch_execution_and_padding), so it cannot
+    tell a draft step from the mixed prefill/decode first pass -- and switching
+    its mode to FULL would strip the drafter's PIECEWISE keys, leaving the first
+    pass eager. Instead this wrapper triggers on the PIECEWISE mode the
+    dispatcher already emits and decides per call:
+
+    * mixed batch -> pass through, so the inner piecewise graphs run as before.
+      ``KunlunImpl.forward`` picks between the prefill and decode kernels on the
+      host from ``num_prefills``/``num_decodes``, so baking that choice into a
+      graph would silently attend over the wrong rows on a later step.
+    * uniform query-len-1 decode -> run the whole drafter forward from one FULL
+      graph. The runtime mode is flipped to FULL for the duration so the inner
+      piecewise wrappers see a mode that is not theirs and pass through, rather
+      than trying to capture inside our capture.
+
+    Two more deviations from the base wrapper:
+
+    * The unpadded request count is folded into the cache key. The dispatcher's
+      descriptor only carries the *padded* token count, while what the graph
+      bakes follows the unpadded count (``block_tables.shape[0]`` becomes the
+      kernel's ``batch_num``), so two batch sizes that pad to the same size must
+      not share a graph.
+    * Capture runs inside ``graph_capture()`` (a non-default stream is required)
+      and is followed by an explicit replay: capture executes nothing, so the
+      base wrapper's post-capture return value is uninitialized memory. During
+      warmup that is harmless, but here the caller is a real drafting step.
+    """
+
+    def __init__(self, runnable, vllm_config, device):
+        super().__init__(runnable, vllm_config, CUDAGraphMode.FULL)
+        self._device = device
+
+    def __call__(self, *args, **kwargs):
+        if not is_forward_context_available():
+            return self.runnable(*args, **kwargs)
+
+        ctx = get_forward_context()
+        if (
+            ctx.cudagraph_runtime_mode != CUDAGraphMode.PIECEWISE
+            or ctx.batch_descriptor is None
+        ):
+            return self.runnable(*args, **kwargs)
+
+        num_reqs = _uniform_decode_num_reqs(ctx.attn_metadata)
+        if num_reqs is None:
+            return self.runnable(*args, **kwargs)
+
+        prev_desc = ctx.batch_descriptor
+        desc = replace(prev_desc, num_reqs=num_reqs, uniform=True)
+        entry = self.concrete_cudagraph_entries.get(desc)
+        prev_mode = ctx.cudagraph_runtime_mode
+        prev_enabled = monitor.cudagraph_capturing_enabled
+        ctx.batch_descriptor = desc
+        ctx.cudagraph_runtime_mode = CUDAGraphMode.FULL
+        try:
+            if entry is not None and entry.cudagraph is not None:
+                return super().__call__(*args, **kwargs)
+            monitor.set_cudagraph_capturing_enabled(True)
+            # ``torch.cuda.graph.__enter__`` calls ``torch.cuda.empty_cache()``
+            # (torch/cuda/graphs.py). During warmup that is free; in a live
+            # process it drops the allocator cache and every following
+            # allocation goes back to cudaMalloc. Measured ~40% of the capture
+            # cost, plus the aftermath. vLLM's own ``CUDAGraphOptions.gc_disable``
+            # does not cover this: it patches ``torch.accelerator.empty_cache``,
+            # a different function from the one graphs.py calls. ``gc.collect()``
+            # is already gated off by ``torch.compiler.config.force_cudagraph_gc``.
+            orig_empty_cache = torch.cuda.empty_cache
+            torch.cuda.empty_cache = lambda *a, **kw: None
+            try:
+                with graph_capture(self._device):
+                    super().__call__(*args, **kwargs)
+            finally:
+                torch.cuda.empty_cache = orig_empty_cache
+            entry = self.concrete_cudagraph_entries[desc]
+            entry.cudagraph.replay()
+            logger.info("[KunlunPlugin] drafter captured a FULL cudagraph %s", desc)
+            return entry.output
+        finally:
+            monitor.set_cudagraph_capturing_enabled(prev_enabled)
+            ctx.batch_descriptor = prev_desc
+            ctx.cudagraph_runtime_mode = prev_mode
+
+
+def _patched_load_model(self, target_model) -> None:
+    _orig_load_model(self, target_model)
+    if not _drafter_full_cudagraph_enabled():
+        return
+    self.model = _DrafterCUDAGraphWrapper(self.model, self.vllm_config, self.device)
+    logger.info("[KunlunPlugin] drafter model wrapped for FULL cudagraphs")
+
+
+EagleProposer.load_model = _patched_load_model

--- a/vllm_kunlun/v1/sample/spec_decode/eagle.py
+++ b/vllm_kunlun/v1/sample/spec_decode/eagle.py
@@ -1,332 +1,95 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-from typing import Optional
+"""Kunlun overrides for the EAGLE / MTP speculative-decode proposer."""
 
 import numpy as np
 import torch
-from vllm.forward_context import set_forward_context
 from vllm.logger import init_logger
-from vllm.model_executor.models.llama_eagle3 import Eagle3LlamaForCausalLM
-from vllm.v1.attention.backends.tree_attn import TreeAttentionMetadata
 from vllm.v1.attention.backends.utils import CommonAttentionMetadata
-from vllm.v1.sample.metadata import SamplingMetadata
 from vllm.v1.spec_decode.eagle import EagleProposer
+from vllm.v1.spec_decode.metadata import SpecDecodeMetadata
 from vllm.v1.worker.gpu_input_batch import CachedRequestState, InputBatch
-from vllm.v1.worker.ubatching import dbo_current_ubatch_id
 
 logger = init_logger(__name__)
 
 PADDING_SLOT_ID = -1
 
+_orig_prepare_next_token_ids_padded = EagleProposer.prepare_next_token_ids_padded
+_orig_prepare_inputs_padded = EagleProposer.prepare_inputs_padded
+_orig_update_positions_dependent_metadata = (
+    EagleProposer._update_positions_dependent_metadata
+)
+_orig_eagle_init = EagleProposer.__init__
 
-def propose(
-    self,
-    # [num_tokens]
-    target_token_ids: torch.Tensor,
-    # [num_tokens]
-    target_positions: torch.Tensor,
-    # [num_tokens, hidden_size]
-    target_hidden_states: torch.Tensor,
-    # [batch_size]
-    next_token_ids: torch.Tensor,
-    last_token_indices: Optional[torch.Tensor],
-    common_attn_metadata: CommonAttentionMetadata,
-    sampling_metadata: SamplingMetadata,
-    mm_embeds: Optional[list[torch.Tensor]] = None,
-) -> torch.Tensor:
-    num_tokens = target_token_ids.shape[0]
-    batch_size = next_token_ids.shape[0]
 
-    if last_token_indices is None:
-        last_token_indices = common_attn_metadata.query_start_loc[1:] - 1
-
-    if self.method == "eagle3":
-        assert isinstance(self.model, Eagle3LlamaForCausalLM)
-        target_hidden_states = self.model.combine_hidden_states(target_hidden_states)
-        assert target_hidden_states.shape[-1] == self.hidden_size
-
-    # Shift the input ids by one token.
-    # E.g., [a1, b1, b2, c1, c2, c3] -> [b1, b2, c1, c2, c3, c3]
-    self.input_ids[: num_tokens - 1] = target_token_ids[1:]
-    # Replace the last token with the next token.
-    # E.g., [b1, b2, c1, c2, c3, c3] -> [a2, b2, b3, c2, c3, c4]
-    self.input_ids[last_token_indices] = next_token_ids
-
-    assert self.runner is not None
-
-    ubatch_id = dbo_current_ubatch_id()
-    attn_metadata_builder = self.runner.attn_groups[0][0].metadata_builders[ubatch_id]
-    attn_metadata = attn_metadata_builder.build_for_drafting(
-        common_attn_metadata=common_attn_metadata, draft_index=0
-    )
-    if (
-        hasattr(attn_metadata, "decode")
-        and attn_metadata.decode is not None
-        and hasattr(attn_metadata.decode, "spec_num_seq_len")
-        and attn_metadata.decode.spec_num_seq_len is not None
-    ):
-        attn_metadata.decode.spec_num_seq_len = -1
-
-    if self.draft_indexer_metadata_builder:
-        draft_indexer_metadata = self.draft_indexer_metadata_builder.build_for_drafting(
-            common_attn_metadata=common_attn_metadata,
-            draft_index=0,
-        )
-    else:
-        draft_indexer_metadata = None
-
-    # At this moment, we assume all eagle layers belong to the same KV
-    # cache group, thus using the same attention metadata.
-    per_layer_attn_metadata = {}
-    for layer_name in self.attn_layer_names:
-        per_layer_attn_metadata[layer_name] = attn_metadata
-    for layer_name in self.indexer_layer_names:
-        assert draft_indexer_metadata is not None
-        per_layer_attn_metadata[layer_name] = draft_indexer_metadata
-    if self.use_cuda_graph and num_tokens <= self.cudagraph_batch_sizes[-1]:
-        num_input_tokens = self.vllm_config.pad_for_cudagraph(num_tokens)
-    else:
-        num_input_tokens = num_tokens
-
-    # copy inputs to buffer for cudagraph
-    self.positions[:num_tokens] = target_positions
-    self.hidden_states[:num_tokens] = target_hidden_states
-    if self.is_multimodal_model:
-        input_ids = self.input_ids[:num_tokens]
-        inputs_embeds = self.model.get_input_embeddings(
-            input_ids,
-            multimodal_embeddings=mm_embeds or None,
-        )
-        self.inputs_embeds[:num_tokens] = inputs_embeds
-        inputs_embeds = self.inputs_embeds[:num_input_tokens]
-        input_ids = None
-    else:
-        inputs_embeds = None
-        input_ids = self.input_ids[:num_input_tokens]
-
-    with set_forward_context(
-        per_layer_attn_metadata, self.vllm_config, num_tokens=num_input_tokens
-    ):
-        ret_hidden_states = self.model(
-            input_ids=input_ids,
-            positions=self.positions[:num_input_tokens],
-            hidden_states=self.hidden_states[:num_input_tokens],
-            inputs_embeds=inputs_embeds,
-        )
-        if self.method == "mtp":
-            last_hidden_states = ret_hidden_states
-            hidden_states = self.hidden_states[:num_input_tokens]
-        else:
-            last_hidden_states, hidden_states = ret_hidden_states
-    sample_hidden_states = last_hidden_states[last_token_indices]
-    if self.method == "mtp":
-        logits = self.model.compute_logits(sample_hidden_states, 0)
-    else:
-        logits = self.model.compute_logits(sample_hidden_states, None)
-    positions = target_positions[last_token_indices]
-    hidden_states = hidden_states[last_token_indices]
-
-    if isinstance(attn_metadata, TreeAttentionMetadata):
-        # Draft using tree attention.
-        draft_token_ids_list = self.propose_tree(
-            batch_size=batch_size,
-            logits=logits,
-            positions=positions,
-            hidden_states=hidden_states,
-            common_attn_metadata=common_attn_metadata,
-        )
-        # [batch_size, num_tree_tokens]
-        return torch.cat(draft_token_ids_list, dim=1)
-
-    draft_token_ids = logits.argmax(dim=-1)
-
-    # Early exit if there is only one draft token to be generated.
-    if self.num_speculative_tokens == 1:
-        # [batch_size, 1]
-        return draft_token_ids.view(-1, 1)
-
-    # TODO: Currently, MTP module released by deepseek only has
-    # one layer. Adapt this code to support multiple layers once
-    # there's a multi-layer MTP module.
-
-    # Generate the remaining draft tokens.
-    draft_token_ids_list = [draft_token_ids]
-    if self.use_cuda_graph and batch_size <= self.cudagraph_batch_sizes[-1]:
-        input_batch_size = self.vllm_config.pad_for_cudagraph(batch_size)
-    else:
-        input_batch_size = batch_size
-
-    common_attn_metadata.num_actual_tokens = batch_size
-    common_attn_metadata.max_query_len = 1
-    common_attn_metadata.query_start_loc = self.arange[: batch_size + 1].to(torch.int32)
-    common_attn_metadata.query_start_loc_cpu = (
-        torch.from_numpy(self.token_arange_np[: batch_size + 1]).clone().to(torch.int32)
-    )
-
-    attn_metadata_builder = self.runner.attn_groups[0][0].metadata_builder
-    for token_index in range(self.num_speculative_tokens - 1):
-        # Update the inputs.
-        # cast to int32 is crucial when eagle model is compiled.
-        # tensor.argmax() returns int64 by default.
-        input_ids = draft_token_ids_list[-1].int()
-        positions += 1
-
-        # NOTE(woosuk): We should handle the case where the draft model
-        # generates tokens beyond the max model length. Since it is complex
-        # to remove such requests from the batch, we keep them in the batch
-        # but adjust the position ids and slot mappings to avoid the
-        # out-of-range access during the model execution. The draft tokens
-        # generated with this adjustment should be ignored.
-        exceeds_max_model_len = positions >= self.max_model_len
-        # Mask out the position ids that exceed the max model length.
-        # Otherwise, we may get out-of-range error in RoPE.
-        clamped_positions = torch.where(exceeds_max_model_len, 0, positions)
-
-        # Increment the sequence lengths.
-        common_attn_metadata.seq_lens += 1
-        common_attn_metadata.seq_lens_cpu += 1
-        # For the requests that exceed the max model length, we set the
-        # sequence length to 1 to minimize their overheads in attention.
-        common_attn_metadata.seq_lens.masked_fill_(exceeds_max_model_len, 1)
-        common_attn_metadata.num_computed_tokens_cpu = (
-            common_attn_metadata.seq_lens_cpu - 1
-        )
-
-        # Compute the slot mapping.
-        block_numbers = clamped_positions // self.block_size
-        block_ids = common_attn_metadata.block_table_tensor.gather(
-            dim=1, index=block_numbers.view(-1, 1)
-        )
-        block_ids = block_ids.view(-1)
-        common_attn_metadata.slot_mapping = (
-            block_ids * self.block_size + clamped_positions % self.block_size
-        )
-        # Mask out the slot mappings that exceed the max model length.
-        # Otherwise, the KV cache will be inadvertently updated with the
-        # padding tokens.
-        common_attn_metadata.slot_mapping.masked_fill_(
-            exceeds_max_model_len, PADDING_SLOT_ID
-        )
-
-        attn_metadata = attn_metadata_builder.build_for_drafting(
-            common_attn_metadata=common_attn_metadata, draft_index=token_index + 1
-        )
-        for layer_name in self.attn_layer_names:
-            per_layer_attn_metadata[layer_name] = attn_metadata
-        # copy inputs to buffer for cudagraph
-        self.input_ids[:batch_size] = input_ids
-        self.positions[:batch_size] = clamped_positions
-        self.hidden_states[:batch_size] = hidden_states
-        if self.is_multimodal_model:
-            inputs_embeds = self.model.get_input_embeddings(input_ids)
-            self.inputs_embeds[:batch_size] = inputs_embeds
-            inputs_embeds = self.inputs_embeds[:input_batch_size]
-            input_ids = None
-        else:
-            inputs_embeds = None
-            input_ids = self.input_ids[:input_batch_size]
-
-        # Run the model.
-        with set_forward_context(
-            per_layer_attn_metadata, self.vllm_config, num_tokens=input_batch_size
-        ):
-            ret_hidden_states = self.model(
-                input_ids=input_ids,
-                positions=self.positions[:input_batch_size],
-                hidden_states=self.hidden_states[:input_batch_size],
-                inputs_embeds=inputs_embeds,
-            )
-            if self.method == "mtp":
-                last_hidden_states = ret_hidden_states
-                hidden_states = ret_hidden_states
-            else:
-                last_hidden_states, hidden_states = ret_hidden_states
-
-        hidden_states = hidden_states[:batch_size]
-        logits = self.model.compute_logits(last_hidden_states[:batch_size])
-        draft_token_ids = logits.argmax(dim=-1)
-        draft_token_ids_list.append(draft_token_ids)
-
-    # [batch_size, num_speculative_tokens]
-    draft_token_ids = torch.stack(draft_token_ids_list, dim=1)
-    return draft_token_ids
+def _is_qwen35_mtp(self) -> bool:
+    # 上游会把 draft 的 model_type 归一化：qwen3_next -> "qwen3_next_mtp"，
+    # qwen3_5/qwen3_5_moe -> "qwen3_5_mtp"（vllm/config/speculative.py）。同时
+    # self.method 会被统一改写成 "mtp"，故不能用它来识别具体模型。
+    hf_config = getattr(getattr(self, "draft_model_config", None), "hf_config", None)
+    model_type = getattr(hf_config, "model_type", None)
+    return model_type in ("qwen3_5_mtp", "qwen3_next_mtp")
 
 
 def prepare_next_token_ids_padded(
     self,
-    common_attn_metadata: CommonAttentionMetadata,
     sampled_token_ids: torch.Tensor,
     requests: dict[str, CachedRequestState],
     gpu_input_batch: InputBatch,
-    discard_request_indices: torch.Tensor,
-    num_discarded_requests: int,
+    discard_request_mask: torch.Tensor,
 ) -> tuple[torch.Tensor, torch.Tensor]:
+    """Torch-native replacement (Qwen3.5-MTP) for the Triton kernel
+    ``eagle_prepare_next_token_padded_kernel``。
     """
-    This function is used to prepare the inputs for speculative decoding.
-    It calculates the next token ids and the number of valid sampled tokens
-    for each request, considering the "discarded" requests whose next token
-    is not sampled and comes from `request.get_token_id()` instead.
-    It also accounts for the rejected tokens in `sampled_token_ids`.
-    This function must use device functions to operate on the inputs, and
-    should not introduce any blocking CPU-GPU synchronization.
-    """
-    # TODO(Ben): Combine this into a custom fused kernel
+    if not _is_qwen35_mtp(self):
+        return _orig_prepare_next_token_ids_padded(
+            self,
+            sampled_token_ids,
+            requests,
+            gpu_input_batch,
+            discard_request_mask,
+        )
 
-    # Precompute get_token_id for when there is no valid next token
+    # Precompute backup token ids
     num_reqs = gpu_input_batch.num_reqs
     self.backup_next_token_ids.np[:num_reqs] = np.array(
         [
             requests[gpu_input_batch.req_ids[i]].get_token_id(
-                common_attn_metadata.seq_lens_cpu[i].item()
+                gpu_input_batch.num_tokens_no_spec[i] - 1
             )
             for i in range(num_reqs)
-        ]
+        ],
+        dtype=np.int32,
     )
     self.backup_next_token_ids.copy_to_gpu(num_reqs)
 
-    # Mask out the sampled tokens indices that should not be sampled.
-    discard_sampled_tokens_req_indices = discard_request_indices[
-        :num_discarded_requests
-    ]
+    # Mask out discarded requests' sampled tokens.
+    discard_sampled_tokens_req_indices = torch.nonzero(
+        discard_request_mask[:num_reqs], as_tuple=False
+    ).flatten()
 
     valid_sampled_token_ids_gpu = sampled_token_ids.clone()
-    # valid_sampled_token_ids_gpu.index_fill_(
-    #     0, discard_sampled_tokens_req_indices, -1)
-    # ---- FIX START ----
-    # XPU/XMLIR index_fill_ does NOT accept empty index tensor.
-    if num_discarded_requests > 0:
-        # make sure index is on same device and is int64
+
+    if discard_sampled_tokens_req_indices.numel() > 0:
         idx = discard_sampled_tokens_req_indices
         if idx.device != valid_sampled_token_ids_gpu.device:
             idx = idx.to(valid_sampled_token_ids_gpu.device, non_blocking=True)
         if idx.dtype != torch.long:
             idx = idx.to(torch.long)
-        if idx.numel() > 0:
-            valid_sampled_token_ids_gpu.index_fill_(0, idx, -1)
-    # ---- FIX END ----
-    # Generate a mask for all valid tokens within those requests
-    max_gen_len = sampled_token_ids.shape[-1]
-    if max_gen_len == 1:
-        valid_mask = torch.ones_like(valid_sampled_token_ids_gpu, dtype=torch.bool)
-    else:
-        valid_mask = (valid_sampled_token_ids_gpu != -1) & (
-            valid_sampled_token_ids_gpu < gpu_input_batch.vocab_size
-        )
+        valid_sampled_token_ids_gpu.index_fill_(0, idx, -1)
 
-    # Count the number of valid tokens in each request
-    valid_sampled_tokens_count = valid_mask.sum(dim=1)
+    valid_mask = (valid_sampled_token_ids_gpu != -1) & (
+        valid_sampled_token_ids_gpu < gpu_input_batch.vocab_size
+    )
+    valid_sampled_tokens_count_long = valid_mask.sum(dim=1)
+    valid_sampled_tokens_count = valid_sampled_tokens_count_long.to(torch.int32)
 
-    # Get the rightmost valid index per row
-    last_valid_indices = valid_sampled_tokens_count - 1
+    last_valid_indices = valid_sampled_tokens_count_long - 1
     last_valid_indices_safe = torch.clamp(last_valid_indices, min=0)
-
-    # Get last valid token from each row
-    # (assume undefined state where there is no valid token)
     selected_tokens = torch.gather(
         valid_sampled_token_ids_gpu, 1, last_valid_indices_safe.unsqueeze(1)
     ).squeeze(1)
 
-    # Use last token if valid, pre-computed backup if not
     batch_size = valid_sampled_token_ids_gpu.shape[0]
     next_token_ids = torch.where(
         last_valid_indices != -1,
@@ -337,5 +100,156 @@ def prepare_next_token_ids_padded(
     return next_token_ids, valid_sampled_tokens_count
 
 
-EagleProposer.propose = propose
+def prepare_inputs_padded(
+    self,
+    common_attn_metadata: CommonAttentionMetadata,
+    spec_decode_metadata: SpecDecodeMetadata,
+    valid_sampled_tokens_count: torch.Tensor,
+) -> tuple[CommonAttentionMetadata, torch.Tensor, torch.Tensor]:
+    """Torch-native replacement (仅 Qwen3.5-MTP) for the Triton kernel
+    ``eagle_prepare_inputs_padded_kernel``"""
+    if not _is_qwen35_mtp(self):
+        return _orig_prepare_inputs_padded(
+            self,
+            common_attn_metadata,
+            spec_decode_metadata,
+            valid_sampled_tokens_count,
+        )
+
+    num_reqs = common_attn_metadata.num_reqs
+
+    cu_num_draft = spec_decode_metadata.cu_num_draft_tokens
+    num_draft = cu_num_draft.clone()
+    if num_reqs > 1:
+        num_draft[1:] = cu_num_draft[1:] - cu_num_draft[:-1]
+
+    valid_count = valid_sampled_tokens_count.to(num_draft.dtype)
+    num_rejected = num_draft + 1 - valid_count
+    num_rejected = torch.where(
+        num_draft > 0, num_rejected, torch.zeros_like(num_rejected)
+    )
+
+    q_last_tok_idx = common_attn_metadata.query_start_loc[1:] - 1
+    token_indices_to_sample = (q_last_tok_idx - num_rejected).to(torch.int32)
+    num_rejected_tokens_gpu = num_rejected.to(torch.int32)
+
+    query_start_loc_cpu = common_attn_metadata.query_start_loc_cpu
+    new_query_len_per_req = query_start_loc_cpu[1:] - query_start_loc_cpu[:-1]
+    total_num_tokens = query_start_loc_cpu[-1].item()
+
+    spec_common_attn_metadata = CommonAttentionMetadata(
+        query_start_loc=common_attn_metadata.query_start_loc,
+        seq_lens=common_attn_metadata.seq_lens,
+        query_start_loc_cpu=query_start_loc_cpu,
+        _seq_lens_cpu=common_attn_metadata._seq_lens_cpu,
+        _num_computed_tokens_cpu=common_attn_metadata._num_computed_tokens_cpu,
+        num_reqs=common_attn_metadata.num_reqs,
+        num_actual_tokens=total_num_tokens,
+        max_query_len=new_query_len_per_req.max().item(),
+        max_seq_len=common_attn_metadata.seq_lens_cpu.max().item(),
+        block_table_tensor=common_attn_metadata.block_table_tensor,
+        slot_mapping=common_attn_metadata.slot_mapping[:total_num_tokens],
+        causal=True,
+        dcp_local_seq_lens=common_attn_metadata.dcp_local_seq_lens,
+    )
+
+    return (
+        spec_common_attn_metadata,
+        token_indices_to_sample,
+        num_rejected_tokens_gpu,
+    )
+
+
+def _update_positions_dependent_metadata(
+    self,
+    positions: torch.Tensor,
+    common_attn_metadata: CommonAttentionMetadata,
+    batch_size: int,
+    input_batch_size: int,
+    block_size: int,
+) -> torch.Tensor:
+    """Torch-native replacement (仅 Qwen3.5-MTP) for the Triton kernel
+    ``eagle_step_slot_mapping_metadata_kernel``。
+    """
+    if not _is_qwen35_mtp(self):
+        return _orig_update_positions_dependent_metadata(
+            self,
+            positions,
+            common_attn_metadata,
+            batch_size,
+            input_batch_size,
+            block_size,
+        )
+
+    cad = common_attn_metadata
+    positions_1d = positions[0] if self.uses_mrope else positions
+
+    new_position = positions_1d + 1
+    exceeds_max = new_position >= self.max_model_len
+    clamped_position = torch.where(
+        exceeds_max, torch.zeros_like(new_position), new_position
+    )
+
+    n_blocks_per_req = cad.block_table_tensor.shape[1]
+    block_number = (clamped_position // block_size).clamp(max=n_blocks_per_req - 1)
+    block_id = cad.block_table_tensor.gather(
+        dim=1, index=block_number.view(-1, 1)
+    ).view(-1)
+    slot = block_id * block_size + (clamped_position % block_size)
+    slot = torch.where(exceeds_max, torch.full_like(slot, PADDING_SLOT_ID), slot)
+
+    new_seq_lens = torch.where(
+        exceeds_max, torch.ones_like(cad.seq_lens), cad.seq_lens + 1
+    ).clamp(max=self.max_model_len)
+    cad.seq_lens.copy_(new_seq_lens)
+
+    if self.uses_mrope:
+        out_pos = self.mrope_positions[0, :batch_size]
+    elif self.uses_xdrope_dim > 0 and self.draft_uses_xdrope_dim > 0:
+        out_pos = self.xdrope_positions[0, :batch_size]
+    else:
+        out_pos = self.positions[:batch_size]
+    out_pos.copy_(clamped_position)
+
+    self._slot_mapping_buffer[:batch_size].copy_(slot)
+    if input_batch_size > batch_size:
+        self._slot_mapping_buffer[batch_size:input_batch_size].fill_(PADDING_SLOT_ID)
+    cad.slot_mapping = self._slot_mapping_buffer[:batch_size]
+
+    if self.uses_mrope:
+        self.mrope_positions[1:, :batch_size] = self.mrope_positions[0, :batch_size]
+        positions = self.mrope_positions[:, :batch_size]
+    elif self.uses_xdrope_dim > 0 and self.draft_uses_xdrope_dim > 0:
+        self.xdrope_positions[1:, :batch_size] = self.xdrope_positions[0, :batch_size]
+        positions = self.xdrope_positions[0, :batch_size]
+    else:
+        positions = self.positions[:batch_size]
+
+    cad.max_seq_len = min(cad.max_seq_len + 1, self.max_model_len)
+
+    if cad._seq_lens_cpu is not None:
+        cad._seq_lens_cpu += 1
+    if cad._num_computed_tokens_cpu is not None:
+        cad._num_computed_tokens_cpu += 1
+    if cad.seq_lens_cpu_upper_bound is not None:
+        cad.seq_lens_cpu_upper_bound += 1
+
+    return positions
+
+
+def _patched_eagle_init(self, *args, **kwargs):
+    _orig_eagle_init(self, *args, **kwargs)
+    if (
+        _is_qwen35_mtp(self)
+        and getattr(self, "uses_mrope", False)
+        and not hasattr(self, "positions")
+    ):
+        self.positions = self.mrope_positions
+
+
 EagleProposer.prepare_next_token_ids_padded = prepare_next_token_ids_padded
+EagleProposer.prepare_inputs_padded = prepare_inputs_padded
+EagleProposer._update_positions_dependent_metadata = (
+    _update_positions_dependent_metadata
+)
+EagleProposer.__init__ = _patched_eagle_init

--- a/vllm_kunlun/v1/sample/spec_decode/suffix_decoding.py
+++ b/vllm_kunlun/v1/sample/spec_decode/suffix_decoding.py
@@ -1,0 +1,79 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Kunlun override for the Suffix Decoding proposer.
+
+Suffix decoding proposes a *dynamic* number of draft tokens per request, so the
+verify step gets a non-uniform query length. Two consequences on Kunlun XPU:
+
+* ``gpu_model_runner._is_uniform_decode`` only dispatches the FULL cudagraph
+  when every request contributes exactly ``1 + num_speculative_tokens`` tokens,
+  so a variable draft length keeps falling back to the PIECEWISE path. Measured
+  on Qwen3.6-35B-A3B / 1 request: ~45 ms per step with MTP (uniform, FULL graph)
+  vs ~70-77 ms with suffix (non-uniform).
+* The GDN spec kernels are written for that same padded layout (see
+  ``gdn_attn.build_spec_pad_indices`` for the fallback that unpads it).
+
+Padding every draft up to the speculation budget trades a couple of wasted
+draft tokens for graph replay. The trade is favourable because a single-request
+decode step is bandwidth-bound: verifying 3 tokens costs about as much as 2.
+At high concurrency the padded tokens stop being free (128 requests x 3 tokens
+instead of the actual draft count), but measured graph replay savings still
+outweigh that cost, so padding is enabled by default.
+
+The rejection sampler still validates every padded draft token against the
+target model. A repeated filler can be accepted when it matches the target, so
+padding is a Kunlun performance policy rather than a bit-identical transform.
+Set ``VLLM_KUNLUN_SUFFIX_PAD_DRAFT=0`` when validating upstream variable-length
+suffix semantics.
+
+Enabled by default on Kunlun for every ``num_speculative_tokens``. Setting
+``VLLM_KUNLUN_SUFFIX_PAD_DRAFT=0`` restores the upstream variable-length
+behaviour, which is equally correct but measured **2-4x slower per step** on
+Qwen3.6-35B-A3B (k=16: copy 19.3 ms/step padded vs 60.5 ms/step variable;
+fresh 22 vs 90 ms/step) -- losing the FULL cudagraph costs far more than the
+wasted draft tokens, at conc=1 and conc=8 alike.
+"""
+
+import os
+
+from vllm.v1.spec_decode.suffix_decoding import SuffixDecodingProposer
+
+_orig_propose = SuffixDecodingProposer.propose
+
+
+def _env_enabled(name: str, default: str) -> bool:
+    return os.environ.get(name, default).lower() not in ("0", "false", "off")
+
+
+def _pad_draft_enabled() -> bool:
+    return _env_enabled("VLLM_KUNLUN_SUFFIX_PAD_DRAFT", "1")
+
+
+def propose(self, input_batch, sampled_token_ids, slot_mappings=None):
+    draft_token_ids = _orig_propose(self, input_batch, sampled_token_ids, slot_mappings)
+    pad_enabled = _pad_draft_enabled()
+
+    for i, sampled_ids in enumerate(sampled_token_ids):
+        if not sampled_ids:
+            # Partial prefill: upstream deliberately proposes nothing, and the
+            # request must not get speculative tokens before it is decoding.
+            continue
+        num_tokens = int(input_batch.num_tokens_no_spec[i])
+        # Same budget upstream uses for ``max_spec_tokens``: never speculate
+        # past ``max_model_len``. Near the end of the context this is smaller
+        # than ``num_speculative_tokens``, so the batch can still be
+        # non-uniform -- the GDN varlen fallback stays necessary.
+        budget = min(self.num_speculative_tokens, self.max_model_len - num_tokens - 1)
+        if budget <= 0:
+            continue
+        draft = [int(t) for t in draft_token_ids[i]]
+        if pad_enabled and len(draft) < budget:
+            # Repeat the most recent token to keep the verify width uniform.
+            # Rejection sampling still evaluates these fillers normally.
+            filler = draft[-1] if draft else int(sampled_ids[-1])
+            draft.extend([filler] * (budget - len(draft)))
+        draft_token_ids[i] = draft
+    return draft_token_ids
+
+
+SuffixDecodingProposer.propose = propose

--- a/vllm_kunlun/v1/worker/block_table.py
+++ b/vllm_kunlun/v1/worker/block_table.py
@@ -3,9 +3,12 @@
 """Kunlun-specific monkey-patch for ``vllm.v1.worker.block_table``.
 
 Replaces ``BlockTable.compute_slot_mapping`` (which dispatches a Triton
-kernel ``_compute_slot_mapping_kernel`` upstream) with a torch-native
-equivalent. Kunlun XPU cannot JIT-compile Triton kernels via the CUDA
-driver path.
+kernel ``_compute_slot_mapping_kernel`` upstream) with the native Kunlun
+XPU op ``kunlun_ops.compute_slot_mappings``. Kunlun XPU cannot JIT-compile
+Triton kernels via the CUDA driver path; the previous torch-native fallback
+relied on ``torch.searchsorted``, which has no Kunlun XPU implementation and
+silently falls back to CPU (host sync + D2H/H2D round trip every step). The
+native op computes the whole mapping on-device in a single launch.
 
 Triggering: imported from ``vllm_kunlun.__init__`` post-import hook
 once ``vllm.v1.worker.block_table`` is loaded. Idempotent under fork()
@@ -14,6 +17,7 @@ and re-import via the ``_kunlun_slot_patched`` flag on the class.
 
 import logging
 
+import kunlun_ops
 import torch
 from vllm.v1.worker.block_table import PAD_SLOT_ID
 from vllm.v1.worker.block_table import BlockTable as _upstream_cls
@@ -23,56 +27,24 @@ logger = logging.getLogger("vllm_kunlun")
 
 def _compute_slot_mapping(self, num_reqs, query_start_loc, positions):
     num_tokens = positions.shape[0]
-    max_num_tokens = self.max_num_batched_tokens
-    block_size = self.block_size
-    slot_mapping = self.slot_mapping.gpu
-    block_table = self.block_table.gpu
-    total_cp = self.pcp_world_size * self.dcp_world_size
-
-    # Common case: no context parallelism. Pure torch index path.
-    if total_cp == 1:
-        if num_tokens > 0:
-            pos = positions[:num_tokens].to(torch.int64)
-            # Per-token req index: search query_start_loc.
-            qsl = query_start_loc[: num_reqs + 1].to(torch.int64)
-            token_arange = torch.arange(
-                num_tokens, device=pos.device, dtype=torch.int64
-            )
-            # req_idx[t] = number of starts <= t, minus 1.
-            req_idx = (torch.searchsorted(qsl, token_arange, right=True) - 1).clamp_(
-                min=0, max=num_reqs - 1
-            )
-            block_idx = pos // block_size
-            offset = pos - block_idx * block_size
-            block_num = block_table[req_idx, block_idx].to(torch.int64)
-            slot_mapping[:num_tokens] = block_num * block_size + offset
-        if max_num_tokens > num_tokens:
-            slot_mapping[num_tokens:max_num_tokens] = PAD_SLOT_ID
-        return
-
-    # CP path: fall back to per-req loop on host.
+    total_cp_world_size = self.pcp_world_size * self.dcp_world_size
     total_cp_rank = self.pcp_rank * self.dcp_world_size + self.dcp_rank
-    cp_int = self.cp_kv_cache_interleave_size
-    virtual_block_size = block_size * total_cp
-    qsl_cpu = query_start_loc[: num_reqs + 1].cpu().tolist()
-    for r in range(num_reqs):
-        s, e = qsl_cpu[r], qsl_cpu[r + 1]
-        if e <= s:
-            continue
-        pos = positions[s:e].to(torch.int64)
-        block_indices = pos // virtual_block_size
-        block_numbers = block_table[r, block_indices].to(torch.int64)
-        virtual_off = pos - block_indices * virtual_block_size
-        is_local = (virtual_off // cp_int) % total_cp == total_cp_rank
-        local_off = (virtual_off // (total_cp * cp_int)) * cp_int + (
-            virtual_off % cp_int
-        )
-        slot = block_numbers * block_size + local_off
-        slot_mapping[s:e] = torch.where(
-            is_local, slot, torch.full_like(slot, PAD_SLOT_ID)
-        )
-    if max_num_tokens > num_tokens:
-        slot_mapping[num_tokens:max_num_tokens] = PAD_SLOT_ID
+    block_sizes = torch.tensor(
+        [self.block_size], dtype=torch.int32, device=self.block_table.gpu.device
+    )
+    kunlun_ops.compute_slot_mappings(
+        [self.slot_mapping.gpu],  # list
+        [self.block_table.gpu],  # list
+        positions,
+        query_start_loc,
+        block_sizes,  # int32 tensor
+        num_reqs,
+        num_tokens,
+        PAD_SLOT_ID,
+        total_cp_world_size,
+        total_cp_rank,
+        self.cp_kv_cache_interleave_size,
+    )
 
 
 # Idempotent monkey-patch: safe under fork() and re-import.

--- a/vllm_kunlun/v1/worker/mamba_utils.py
+++ b/vllm_kunlun/v1/worker/mamba_utils.py
@@ -1,0 +1,323 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import dataclasses
+import itertools
+from collections.abc import Callable
+from math import prod
+from typing import Any
+
+import torch
+from vllm.config import CacheConfig
+from vllm.model_executor.layers.mamba.mamba_utils import MambaStateCopyFunc
+from vllm.triton_utils import tl, triton
+from vllm.utils.math_utils import cdiv
+from vllm.utils.torch_utils import get_dtype_size
+from vllm.v1.core.sched.output import SchedulerOutput
+from vllm.v1.kv_cache_interface import AttentionSpec, KVCacheConfig, MambaSpec
+from vllm.v1.utils import CpuGpuBuffer
+from vllm.v1.worker.gpu_input_batch import CachedRequestState
+from vllm.v1.worker.lora_model_runner_mixin import GPUInputBatch
+
+
+@triton.jit
+def batch_memcpy_kernel(src_ptrs, dst_ptrs, sizes, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(0)
+
+    src_ptr = tl.load(src_ptrs + pid)
+    dst_ptr = tl.load(dst_ptrs + pid)
+    size = tl.load(sizes + pid)
+
+    offsets = tl.arange(0, BLOCK_SIZE)
+    for i in range(0, size, BLOCK_SIZE):
+        mask = (i + offsets) < size
+
+        curr_src_ptr = (src_ptr + i + offsets).to(tl.pointer_type(tl.uint8))
+        curr_dst_ptr = (dst_ptr + i + offsets).to(tl.pointer_type(tl.uint8))
+
+        data = tl.load(curr_src_ptr, mask=mask)
+        tl.store(curr_dst_ptr, data, mask=mask)
+
+
+def batch_memcpy(src_ptrs, dst_ptrs, sizes):
+    batch = src_ptrs.shape[0]
+    assert dst_ptrs.shape[0] == batch
+    assert sizes.shape[0] == batch
+    torch.ops.xspeedgate_ops.batch_memcpy(src_ptrs, dst_ptrs, sizes)
+
+
+def get_mamba_groups(kv_cache_config: KVCacheConfig) -> tuple[list[int], MambaSpec]:
+    mamba_group_ids: list[int] = []
+    mamba_specs: list[MambaSpec] = []
+    for i in range(len(kv_cache_config.kv_cache_groups)):
+        kv_cache_spec = kv_cache_config.kv_cache_groups[i].kv_cache_spec
+        if isinstance(kv_cache_spec, MambaSpec):
+            mamba_group_ids.append(i)
+            mamba_specs.append(kv_cache_spec)
+    assert len(mamba_group_ids) > 0, "no mamba layers in the model"
+    assert all(mamba_specs[0] == spec for spec in mamba_specs)
+    return mamba_group_ids, mamba_specs[0]
+
+
+@dataclasses.dataclass
+class MambaCopyBuffers:
+    src_ptrs: CpuGpuBuffer
+    dst_ptrs: CpuGpuBuffer
+    sizes: CpuGpuBuffer
+    mamba_group_ids: list[int]
+    mamba_spec: MambaSpec
+    offset: int = 0
+
+    @classmethod
+    def create(
+        cls,
+        max_num_reqs: int,
+        kv_cache_config: KVCacheConfig,
+        copy_funcs: tuple[MambaStateCopyFunc, ...],
+        make_buffer: Callable[..., CpuGpuBuffer],
+    ) -> "MambaCopyBuffers":
+        mamba_group_ids, mamba_spec = get_mamba_groups(kv_cache_config)
+        entries_per_req = sum(
+            len(kv_cache_config.kv_cache_groups[gid].layer_names)
+            for gid in mamba_group_ids
+        ) * len(copy_funcs)
+        n = max_num_reqs * entries_per_req
+        return cls(
+            src_ptrs=make_buffer(n, dtype=torch.int64),
+            dst_ptrs=make_buffer(n, dtype=torch.int64),
+            sizes=make_buffer(n, dtype=torch.int64),
+            mamba_group_ids=mamba_group_ids,
+            mamba_spec=mamba_spec,
+        )
+
+
+def collect_mamba_copy_meta(
+    copy_bufs: MambaCopyBuffers,
+    kv_cache_config: KVCacheConfig,
+    mamba_state_copy_funcs: tuple[MambaStateCopyFunc, ...],
+    mamba_group_ids: list[int],
+    src_block_idx: int,
+    dest_block_idx: int,
+    accept_token_bias: int,
+    req_state: CachedRequestState,
+    forward_context: dict[str, Any],
+) -> None:
+    if src_block_idx == dest_block_idx and accept_token_bias == 0:
+        return
+
+    src_ptrs_np = copy_bufs.src_ptrs.np
+    dst_ptrs_np = copy_bufs.dst_ptrs.np
+    sizes_np = copy_bufs.sizes.np
+    offset = copy_bufs.offset
+
+    for mamba_group_id in mamba_group_ids:
+        block_ids = req_state.block_ids[mamba_group_id]
+        dest_block_id = block_ids[dest_block_idx]
+        layer_names = kv_cache_config.kv_cache_groups[mamba_group_id].layer_names
+        for layer_name in layer_names:
+            attention = forward_context[layer_name]
+            kv_caches: list[torch.Tensor] = attention.kv_cache
+            for state, state_copy_func in zip(kv_caches, mamba_state_copy_funcs):
+                copy_spec = state_copy_func(
+                    state, block_ids, src_block_idx, accept_token_bias + 1
+                )
+
+                src_ptrs_np[offset] = copy_spec.start_addr
+                dst_ptrs_np[offset] = state[dest_block_id].data_ptr()
+                sizes_np[offset] = copy_spec.num_elements * state.element_size()
+                offset += 1
+
+    copy_bufs.offset = offset
+
+
+def do_mamba_copy_block(copy_bufs: MambaCopyBuffers):
+    n = copy_bufs.offset
+    if n == 0:
+        return
+    batch_memcpy(
+        copy_bufs.src_ptrs.copy_to_gpu(n),
+        copy_bufs.dst_ptrs.copy_to_gpu(n),
+        copy_bufs.sizes.copy_to_gpu(n),
+    )
+
+
+def preprocess_mamba(
+    scheduler_output: SchedulerOutput,
+    kv_cache_config: KVCacheConfig,
+    cache_config: CacheConfig,
+    mamba_state_idx: dict[str, int],
+    input_batch: GPUInputBatch,
+    requests: dict[str, CachedRequestState],
+    forward_context: dict[str, Any],
+    mamba_state_copy_funcs: tuple[MambaStateCopyFunc, ...],
+    copy_bufs: MambaCopyBuffers,
+):
+    """
+    Copy the mamba state of previous step to the last
+    (1 + num_speculative_blocks) block.
+    """
+    mamba_group_ids = copy_bufs.mamba_group_ids
+    mamba_spec = copy_bufs.mamba_spec
+    num_speculative_blocks = mamba_spec.num_speculative_blocks
+    # TODO(Chen): we need to optimize this function a lot
+    assert cache_config.enable_prefix_caching
+    block_size = mamba_spec.block_size
+    finished_req_ids = scheduler_output.finished_req_ids
+    preempted_req_ids = scheduler_output.preempted_req_ids or set()
+    # We need to clear mamba_state_idx for resumed requests. When requests are
+    # force-preempted (e.g., during reset_prefix_cache / KV cache flush),
+    # they appear in resumed_req_ids without a corresponding entry in
+    # preempted_req_ids, leaving stale mamba_state_idx entries that can
+    # point to block indices beyond the new (smaller) block allocation.
+    resumed_req_ids = scheduler_output.scheduled_cached_reqs.resumed_req_ids
+    for req_id in itertools.chain(finished_req_ids, preempted_req_ids, resumed_req_ids):
+        mamba_state_idx.pop(req_id, None)
+
+    copy_bufs.offset = 0
+    for i, req_id in enumerate(input_batch.req_ids):
+        req_state = requests[req_id]
+        prev_state_idx = mamba_state_idx.get(req_id)
+        if prev_state_idx is None:
+            # new / resumed request, no previous state
+            # if num_computed_tokens is 0, prev_state_idx will be -1
+            prev_state_idx = (req_state.num_computed_tokens - 1) // block_size
+
+        num_scheduled_tokens = scheduler_output.num_scheduled_tokens[req_id]
+        num_blocks: int = (
+            cdiv(req_state.num_computed_tokens + num_scheduled_tokens, block_size)
+            + num_speculative_blocks
+        )
+
+        # We always save the current running state at the last
+        # (1 + num_speculative_blocks) block.
+        # A corner case worth mention here: assume we have block_size = 4 and
+        # num_speculative_tokens = 2. The request is [A, B, C] and contains 2 draft
+        # tokens [draft 1, draft 2]. Then we will have:
+        # Block 0: [A, B, C, draft 1]
+        # Block 1: [draft 2, TOFILL, TOFILL, TOFILL]
+        # Block 2: speculative block
+        # Block 3: speculative block
+        # And use block 1 to save the running state.
+        curr_state_idx = num_blocks - 1 - num_speculative_blocks
+        mamba_state_idx[req_id] = curr_state_idx
+        if prev_state_idx != -1 and prev_state_idx != curr_state_idx:
+            collect_mamba_copy_meta(
+                copy_bufs,
+                kv_cache_config,
+                mamba_state_copy_funcs,
+                mamba_group_ids,
+                prev_state_idx,
+                curr_state_idx,
+                input_batch.num_accepted_tokens_cpu[i] - 1,
+                req_state,
+                forward_context,
+            )
+            input_batch.num_accepted_tokens_cpu[i] = 1
+    do_mamba_copy_block(copy_bufs)
+
+
+def get_hybrid_attention_mamba_layout(
+    kv_cache_shape: tuple[int, ...],
+    kv_cache_stride: tuple[int, ...],
+    kv_cache_spec: AttentionSpec,
+    block_dim: int,
+    layer_idx: int,
+    kernel_block_size: int,
+) -> tuple[tuple[int, ...], int]:
+    """
+    Compute the stride and storage offset for the hybrid attention+mamba layout.
+
+    Args:
+        kv_cache_shape: The shape of the KV cache tensor.
+        kv_cache_stride: The stride of the KV cache tensor.
+        kv_cache_spec: The specification of the KV cache.
+        layer_idx: The index of the layer.
+        kernel_num_blocks: The number of kernel blocks.
+        kernel_block_size: The size of the kernel block.
+    Returns:
+        A tuple containing the target stride and storage offset.
+    """
+    target_stride_list = list(kv_cache_stride)
+    storage_offset = 0
+
+    attn_pack_size = kv_cache_spec.pack_size
+    # block_dim: 0 means (num_blocks, 2, ...); 1 means (2, num_blocks, ...).
+    if block_dim != 0:
+        # Hybrid attention+mamba uses (2, num_blocks, ...) logical shape but
+        # (num_blocks, 2, ...) physical layout.
+        assert kv_cache_shape[0] == 2, (
+            "Fail to determine whether the layout is "
+            "(2, num_blocks, ...) or (num_blocks, 2, ...) for "
+            f"a tensor of shape {kv_cache_shape}"
+        )
+        assert block_dim == 1
+        hidden_size = prod(kv_cache_shape[2:])
+        target_stride_list[0] = hidden_size
+        target_stride_list[1] = 2 * hidden_size
+    # When multiple attention layers share one physical KV cache block
+    # (attn_pack_size > 1), scale the block-dim stride by attn_pack_size
+    # and compute this layer's element offset within the shared block.
+    if attn_pack_size > 1:
+        target_stride_list[block_dim] *= attn_pack_size
+        dtype_size = get_dtype_size(kv_cache_spec.dtype)
+        num_element_per_page = kv_cache_spec.page_size_bytes // dtype_size
+        num_blocks_per_kv_block = kv_cache_spec.block_size // kernel_block_size
+        num_element_per_attn_pack = (
+            num_element_per_page // num_blocks_per_kv_block // attn_pack_size
+        )
+        attn_pack_idx = layer_idx % attn_pack_size
+        storage_offset = attn_pack_idx * num_element_per_attn_pack
+    return tuple(target_stride_list), storage_offset
+
+
+def postprocess_mamba(
+    scheduler_output: SchedulerOutput,
+    kv_cache_config: KVCacheConfig,
+    input_batch: GPUInputBatch,
+    requests: dict[str, CachedRequestState],
+    mamba_state_idx: dict[str, int],
+    forward_context: dict[str, Any],
+    mamba_state_copy_funcs: tuple[MambaStateCopyFunc, ...],
+    copy_bufs: MambaCopyBuffers,
+):
+    """
+    If a blocks is converted from partial block to full block in this step, copy the
+    state from the block for running state to the new full block.
+    """
+    num_scheduled_tokens_dict = scheduler_output.num_scheduled_tokens
+    scheduled_spec_decode_tokens_dict = scheduler_output.scheduled_spec_decode_tokens
+    num_accepted_tokens_cpu = input_batch.num_accepted_tokens_cpu
+    mamba_group_ids = copy_bufs.mamba_group_ids
+    mamba_spec = copy_bufs.mamba_spec
+    copy_bufs.offset = 0
+    for i, req_id in enumerate(input_batch.req_ids):
+        req_state = requests[req_id]
+        num_computed_tokens = req_state.num_computed_tokens
+        num_draft_tokens = len(scheduled_spec_decode_tokens_dict.get(req_id, []))
+        num_scheduled_tokens = num_scheduled_tokens_dict[req_id]
+        num_accepted_tokens = num_accepted_tokens_cpu[i]
+        num_tokens_running_state = (
+            num_computed_tokens + num_scheduled_tokens - num_draft_tokens
+        )
+        new_num_computed_tokens = num_tokens_running_state + num_accepted_tokens - 1
+        aligned_new_computed_tokens = (
+            new_num_computed_tokens // mamba_spec.block_size * mamba_spec.block_size
+        )
+        # TODO: how to ensure all blocks that cache_blocks called are cached here?
+        if aligned_new_computed_tokens >= num_tokens_running_state:
+            accept_token_bias = aligned_new_computed_tokens - num_tokens_running_state
+            src_block_idx = mamba_state_idx[req_id]
+            dest_block_idx = aligned_new_computed_tokens // mamba_spec.block_size - 1
+            collect_mamba_copy_meta(
+                copy_bufs,
+                kv_cache_config,
+                mamba_state_copy_funcs,
+                mamba_group_ids,
+                src_block_idx,
+                dest_block_idx,
+                accept_token_bias,
+                req_state,
+                forward_context,
+            )
+            if src_block_idx == dest_block_idx:
+                num_accepted_tokens_cpu[i] = 1
+    do_mamba_copy_block(copy_bufs)

--- a/vllm_kunlun/v1/worker/mamba_utils.py
+++ b/vllm_kunlun/v1/worker/mamba_utils.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import dataclasses
 import itertools
+import logging
 from collections.abc import Callable
 from math import prod
 from typing import Any
@@ -137,6 +138,113 @@ def do_mamba_copy_block(copy_bufs: MambaCopyBuffers):
         copy_bufs.src_ptrs.copy_to_gpu(n),
         copy_bufs.dst_ptrs.copy_to_gpu(n),
         copy_bufs.sizes.copy_to_gpu(n),
+    )
+
+
+def reanchor_spec_to_non_spec_states(
+    runner: Any,
+    scheduler_output: SchedulerOutput,
+) -> int:
+    """Move accepted speculative candidates to canonical non-spec state slots.
+
+    In Mamba cache mode ``none``, each request owns one canonical block followed
+    by speculative candidate blocks. A speculative GDN step writes conv history
+    candidate ``a`` at row offset ``a - 1`` of the canonical block and writes the
+    temporal candidate to block ``a - 1``. If the next suffix step has no draft,
+    the request switches to non-spec kernels, which read only canonical offset 0.
+    Re-anchor only those transitions before attention metadata is built.
+    """
+    if (
+        runner.cache_config.mamba_cache_mode != "none"
+        or not runner.speculative_config
+        or not runner.model_config.is_hybrid
+    ):
+        return 0
+
+    scheduled_spec = scheduler_output.scheduled_spec_decode_tokens
+    transitions: list[tuple[int, str, int]] = []
+    for row, req_id in enumerate(runner.input_batch.req_ids):
+        accepted = int(runner.num_accepted_tokens.np[row])
+        draft_len = len(scheduled_spec.get(req_id, ()))
+        is_decode = (
+            runner.input_batch.num_computed_tokens_cpu[row]
+            >= runner.input_batch.num_prompt_tokens[row]
+        )
+        current_is_spec = draft_len > 0 and is_decode
+        if accepted > 1 and not current_is_spec:
+            transitions.append((row, req_id, accepted))
+
+    if not transitions:
+        return 0
+
+    copy_funcs = runner.model.get_mamba_state_copy_func()
+    mamba_group_ids, mamba_spec = get_mamba_groups(runner.kv_cache_config)
+    num_spec = mamba_spec.num_speculative_blocks
+    assert len(copy_funcs) == 2, "GDN re-anchor expects conv and temporal states"
+
+    for group_id in mamba_group_ids:
+        layer_names = runner.kv_cache_config.kv_cache_groups[group_id].layer_names
+        dest_block_ids: list[int] = []
+        source_block_ids: list[int] = []
+        offsets: list[int] = []
+        for _, req_id, accepted in transitions:
+            block_ids = runner.requests[req_id].block_ids[group_id]
+            assert (
+                1 <= accepted <= len(block_ids)
+            ), f"accepted count {accepted} exceeds block table for {req_id}"
+            dest_block_ids.append(block_ids[0])
+            source_block_ids.append(block_ids[accepted - 1])
+            offsets.append(accepted - 1)
+
+        first_attention = runner.compilation_config.static_forward_context[
+            layer_names[0]
+        ]
+        first_conv_state = first_attention.kv_cache[0]
+        history_len = first_conv_state.shape[1] - num_spec
+        assert history_len > 0
+
+        device = first_conv_state.device
+        dest = torch.tensor(dest_block_ids, dtype=torch.long, device=device)
+        source = torch.tensor(source_block_ids, dtype=torch.long, device=device)
+        offset = torch.tensor(offsets, dtype=torch.long, device=device)
+        history_rows = torch.arange(history_len, device=device)
+        source_rows = offset[:, None] + history_rows[None, :]
+
+        for layer_name in layer_names:
+            attention = runner.compilation_config.static_forward_context[layer_name]
+            conv_state, temporal_state = attention.kv_cache
+            assert conv_state.shape[1] - num_spec == history_len
+
+            conv_history = conv_state[dest[:, None], source_rows].clone()
+            conv_state[dest[:, None], history_rows[None, :]] = conv_history
+
+            temporal_candidates = temporal_state.index_select(0, source)
+            temporal_state.index_copy_(0, dest, temporal_candidates)
+
+    rows = [row for row, _, _ in transitions]
+    runner.input_batch.num_accepted_tokens_cpu[rows] = 1
+    runner.num_accepted_tokens.np[rows] = 1
+    row_tensor = torch.tensor(rows, dtype=torch.long, device=runner.device)
+    runner.num_accepted_tokens.gpu.index_fill_(0, row_tensor, 1)
+    return len(transitions)
+
+
+def patch_gpu_model_runner(module: Any) -> None:
+    """Patch the upstream runner at the post-input-preparation boundary."""
+    cls = module.GPUModelRunner
+    original = cls._prepare_inputs
+    if getattr(original, "_kunlun_spec_reanchor_patched", False):
+        return
+
+    def _prepare_inputs_with_reanchor(self, scheduler_output, num_scheduled_tokens):
+        result = original(self, scheduler_output, num_scheduled_tokens)
+        reanchor_spec_to_non_spec_states(self, scheduler_output)
+        return result
+
+    _prepare_inputs_with_reanchor._kunlun_spec_reanchor_patched = True
+    cls._prepare_inputs = _prepare_inputs_with_reanchor
+    logging.getLogger(__name__).info(
+        "[KunlunPlugin] GPUModelRunner speculative state re-anchor patched"
     )
 
 

--- a/vllm_kunlun/v1/worker/utils.py
+++ b/vllm_kunlun/v1/worker/utils.py
@@ -12,10 +12,45 @@ hook is installed, ensuring upstream is loaded first.
 """
 
 import logging
+import sys
+from collections import defaultdict
 
+import vllm.v1.worker.utils as _upstream_utils
+from vllm.model_executor.models.utils import extract_layer_index
 from vllm.v1.worker.utils import KVBlockZeroer as _upstream_cls
 
 logger = logging.getLogger("vllm_kunlun")
+
+
+def _bind_kv_cache(kv_caches, forward_context, runner_kv_caches, num_attn_module=1):
+    """Kunlun replacement for ``vllm.v1.worker.utils.bind_kv_cache``.
+
+    Identical to upstream except the multi-layer-per-index branch does not
+    raise on Kunlun (OOT platform). Upstream only ``pass``es this branch for
+    cuda/xpu/cpu because ``runner_kv_caches`` is not consumed in a way that
+    is impacted by the ordering. Kunlun's GPU-style runner has the same
+    property, so raising ``NotImplementedError`` here is spurious.
+
+    This branch is hit by hybrid + MTP models (e.g. Qwen3.5): a target
+    ``linear_attn`` layer and the MTP draft ``self_attn`` layer can share the
+    same ``extract_layer_index`` value (both 0).
+    """
+    assert len(runner_kv_caches) == 0
+
+    index2name = defaultdict(list)
+    for layer_name in kv_caches:
+        index2name[extract_layer_index(layer_name, num_attn_module)].append(layer_name)
+
+    for layer_index in sorted(index2name.keys()):
+        layer_names = index2name[layer_index]
+        # NOTE(kunlun): upstream raises NotImplementedError here for non
+        # cuda/xpu/cpu platforms. Kunlun's runner is unaffected by the
+        # multi-name-per-index case, so we simply keep all of them.
+        for layer_name in layer_names:
+            runner_kv_caches.append(kv_caches[layer_name])
+
+    for layer_name, kv_cache in kv_caches.items():
+        forward_context[layer_name].kv_cache = kv_cache
 
 
 def _init_meta(
@@ -135,4 +170,30 @@ if not getattr(_upstream_cls, "_kunlun_patched", False):
     _upstream_cls._kunlun_patched = True
     logger.info(
         "[KunlunPlugin] KVBlockZeroer patched in vllm_kunlun/v1/worker/utils.py"
+    )
+
+
+# Patch bind_kv_cache. It is imported by-name at the top of
+# ``vllm.v1.worker.gpu_model_runner`` (``from ... import bind_kv_cache``), so
+# patching the upstream module attribute alone is not enough -- we must also
+# rebind the name in every already-imported consumer module.
+if not getattr(_upstream_utils.bind_kv_cache, "_kunlun_patched", False):
+    _original_bind = _upstream_utils.bind_kv_cache
+    _bind_kv_cache._kunlun_patched = True  # type: ignore[attr-defined]
+    _upstream_utils.bind_kv_cache = _bind_kv_cache
+
+    rebind_count = 0
+    for module in list(sys.modules.values()):
+        if module is None or module is _upstream_utils:
+            continue
+        if getattr(module, "bind_kv_cache", None) is _original_bind:
+            try:
+                setattr(module, "bind_kv_cache", _bind_kv_cache)
+                rebind_count += 1
+            except Exception:
+                pass
+    logger.info(
+        "[KunlunPlugin] bind_kv_cache patched in "
+        "vllm_kunlun/v1/worker/utils.py, rebound=%s",
+        rebind_count,
     )

--- a/vllm_kunlun/vllm_utils_wrapper.py
+++ b/vllm_kunlun/vllm_utils_wrapper.py
@@ -104,9 +104,10 @@ def vllm_kunlun_all_gather(self, input_: torch.Tensor, dim: int = -1) -> torch.T
     output_tensor = torch.empty(
         (world_size,) + input_size, dtype=input_.dtype, device=input_.device
     )
+    cast_output_tensor = output_tensor.view(-1, input_.shape[-1])  # for cudagraph
     # All-gather.
     torch.distributed.all_gather_into_tensor(
-        output_tensor, input_, group=self.device_group
+        cast_output_tensor, input_, group=self.device_group
     )
     # Reshape
     output_tensor = output_tensor.movedim(0, dim)


### PR DESCRIPTION
## What does this PR do?

This PR adds speculative decoding support for Qwen3.5 and Qwen3.6 on the
vLLM 0.21 Kunlun backend.

The main changes include:

- Add the Qwen3.5 MTP model implementation and model registration.
- Adapt Eagle/MTP speculative decoding to the Kunlun attention and GDN paths.
- Add Kunlun suffix decoding support for Qwen3.6.
- Improve speculative decoding precision and performance under concurrent
  workloads.
- Support variable-length speculative batches in GDN and Mamba state handling.

## Key Changes

### Qwen3.5 MTP support

- Add `Qwen3_5MTP` model implementation and registration.
- Adapt the Eagle proposer, rejection sampler, block table, and model runner
  utilities for MTP decoding.
- Add Kunlun implementations for the fused recurrent GDN path and Mamba state
  management.
- Extend attention metadata and sampling operations required by speculative
  decoding.
- Add compressed-tensors MoE compatibility for the MTP execution path.

### Qwen3.6 suffix decoding

- Patch `SuffixDecodingProposer` on Kunlun to pad draft tokens to the configured
  speculative-token budget.
- Keep verification batches uniform so they can use the FULL cudagraph path.
- Add `VLLM_KUNLUN_SUFFIX_PAD_DRAFT=0` to restore upstream variable-length
  suffix behavior when semantic comparison is required.
- Preserve partial-prefill behavior and respect the remaining model-length
  budget.

### Variable-length GDN fallback

- Add gather/unpad indices for non-uniform speculative query lengths.
- Pad inputs only for the fixed-width convolution kernel and restore the real
  token layout before the recurrent kernel.
- Disable FULL cudagraph replay when the variable-length fallback is active.
- Preserve output dtype while executing recurrent state calculations with the
  state dtype.

### Speculative Mamba state handling

- Re-anchor accepted speculative Conv and temporal states to their canonical
  non-speculative cache slots.
- Handle transitions where a request accepts speculative tokens but the next
  suffix step produces no draft.
- Apply the runner patch through post-import hooks so the upstream class
  definition does not overwrite it.

## Performance

Padding suffix drafts enables FULL cudagraph replay on Kunlun. Measurements
recorded during development on Qwen3.6-35B-A3B showed that the padded path was
substantially faster than variable-length PIECEWISE execution, including at
concurrency 1 and concurrency 8.

The padding policy is enabled by default because the graph replay savings
outweigh the additional verification work in the measured workloads.

## Compatibility

- Target vLLM version: `0.21.x`
- Target backend: Kunlun XPU
- Models covered:
  - Qwen3.5 MTP
  - Qwen3.6 suffix decoding
- Upstream variable-length suffix behavior can be enabled with:

  ```bash
  export VLLM_KUNLUN_SUFFIX_PAD_DRAFT=0