### PR TITLE
ci: automate issue and pull request labeling

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,50 @@
+"area: kunlun-xpu":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "vllm_kunlun/**"
+          - "build.sh"
+          - "setup_env.sh"
+          - "collect_env.py"
+
+"area: ci":
+  - changed-files:
+      - any-glob-to-any-file:
+          - ".github/**"
+          - "ci.yml"
+          - ".pre-commit-config.yaml"
+
+"area: documentation":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/*.md"
+          - "docs/**"
+          - ".readthedocs.yaml"
+
+"area: tests":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "tests/**"
+          - "**/test_*.py"
+          - "**/*_test.py"
+
+"area: dependencies":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "requirements*.txt"
+          - "pyproject.toml"
+          - "setup.py"
+          - "setup.cfg"
+          - "uv.lock"
+
+"area: performance":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "benchmarks/**"
+          - "benchmark/**"
+          - "**/benchmark*.py"
+
+"area: examples":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "examples/**"
+          - "community/**"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -4,7 +4,6 @@
           - "vllm_kunlun/**"
           - "build.sh"
           - "setup_env.sh"
-          - "collect_env.py"
 
 "area: ci":
   - changed-files:

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -59,11 +59,21 @@ jobs:
 
             for (const definition of labelDefinitions) {
               try {
-                await github.rest.issues.getLabel({
+                const existing = await github.rest.issues.getLabel({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   name: definition.name
                 });
+                if (existing.data.color !== definition.color ||
+                    (existing.data.description || '') !== definition.description) {
+                  await github.rest.issues.updateLabel({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    name: definition.name,
+                    color: definition.color,
+                    description: definition.description
+                  });
+                }
               } catch (error) {
                 if (error.status !== 404) throw error;
                 try {
@@ -84,6 +94,7 @@ jobs:
             const rules = [
               { label: 'bug', patterns: [/\bbug\b/, /error/, /exception/, /crash/, /fail/, /regression/] },
               { label: 'documentation', patterns: [/\bdocs?\b/, /documentation/, /readme/, /tutorial/] },
+              { label: 'feature request', patterns: [/feature request/, /propose a new feature/, /new feature/] },
               { label: 'enhancement', patterns: [/feature/, /enhancement/, /support .*model/, /add .*support/] },
               { label: 'question', patterns: [/\bquestion\b/, /how do i/, /how can i/, /请问/, /咨询/] },
               { label: 'area: performance', patterns: [/performance/, /benchmark/, /latency/, /throughput/, /speedup/, /性能/, /延迟/] },

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -42,6 +42,10 @@ jobs:
             const add = [];
 
             const labelDefinitions = [
+              { name: 'bug', color: 'd73a4a', description: 'Something is not working' },
+              { name: 'documentation', color: '0075ca', description: 'Improvements or additions to documentation' },
+              { name: 'enhancement', color: 'a2eeef', description: 'New feature or request' },
+              { name: 'question', color: 'd876e3', description: 'Further information is requested' },
               { name: 'feature request', color: 'a2eeef', description: 'New feature or request from the feature request form' },
               { name: 'needs review', color: 'fbca04', description: 'Issue or pull request is ready for maintainer review' },
               { name: 'area: kunlun-xpu', color: '5319e7', description: 'Kunlun XPU runtime, build, or integration code' },
@@ -62,13 +66,18 @@ jobs:
                 });
               } catch (error) {
                 if (error.status !== 404) throw error;
-                await github.rest.issues.createLabel({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  name: definition.name,
-                  color: definition.color,
-                  description: definition.description
-                });
+                try {
+                  await github.rest.issues.createLabel({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    name: definition.name,
+                    color: definition.color,
+                    description: definition.description
+                  });
+                } catch (createError) {
+                  // Another workflow run may have created the label first.
+                  if (createError.status !== 422) throw createError;
+                }
               }
             }
 

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -1,0 +1,72 @@
+name: Auto label issues and pull requests
+
+on:
+  issues:
+    types: [opened, edited, reopened]
+  pull_request_target:
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  label-by-files:
+    name: Label pull request by changed files
+    if: github.event_name == 'pull_request_target'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Apply area labels
+        uses: actions/labeler@v6
+        with:
+          configuration-path: .github/labeler.yml
+          sync-labels: false
+
+  label-by-content:
+    name: Label issue or pull request by content
+    runs-on: ubuntu-latest
+    steps:
+      - name: Apply semantic labels
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const event = context.eventName;
+            const payload = context.payload;
+            const item = payload.issue ?? payload.pull_request;
+            if (!item) return;
+
+            const title = (item.title || '').toLowerCase();
+            const body = (item.body || '').toLowerCase();
+            const labels = new Set((item.labels || []).map(label => label.name));
+            const add = [];
+
+            const rules = [
+              { label: 'bug', patterns: [/\bbug\b/, /error/, /exception/, /crash/, /fail/, /regression/] },
+              { label: 'documentation', patterns: [/\bdocs?\b/, /documentation/, /readme/, /tutorial/] },
+              { label: 'enhancement', patterns: [/feature/, /enhancement/, /support .*model/, /add .*support/] },
+              { label: 'question', patterns: [/\bquestion\b/, /how do i/, /how can i/, /请问/, /咨询/] },
+              { label: 'area: performance', patterns: [/performance/, /benchmark/, /latency/, /throughput/, /speedup/, /性能/, /延迟/] },
+              { label: 'area: dependencies', patterns: [/dependenc/, /requirements/, /install/, /package/, /版本/] },
+              { label: 'area: tests', patterns: [/test/, /pytest/, /ci/, /continuous integration/, /测试/] },
+              { label: 'area: kunlun-xpu', patterns: [/kunlun/, /xpu/, /p800/, /mlu/, /昆仑/] }
+            ];
+
+            for (const rule of rules) {
+              if (!labels.has(rule.label) && rule.patterns.some(pattern => pattern.test(`${title}\n${body}`))) {
+                add.push(rule.label);
+              }
+            }
+
+            if (event === 'pull_request_target' && !labels.has('needs review')) {
+              add.push('needs review');
+            }
+
+            if (add.length > 0) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: item.number,
+                labels: add
+              });
+            }

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Apply area labels
-        uses: actions/labeler@v6
+        uses: actions/labeler@b8dd2d9be0f68b860e7dae5dae7d772984eacd6d # v6
         with:
           configuration-path: .github/labeler.yml
           sync-labels: false
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Apply semantic labels
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const event = context.eventName;
@@ -41,6 +41,37 @@ jobs:
             const labels = new Set((item.labels || []).map(label => label.name));
             const add = [];
 
