### PR TITLE
[Refactor] Migrate model attention imports to vLLM v1

### DIFF
--- a/vllm_kunlun/models/deepseek_v2.py
+++ b/vllm_kunlun/models/deepseek_v2.py
@@ -33,7 +33,7 @@ import torch
 from torch import nn
 from torch.library import custom_op
 from transformers import DeepseekV2Config, DeepseekV3Config
-from vllm.attention.ops.common import pack_seq_triton, unpack_seq_triton
+from vllm.v1.attention.ops.common import pack_seq_triton, unpack_seq_triton
 from vllm.compilation.decorators import support_torch_compile
 from vllm.config import CacheConfig, ParallelConfig, VllmConfig
 from vllm.distributed import (

--- a/vllm_kunlun/models/deepseek_v2.py
+++ b/vllm_kunlun/models/deepseek_v2.py
@@ -45,6 +45,7 @@ from vllm.distributed import (
 )
 from vllm.forward_context import get_forward_context
 from vllm.logger import init_logger
+from vllm.model_executor.layers.attention import Attention
 from vllm.model_executor.layers.activation import SiluAndMul
 from vllm.model_executor.layers.fused_moe import FusedMoE
 from vllm.model_executor.layers.layernorm import LayerNorm, RMSNorm
@@ -82,7 +83,6 @@ from vllm.model_executor.models.utils import (
 from vllm.platforms import current_platform
 from vllm.sequence import IntermediateTensors
 
-from vllm_kunlun.ops.attention.layer import Attention
 from vllm_kunlun.ops.deep_gemm import int8_mqa_logits, int8_paged_mqa_logits
 from vllm_kunlun.ops.linear import ReplicatedLinear
 from vllm_kunlun.v1.attention.backends.mla.indexer import DeepseekV32IndexerMetadata

--- a/vllm_kunlun/models/gemma4.py
+++ b/vllm_kunlun/models/gemma4.py
@@ -25,7 +25,7 @@ from itertools import islice
 import regex as re
 import torch
 from torch import nn
-from vllm.attention.layer import Attention
+from vllm.model_executor.layers.attention import Attention
 from vllm.compilation.decorators import support_torch_compile
 from vllm.config import CacheConfig, VllmConfig
 from vllm.distributed import (

--- a/vllm_kunlun/models/gpt_oss.py
+++ b/vllm_kunlun/models/gpt_oss.py
@@ -17,6 +17,7 @@ from vllm.distributed import (
     get_tensor_model_parallel_world_size,
     tensor_model_parallel_all_gather,
 )
+from vllm.model_executor.layers.attention import Attention
 from vllm.model_executor.layers.fused_moe import FusedMoE
 from vllm.model_executor.layers.layernorm import RMSNorm
 from vllm.model_executor.layers.linear import QKVParallelLinear, RowParallelLinear
@@ -41,8 +42,6 @@ from vllm.model_executor.models.utils import (
 )
 from vllm.sequence import IntermediateTensors
 from vllm.utils import cdiv
-
-from vllm_kunlun.ops.attention.layer import Attention
 
 
 class OAIAttention(nn.Module):

--- a/vllm_kunlun/models/gpt_oss.py
+++ b/vllm_kunlun/models/gpt_oss.py
@@ -7,7 +7,7 @@ import torch
 import torch.distributed as dist
 from torch import nn
 from transformers import GptOssConfig
-from vllm.attention import AttentionType
+from vllm.v1.attention.backend import AttentionType
 from vllm.compilation.decorators import support_torch_compile
 from vllm.config import CacheConfig, VllmConfig
 from vllm.distributed import (

--- a/vllm_kunlun/models/mimo_v2_flash.py
+++ b/vllm_kunlun/models/mimo_v2_flash.py
@@ -5,7 +5,7 @@ from itertools import islice
 
 import torch
 from torch import nn
-from vllm.attention.backends.abstract import AttentionType
+from vllm.v1.attention.backend import AttentionType
 from vllm.config import CacheConfig, VllmConfig, get_current_vllm_config
 from vllm.distributed import (
     get_ep_group,

--- a/vllm_kunlun/models/mimo_v2_flash.py
+++ b/vllm_kunlun/models/mimo_v2_flash.py
@@ -14,6 +14,7 @@ from vllm.distributed import (
     get_tensor_model_parallel_world_size,
 )
 from vllm.logger import init_logger
+from vllm.model_executor.layers.attention import Attention
 from vllm.model_executor.layers.activation import SiluAndMul
 from vllm.model_executor.layers.fused_moe.layer import FusedMoE
 from vllm.model_executor.layers.layernorm import RMSNorm
@@ -44,8 +45,6 @@ from vllm.model_executor.models.utils import (
     maybe_prefix,
 )
 from vllm.sequence import IntermediateTensors
-
-from vllm_kunlun.ops.attention.layer import Attention
 
 logger = init_logger(__name__)
 

--- a/vllm_kunlun/models/seed_oss.py
+++ b/vllm_kunlun/models/seed_oss.py
@@ -34,6 +34,7 @@ from vllm.compilation.decorators import support_torch_compile
 from vllm.config import CacheConfig, VllmConfig
 from vllm.distributed import get_pp_group, get_tensor_model_parallel_world_size
 from vllm.logger import init_logger
+from vllm.model_executor.layers.attention import Attention
 from vllm.model_executor.layers.activation import SiluAndMul
 from vllm.model_executor.layers.layernorm import RMSNorm
 from vllm.model_executor.layers.linear import (
@@ -59,7 +60,6 @@ from vllm.model_executor.models.utils import (
 )
 from vllm.sequence import IntermediateTensors
 
-from vllm_kunlun.ops.attention.layer import Attention
 from vllm_kunlun.ops.vocab_parallel_embedding import (
     ParallelLMHead,
     VocabParallelEmbedding,

--- a/vllm_kunlun/models/seed_oss.py
+++ b/vllm_kunlun/models/seed_oss.py
@@ -29,7 +29,7 @@ from itertools import islice
 import torch
 from torch import nn
 from transformers import PretrainedConfig as SeedOssConfig
-from vllm.attention import AttentionType
+from vllm.v1.attention.backend import AttentionType
 from vllm.compilation.decorators import support_torch_compile
 from vllm.config import CacheConfig, VllmConfig
 from vllm.distributed import get_pp_group, get_tensor_model_parallel_world_size


### PR DESCRIPTION
## Description

Migrate attention-related imports in Kunlun model definitions to the
vLLM v1 API and remove dependencies on legacy `vllm.attention` paths.

## Changes

- Update model `Attention` imports to
  `vllm.model_executor.layers.attention`
- Update `AttentionType` imports to
  `vllm.v1.attention.backend`
- Update DeepSeek attention ops imports to
  `vllm.v1.attention.ops.common`
- Apply the migration to:
  - DeepSeek V2
  - Gemma4
  - GPT-OSS
  - MiMo V2 Flash
  - Seed OSS

## Motivation

The previous model implementations imported `Attention` from the
Kunlun-specific attention wrapper or used legacy `vllm.attention` paths.

These paths are not available or are no longer canonical in the current
vLLM environment. For example:

```text
ModuleNotFoundError: No module named 'vllm.attention.backends'