### PR TITLE
[Feature] Support sleep mode on Kunlun XPU

### DIFF
--- a/docs/source/user_guide/feature_guide/index.md
+++ b/docs/source/user_guide/feature_guide/index.md
@@ -8,4 +8,5 @@ This section provides a detailed usage guide of vLLM Kunlun features.
 graph_mode
 quantization
 lora
+sleep_mode
 :::

--- a/docs/source/user_guide/feature_guide/sleep_mode.md
+++ b/docs/source/user_guide/feature_guide/sleep_mode.md
@@ -1,0 +1,85 @@
+# Sleep Mode Guide
+
+## Overview
+
+Sleep mode offloads or discards the model weights and the KV cache from device
+memory while the engine stays alive, so another process can use the freed XPU
+memory. It is mainly used by reinforcement learning (RL) post-training
+workloads (PPO, GRPO, DPO, ...), where the same device is shared between the
+vLLM rollout engine and the trainer.
+
+The API is the upstream vLLM one, see
+[vLLM sleep mode](https://docs.vllm.ai/en/latest/features/sleep_mode.html).
+vLLM Kunlun makes it work on Kunlun XPU; no Kunlun-specific API or flag is
+introduced.
+
+Two sleep levels are supported, same semantics as upstream:
+
+- **Level 1**: weights are offloaded to host memory, the KV cache is discarded.
+  Use it when the same model will be reused after `wake_up()`. Make sure the
+  host has enough free memory to hold the weights.
+- **Level 2**: both weights and KV cache are discarded. Use it when the weights
+  will be replaced anyway, e.g. when the trainer pushes updated weights, or
+  when switching to another model.
+
+## Usage
+
+Offline inference:
+
+```python
+from vllm import LLM
+
+llm = LLM(model="/models/Qwen3-8B", enable_sleep_mode=True)
+llm.generate("Hello, how are you?")
+
+llm.sleep(level=1)  # free device memory
+llm.wake_up()       # restore weights and KV cache
+
+# level 2 + weight update from the trainer
+llm.sleep(level=2)
+llm.wake_up(tags=["weights"])   # re-map the weights pool only
+llm.collective_rpc("reload_weights")
+llm.wake_up(tags=["kv_cache"])  # re-allocate the KV cache
+```
+
+Online serving:
+
+```shell
+VLLM_SERVER_DEV_MODE=1 vllm serve /models/Qwen3-8B --enable-sleep-mode
+```
+
+```shell
+curl -X POST 'http://127.0.0.1:8000/sleep?level=1'
+curl -X GET  'http://127.0.0.1:8000/is_sleeping'
+curl -X POST 'http://127.0.0.1:8000/wake_up'
+```
+
+The `/sleep`, `/wake_up` and `/is_sleeping` endpoints are only exposed when
+`VLLM_SERVER_DEV_MODE=1`. They are unauthenticated administrative endpoints, so
+only enable them in a trusted development environment.
+
+## Kunlun Implementation Notes
+
+Sleep mode relies on `vllm.device_allocator.cumem.CuMemAllocator`, which backs
+the weights and KV cache pools with CUDA VMM allocations (`cuMemCreate` +
+`cuMemMap`). Two Kunlun-specific adaptations live in
+`vllm_kunlun/device_allocator/cumem.py`, both installed through post-import
+hooks registered in `vllm_kunlun/__init__.py`:
+
+1. **Offload copies go through the CUDA driver API.** Upstream
+   `sleep()` / `wake_up()` move the pool contents with the CUDA *runtime*
+   `cudaMemcpy`, which does not accept the VMM virtual addresses on Kunlun XPU
+   and crashes. During the two calls the module-global `libcudart` is replaced
+   by a passthrough shim whose `cudaMemcpy` is routed to `cuMemcpyDtoH_v2` /
+   `cuMemcpyHtoD_v2`. The direction is pinned per call (`sleep()` only copies
+   device to host, `wake_up()` only host to device), because Kunlun runs with
+   `CUDA_FAKE_UVA_ENABLE=1` where the direction cannot be inferred from the
+   pointer.
+2. **`reload_weights()` re-maps the weights pool when needed.** After a level-2
+   sleep the weights pool is unmapped. Calling `reload_weights()` without a
+   preceding `wake_up(tags=["weights"])` would write into released device memory
+   and fail with XPU error `-707`. `GPUModelRunner.reload_weights` is wrapped so
+   the weights pool is woken up first if it is still unmapped.
+
+Both patches are idempotent, and are skipped when the cumem extension is not
+available (in which case sleep mode is unavailable anyway).

--- a/docs/source/user_guide/support_matrix/supported_features.md
+++ b/docs/source/user_guide/support_matrix/supported_features.md
@@ -12,3 +12,4 @@ You can check the [support status of vLLM V1 Engine][v1_user_guide]. Below is th
 |Graph Mode|🟢 Functional||
 |Quantization| 🟢 Functional||
 |LoRA|⚠️ Need Test|Only LLM models|
+|Sleep Mode|🟢 Functional|Level 1 and level 2, see [Sleep Mode Guide](../feature_guide/sleep_mode.md)|

--- a/vllm_kunlun/__init__.py
+++ b/vllm_kunlun/__init__.py
@@ -309,6 +309,66 @@ _register_post_import_hook(
 )
 
 
+# --- hook 10: sleep-mode driver copies in vllm.device_allocator.cumem -------
+# CuMemAllocator.sleep()/wake_up() offload through the CUDA *runtime*
+# cudaMemcpy, which segfaults on the VMM addresses the cumem allocator hands
+# out. Wrap both to route the copy through the driver API. See
+# vllm_kunlun/device_allocator/cumem.py.
+#
+# ``applied`` deliberately returns False while CuMemAllocator is missing: that
+# means cumem's own module body is still executing (one of its inner imports
+# re-entered the dispatcher), and ``apply`` no-ops so the hook is retried on
+# the next import, once the class exists.
+def _cumem_applied(mod):
+    cls = getattr(mod, "CuMemAllocator", None)
+    return cls is not None and getattr(cls, "_kunlun_sleep_patched", False)
+
+
+def _cumem_apply(mod):
+    if not hasattr(mod, "CuMemAllocator"):
+        return
+    from vllm_kunlun.device_allocator.cumem import patch_cumem
+
+    patch_cumem(mod)
+
+
+_register_post_import_hook("vllm.device_allocator.cumem", _cumem_applied, _cumem_apply)
+
+
+# --- hook 11: GPUModelRunner.reload_weights after a level-2 sleep -----------
+# A standalone reload_weights() (no wake_up(tags=["weights"]) first) would load
+# into weight tensors whose VMM pool sleep() discarded -> XPU error -707. Same
+# consumer-trigger pattern as hook 8: a hook targeting gpu_model_runner itself
+# can run while that module is still being defined.
+def _reload_weights_applied(_consumer_mod):
+    runner_mod = sys.modules.get("vllm.v1.worker.gpu_model_runner")
+    cls = getattr(runner_mod, "GPUModelRunner", None)
+    if cls is None:
+        return False
+    fn = getattr(cls, "reload_weights", None)
+    return fn is not None and getattr(fn, "_kunlun_reload_weights_patched", False)
+
+
+def _reload_weights_apply(_consumer_mod):
+    runner_mod = sys.modules.get("vllm.v1.worker.gpu_model_runner")
+    if runner_mod is None or not hasattr(runner_mod, "GPUModelRunner"):
+        return
+    from vllm_kunlun.device_allocator.cumem import patch_reload_weights
+
+    patch_reload_weights(runner_mod)
+
+
+for _reload_consumer in (
+    "vllm.v1.worker.gpu_worker",
+    "vllm.v1.worker.xpu_model_runner",
+):
+    _register_post_import_hook(
+        _reload_consumer,
+        _reload_weights_applied,
+        _reload_weights_apply,
+    )
+
+
 def _preload_mapped(full_name):
     """Load the kunlun replacement for ``full_name`` into sys.modules."""
     if full_name in sys.modules:

--- a/vllm_kunlun/device_allocator/__init__.py
+++ b/vllm_kunlun/device_allocator/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Kunlun-specific patches for ``vllm.device_allocator``."""

--- a/vllm_kunlun/device_allocator/cumem.py
+++ b/vllm_kunlun/device_allocator/cumem.py
@@ -1,0 +1,249 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Kunlun-specific monkey-patches enabling vLLM sleep mode on Kunlun XPU.
+
+Two independent fixes, both required for ``--enable-sleep-mode``:
+
+1. **Offload copies must go through the CUDA driver API.**
+   ``CuMemAllocator.sleep()`` / ``wake_up()`` move the pool contents with
+   ``libcudart.cudaMemcpy``, i.e. the CUDA *runtime* copy. The device
+   addresses involved are VMM virtual addresses (allocated by
+   ``cuMemCreate`` + ``cuMemMap`` in the cumem allocator), and the runtime
+   copy segfaults on them; the *driver* copies ``cuMemcpyDtoH_v2`` /
+   ``cuMemcpyHtoD_v2`` understand them. Instead of reimplementing the two
+   methods, we swap the module-global ``libcudart`` for a passthrough shim
+   whose ``cudaMemcpy`` is pinned to one direction, for the duration of the
+   call. ``sleep()`` only ever copies device->host and ``wake_up()`` only
+   host->device, so the direction is known statically and no pointer
+   introspection is needed -- which matters because Kunlun runs with
+   ``CUDA_FAKE_UVA_ENABLE=1``, where deciding the direction from a pointer's
+   address space is not reliable.
+
+2. **The weights pool must be re-mapped before a standalone
+   ``reload_weights()``.** After a level-2 sleep the weights VMM pool is
+   unmapped; loading into the weight tensors without a preceding
+   ``wake_up(tags=["weights"])`` writes to released device memory and fails
+   with XPU error -707, taking down the engine. The ``sleep()`` /
+   ``wake_up()`` wrappers maintain ``_kunlun_unmapped_tags`` on the
+   allocator so the runner patch can detect that state.
+
+Triggering: post-import hooks registered in ``vllm_kunlun/__init__.py``.
+Both patches are idempotent under fork() and re-import via the
+``_kunlun_sleep_patched`` / ``_kunlun_reload_weights_patched`` flags.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import ctypes
+import functools
+import inspect
+import logging
+from typing import Any
+
+logger = logging.getLogger("vllm_kunlun")
+
+_DTOH = "DeviceToHost"
+_HTOD = "HostToDevice"
+
+# ``libcuda.so.1`` handle with the two driver copy entry points configured.
+# Populated by ``_init_driver_copies()`` at patch time.
+_libcuda: Any = None
+
+
+def _init_driver_copies() -> None:
+    """Load libcuda and declare the driver copy signatures.
+
+    ``CUdeviceptr`` is a 64-bit unsigned integer, host pointers are plain
+    ``void *``.
+    """
+    global _libcuda
+    if _libcuda is not None:
+        return
+
+    lib = ctypes.CDLL("libcuda.so.1")
+    lib.cuMemcpyDtoH_v2.restype = ctypes.c_int
+    lib.cuMemcpyDtoH_v2.argtypes = [
+        ctypes.c_void_p,  # dstHost
+        ctypes.c_ulonglong,  # srcDevice
+        ctypes.c_size_t,  # ByteCount
+    ]
+    lib.cuMemcpyHtoD_v2.restype = ctypes.c_int
+    lib.cuMemcpyHtoD_v2.argtypes = [
+        ctypes.c_ulonglong,  # dstDevice
+        ctypes.c_void_p,  # srcHost
+        ctypes.c_size_t,  # ByteCount
+    ]
+    _libcuda = lib
+
+
+class _DirectionPinnedLibcudart:
+    """Passthrough proxy over ``CudaRTLibrary`` with a driver-based copy.
+
+    Every attribute except ``cudaMemcpy`` resolves on the real runtime
+    library, so installing this in place of ``cumem.libcudart`` cannot
+    change the behaviour of anything else.
+    """
+
+    def __init__(self, wrapped: Any, direction: str) -> None:
+        self._wrapped = wrapped
+        self._direction = direction
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._wrapped, name)
+
+    def cudaMemcpy(self, dst: int, src: int, count: int) -> None:  # noqa: N802
+        """Copy ``count`` bytes in the pinned direction via the driver API."""
+        if self._direction == _DTOH:
+            ret = _libcuda.cuMemcpyDtoH_v2(dst, src, count)
+            assert ret == 0, f"cuMemcpyDtoH_v2 failed with CUresult={ret}"
+        else:
+            ret = _libcuda.cuMemcpyHtoD_v2(dst, src, count)
+            assert ret == 0, f"cuMemcpyHtoD_v2 failed with CUresult={ret}"
+
+
+@contextlib.contextmanager
+def _driver_memcpy(module: Any, direction: str):
+    """Route ``module``'s runtime copies through the driver API.
+
+    Not thread-safe by design: ``sleep()`` / ``wake_up()`` are serialized
+    engine-level operations executed on the worker's own thread.
+    """
+    original = module.libcudart
+    module.libcudart = _DirectionPinnedLibcudart(original, direction)
+    try:
+        yield
+    finally:
+        module.libcudart = original
+
+
+def _check_memcpy_assumption(func: Any, direction: str) -> None:
+    """Warn if the wrapped method no longer does exactly one runtime copy.
+
+    The direction-pinned shim is only correct while ``sleep()`` copies
+    solely device->host and ``wake_up()`` solely host->device. This is a
+    cheap tripwire so an upstream change surfaces as a log line instead of
+    silently copying in the wrong direction.
+    """
+    try:
+        source = inspect.getsource(func)
+    except (OSError, TypeError):
+        return
+
+    count = source.count("libcudart.cudaMemcpy")
+    if count != 1:
+        logger.warning(
+            "[KunlunPlugin] %s contains %d libcudart.cudaMemcpy call(s), "
+            "expected exactly 1 (%s). The driver-copy shim in "
+            "vllm_kunlun/device_allocator/cumem.py pins the copy direction "
+            "and may now be wrong -- please re-check it against upstream.",
+            getattr(func, "__qualname__", func),
+            count,
+            direction,
+        )
+
+
+def patch_cumem(module: Any) -> None:
+    """Wrap ``CuMemAllocator.sleep`` / ``wake_up`` on ``module``.
+
+    ``module`` is the upstream ``vllm.device_allocator.cumem`` module.
+    """
+    cls = getattr(module, "CuMemAllocator", None)
+    if cls is None or getattr(cls, "_kunlun_sleep_patched", False):
+        return
+
+    if not getattr(module, "cumem_available", False):
+        # No cumem extension (sleep mode is unavailable anyway). Mark as
+        # handled so the post-import hook stops retrying.
+        cls._kunlun_sleep_patched = True
+        logger.debug(
+            "[KunlunPlugin] cumem allocator unavailable, sleep-mode patch skipped"
+        )
+        return
+
+    _init_driver_copies()
+
+    original_sleep = cls.sleep
+    original_wake_up = cls.wake_up
+    _check_memcpy_assumption(original_sleep, _DTOH)
+    _check_memcpy_assumption(original_wake_up, _HTOD)
+
+    @functools.wraps(original_sleep)
+    def sleep(self, offload_tags=None):
+        with _driver_memcpy(module, _DTOH):
+            original_sleep(self, offload_tags)
+        # sleep() unmaps every allocation it walked, regardless of whether it
+        # was offloaded to CPU first (offload_tags only decides backup vs
+        # discard), so every tag still on record is now unmapped.
+        self._kunlun_unmapped_tags = {
+            data.tag for data in self.pointer_to_data.values()
+        }
+
+    @functools.wraps(original_wake_up)
+    def wake_up(self, tags=None):
+        with _driver_memcpy(module, _HTOD):
+            original_wake_up(self, tags)
+        if tags is None:
+            self._kunlun_unmapped_tags = set()
+        else:
+            self._kunlun_unmapped_tags = set(
+                getattr(self, "_kunlun_unmapped_tags", ())
+            ) - set(tags)
+
+    cls.sleep = sleep
+    cls.wake_up = wake_up
+    # Class-level default so readers work before the first sleep().
+    cls._kunlun_unmapped_tags = frozenset()
+    cls._kunlun_sleep_patched = True
+    logger.info(
+        "[KunlunPlugin] CuMemAllocator.sleep/wake_up patched to use driver "
+        "memcpy in vllm_kunlun/device_allocator/cumem.py"
+    )
+
+
+def _wake_up_weights_if_unmapped(runner: Any) -> None:
+    """Re-map the weights pool if a level-2 sleep left it unmapped.
+
+    ``sleep(offload_tags=())`` (level 2) discards the weights pool. A
+    standalone ``reload_weights()`` -- no ``wake_up(tags=["weights"])``
+    first -- would load into weight tensors backed by released device
+    memory and fail with XPU error -707.
+    """
+    if not runner.vllm_config.model_config.enable_sleep_mode:
+        return
+
+    from vllm.device_allocator.cumem import CuMemAllocator
+
+    allocator = CuMemAllocator.get_instance()
+    if "weights" in getattr(allocator, "_kunlun_unmapped_tags", ()):
+        logger.info(
+            "[KunlunPlugin] reload_weights after a level-2 sleep: re-mapping "
+            "the weights pool before loading"
+        )
+        allocator.wake_up(tags=["weights"])
+
+
+def patch_reload_weights(module: Any) -> None:
+    """Prepend the weights re-map to ``GPUModelRunner.reload_weights``.
+
+    ``module`` is the upstream ``vllm.v1.worker.gpu_model_runner`` module.
+    """
+    cls = getattr(module, "GPUModelRunner", None)
+    if cls is None:
+        return
+
+    original = cls.reload_weights
+    if getattr(original, "_kunlun_reload_weights_patched", False):
+        return
+
+    @functools.wraps(original)
+    def reload_weights(self, *args, **kwargs):
+        _wake_up_weights_if_unmapped(self)
+        return original(self, *args, **kwargs)
+
+    reload_weights._kunlun_reload_weights_patched = True
+    cls.reload_weights = reload_weights
+    logger.info(
+        "[KunlunPlugin] GPUModelRunner.reload_weights patched for level-2 "
+        "sleep in vllm_kunlun/device_allocator/cumem.py"
+    )

--- a/vllm_kunlun/platforms/kunlun.py
+++ b/vllm_kunlun/platforms/kunlun.py
@@ -105,7 +105,7 @@ class KunlunPlatform(Platform):
 
     def is_sleep_mode_available(self) -> bool:
         """is_sleep_mode_available"""
-        return self._enum == PlatformEnum.CUDA
+        return self._enum == PlatformEnum.OOT
 
     @classmethod
     def get_device_name(cls, device_id: int = 0) -> str:


### PR DESCRIPTION
### What this PR does / why we need it?

Makes vLLM sleep mode (`--enable-sleep-mode`, level 1 and level 2) work on Kunlun XPU. Sleep mode is required by RL post-training workloads that share one device between the rollout engine and the trainer.

Three changes:

1. `KunlunPlatform.is_sleep_mode_available()` now checks for the OOT platform enum instead of CUDA, so the capability is actually reported on Kunlun.
2. `vllm_kunlun/device_allocator/cumem.py` wraps `CuMemAllocator.sleep()` / `wake_up()` so the offload copies go through the CUDA driver API (`cuMemcpyDtoH_v2` / `cuMemcpyHtoD_v2`). Upstream uses the CUDA *runtime* `cudaMemcpy`, which crashes on the VMM virtual addresses handed out by the cumem allocator. The copy direction is pinned per call (`sleep()` is device to host only, `wake_up()` is host to device only), because Kunlun runs with `CUDA_FAKE_UVA_ENABLE=1` where the direction cannot be inferred from a pointer. A tripwire logs a warning if an upstream change makes the single-copy assumption invalid.
3. `GPUModelRunner.reload_weights` is wrapped to wake up the weights pool first if a level-2 sleep left it unmapped. Without it, a standalone `reload_weights()` writes into released device memory and fails with XPU error `-707`, taking down the engine.

Both patches are installed via the existing post-import hook mechanism in `vllm_kunlun/__init__.py`, are idempotent, and no-op when the cumem extension is unavailable.

### Does this PR introduce any user-facing change?

No new API or flag. Sleep mode now works through the standard vLLM interface (`enable_sleep_mode=True`, `llm.sleep()` / `llm.wake_up()`, and the `/sleep`, `/wake_up`, `/is_sleeping` dev-mode endpoints).

Docs: adds `docs/source/user_guide/feature_guide/sleep_mode.md` (usage plus Kunlun implementation notes), registers it in the feature guide toctree, and adds a Sleep Mode row to the support matrix.

### How was this patch tested?

- Sleep level 1 / wake up and sleep level 2 + `wake_up(tags=["weights"])` + `reload_weights()` + `wake_up(tags=["kv_cache"])` on Kunlun XPU.
- `pre-commit run --files ...` passes on all changed files.