### PR TITLE
[Bugfix] Avoid probing lazy module __getattr__ when rebinding apply_grammar_bitmask

### DIFF
--- a/vllm_kunlun/v1/structured_output/utils.py
+++ b/vllm_kunlun/v1/structured_output/utils.py
@@ -109,7 +109,15 @@ if not getattr(_ORIGINAL, "_kunlun_patched", False):
     for module in list(sys.modules.values()):
         if module is None or module is _upstream:
             continue
-        if getattr(module, "apply_grammar_bitmask", None) is _ORIGINAL:
+        # ``__dict__.get`` rather than ``getattr``: a real ``from ... import``
+        # binding always lands in the module's own ``__dict__``, while
+        # ``getattr`` would fall through to module-level ``__getattr__``
+        # hooks. transformers registers ~192 backward-compat alias modules
+        # (``models.*.image_processing_*``) whose catch-all
+        # ``__getattr__`` logs a warning and eagerly imports the real
+        # module for *any* attribute name -- probing them costs ~0.75s and
+        # ~38MB per process and floods the log.
+        if module.__dict__.get("apply_grammar_bitmask") is _ORIGINAL:
             try:
                 setattr(module, "apply_grammar_bitmask", apply_grammar_bitmask)
                 rebind_count += 1


### PR DESCRIPTION
## PR Description

**What problem does it solve?**

The `apply_grammar_bitmask` patch in `vllm_kunlun/v1/structured_output/utils.py`
rebinds the symbol in already-imported consumer modules by walking `sys.modules`
and probing each entry with `getattr(module, "apply_grammar_bitmask", None)`.

`getattr` falls through to module-level `__getattr__` hooks. transformers
registers a large number of backward-compat alias modules
(`transformers.models.*.image_processing_*`) whose catch-all `__getattr__` logs a
deprecation warning **and eagerly imports the real module** for *any* attribute
name. Every vLLM process therefore prints ~190 lines of

```
Accessing `apply_grammar_bitmask` from `.models.aria.image_processing_aria`.
Returning `apply_grammar_bitmask` instead. Behavior may be different and this
alias will be removed in future versions.
```

— roughly 570 lines per launch across APIServer / EngineCore / Worker — and pays
the import cost of image processors the engine never touches.

**What is the approach?**

Probe `module.__dict__.get("apply_grammar_bitmask")` instead. A genuine
`from ... import apply_grammar_bitmask` binding always lands in the importing
module's own `__dict__`, so every real consumer is still found, while a lazy or
alias module's `__getattr__` is never invoked. Rebind semantics are unchanged;
this is a one-line behavioral fix plus an explanatory comment.

**Verification** — same launch (MiMo-VL-7B-RL-2508, Kunlun XPU, TP=1, mp executor):

before

```
INFO 08-07 07:04:13 [__init__.py:237] Platform plugin kunlun is activated
Accessing `apply_grammar_bitmask` from `.models.aria.image_processing_aria`. ...
... (~190 lines, repeated in all 3 processes) ...
INFO 08-07 07:04:19 [utils.py:119] [KunlunPlugin] apply_grammar_bitmask patched ..., rebound=0
```

after

```
INFO 08-07 07:00:28 [__init__.py:237] Platform plugin kunlun is activated
INFO 08-07 07:00:34 [utils.py:127] [KunlunPlugin] apply_grammar_bitmask patched ..., rebound=0
```

`rebound=0` is identical before and after, and the server starts and serves
`/v1/chat/completions` normally afterwards.

FIX #421

---

## Checklist (Required)

- [x] All code changes pass the [`pre-commit`](https://github.com/baidu/vLLM-Kunlun/blob/main/CONTRIBUTING.md) checks.
- [x] Commits are signed off using `git commit -s`.
- [x] The PR title is properly classified (see below).
