### PR TITLE
[Bugfix] Remove an unreachable branch in Kunlun attention backend selection.

### DIFF
--- a/vllm_kunlun/platforms/kunlun.py
+++ b/vllm_kunlun/platforms/kunlun.py
@@ -309,14 +309,10 @@ class KunlunPlatform(Platform):
                     "FlashMLASparseBackend"
                 )
             return "vllm_kunlun.v1.attention.backends.mla.flashmla.FlashMLABackend"
-        elif not attn_selector_config.use_mla:
-            return (
-                "vllm_kunlun.v1.attention.backends.kunlun_attn.KunlunAttentionBackend"
-            )
-        else:
-            return (
-                "vllm_kunlun.v1.attention.backends.kunlun_mla.KunlunMLAAttentionBackend"
-            )
+
+        return (
+            "vllm_kunlun.v1.attention.backends.kunlun_attn.KunlunAttentionBackend"
+        )
 
     @classmethod
     def get_current_memory_usage(


### PR DESCRIPTION
## Summary

This PR replaces #373 and rebases the change onto the current
`v0.25.1-dev` branch, as requested in the review comments.

`use_mla` and `not use_mla` already cover all valid cases, so the final
`else` branch can never be reached. This change simplifies the control
flow while preserving the existing behavior:

- MLA + sparse -> `FlashMLASparseBackend`
- MLA + non-sparse -> `FlashMLABackend`
- non-MLA -> `KunlunAttentionBackend`

## Changes from #373

- Changed the base branch from `v0.15.0-dev` to `v0.25.1-dev`
- Added the required `Signed-off-by` line to pass the DCO check
- Kept the original functional change unchanged