+            const labelDefinitions = [
+              { name: 'feature request', color: 'a2eeef', description: 'New feature or request from the feature request form' },
+              { name: 'needs review', color: 'fbca04', description: 'Issue or pull request is ready for maintainer review' },
+              { name: 'area: kunlun-xpu', color: '5319e7', description: 'Kunlun XPU runtime, build, or integration code' },
+              { name: 'area: ci', color: '1d76db', description: 'Continuous integration and repository automation' },
+              { name: 'area: documentation', color: '0075ca', description: 'Documentation, tutorials, or README changes' },
+              { name: 'area: tests', color: 'b60205', description: 'Unit, integration, or end-to-end tests' },
+              { name: 'area: dependencies', color: '0366d6', description: 'Packaging, dependencies, or installation changes' },
+              { name: 'area: performance', color: 'd4c5f9', description: 'Performance, benchmark, latency, or throughput changes' },
+              { name: 'area: examples', color: 'c5def5', description: 'Examples, demos, or community utilities' }
+            ];
+
+            for (const definition of labelDefinitions) {
+              try {
+                await github.rest.issues.getLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name: definition.name
+                });
+              } catch (error) {
+                if (error.status !== 404) throw error;
+                await github.rest.issues.createLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name: definition.name,
+                  color: definition.color,
+                  description: definition.description
+                });
+              }
+            }
+
             const rules = [
               { label: 'bug', patterns: [/\bbug\b/, /error/, /exception/, /crash/, /fail/, /regression/] },
               { label: 'documentation', patterns: [/\bdocs?\b/, /documentation/, /readme/, /tutorial/] },
@@ -48,7 +79,8 @@ jobs:
               { label: 'question', patterns: [/\bquestion\b/, /how do i/, /how can i/, /请问/, /咨询/] },
               { label: 'area: performance', patterns: [/performance/, /benchmark/, /latency/, /throughput/, /speedup/, /性能/, /延迟/] },
               { label: 'area: dependencies', patterns: [/dependenc/, /requirements/, /install/, /package/, /版本/] },
-              { label: 'area: tests', patterns: [/test/, /pytest/, /ci/, /continuous integration/, /测试/] },
+              { label: 'area: ci', patterns: [/\bci\b/, /continuous integration/, /github actions/, /workflow/, /测试流水线/] },
+              { label: 'area: tests', patterns: [/\btest\b/, /pytest/, /unit test/, /integration test/, /e2e/, /测试/] },
               { label: 'area: kunlun-xpu', patterns: [/kunlun/, /xpu/, /p800/, /mlu/, /昆仑/] }
             ];
 

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -14,6 +14,7 @@ permissions:
 jobs:
   label-by-files:
     name: Label pull request by changed files
+    needs: label-by-content
     if: github.event_name == 'pull_request_target'
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary

This change adds a GitHub Actions workflow that labels issues and pull requests from their content and changed files.

It applies area labels for Kunlun XPU code, CI, documentation, tests, dependencies, performance work, and examples. It also applies semantic labels such as `bug`, `enhancement`, `question`, and `needs review` when the title or body matches the corresponding terms.

The workflow provisions the labels it uses when they are missing, including the `feature request` label referenced by the issue form, and updates existing labels so their colors and descriptions stay consistent.

## Implementation

- Add `.github/labeler.yml` with path-based rules for pull requests.
- Add `.github/workflows/auto-label.yml` for issue and pull request labeling.
- Pin third-party actions to full commit SHAs.
- Use `pull_request_target` without checking out or executing pull request code.
- Provision and synchronize required labels through the GitHub API before applying them.
- Keep file-based labeling behind the label-provisioning job to avoid a first-run race.
- Separate CI-related content matches from test-related matches.
- Remove the stale `collect_env.py` path rule and use `area: documentation` consistently.

## Validation

- `pre-commit run --all-files`
- `git diff --cached --check`
- `actionlint .github/workflows/auto-label.yml`

All local checks pass. The commits are signed off with `git commit -s`.