### PR TITLE
[Doc] Add automated OpenWiki updates

### DIFF
--- a/.github/workflows/openwiki-update.yml
+++ b/.github/workflows/openwiki-update.yml
@@ -1,0 +1,79 @@
+name: OpenWiki Update
+
+on:
+  workflow_dispatch:
+  schedule:
+    # GitHub schedules use UTC; 08:00 UTC is 16:00 Beijing time.
+    - cron: "0 8 * * *"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: true
+          # OpenWiki needs the full history to compare against its last update.
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: "22"
+
+      - name: Install OpenWiki
+        # Mermaid and jsdom validate diagrams when the Wiki contains them.
+        run: npm install --global openwiki mermaid@11.16.0 jsdom@29.1.1
+
+      - name: Update OpenWiki
+        id: openwiki
+        continue-on-error: true
+        run: openwiki code --update --print
+        env:
+          # Configure this secret in the Fork repository settings.
+          OPENWIKI_PROVIDER: openrouter
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          OPENWIKI_MODEL_ID: z-ai/glm-5.2
+          # Disable anonymous telemetry if desired.
+          # OPENWIKI_TELEMETRY_DISABLED: "1"
+
+      - name: Remove transient OpenWiki state
+        if: ${{ !cancelled() }}
+        run: rm -f -- openwiki/.run.json
+
+      - name: Create OpenWiki update pull request
+        if: ${{ !cancelled() }}
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7
+        with:
+          add-paths: |
+            openwiki
+          branch: openwiki/update
+          delete-branch: true
+          commit-message: "docs: update OpenWiki"
+          title: "[Doc] Update OpenWiki knowledge base"
+          body: |
+            ## Description
+
+            This PR updates the generated OpenWiki knowledge base from the latest repository changes.
+
+            ## Validation
+
+            The workflow runs OpenWiki in Code mode and keeps the generated changes under `openwiki/`.
+            Please review source-grounded claims, hardware and model support, compatibility statements,
+            performance descriptions, and any newly identified gaps before merging.
+
+            ## Checklist
+
+            - [ ] The generated pages accurately reflect the current source and tests.
+            - [ ] Claims include repository evidence where applicable.
+            - [ ] No sensitive internal information is included.
+
+      - name: Propagate OpenWiki failure
+        if: ${{ steps.openwiki.outcome == 'failure' }}
+        run: exit 1


### PR DESCRIPTION
## PR Description

### What problem does it solve?

The OpenWiki knowledge base in `openwiki/` is currently updated manually. Without an automated update path, documentation can fall behind changes to the source code, tests, and repository workflows.

### Why is this change needed?

This change adds a scheduled GitHub Actions workflow that keeps the generated OpenWiki content synchronized with the repository. Updates are proposed through a pull request so that maintainers can review source-grounded claims, hardware and model support statements, compatibility notes, performance descriptions, and newly identified gaps before merging.

### Overall approach

- Run OpenWiki in Code mode with the repository's full Git history.
- Support both manual execution and a daily scheduled run at 08:00 UTC.
- Keep generated changes under `openwiki/` and remove transient run state before creating the update pull request.
- Use pinned GitHub Action revisions for the checkout, pull-request creation, and Node.js setup steps.
- Keep the model provider key in GitHub Actions Secrets rather than in the workflow file.
- Fail the workflow when OpenWiki cannot complete, while preserving any pages completed before the failure for review.

### Validation

- Ran the applicable pre-commit checks for the new workflow.
- Passed YAML, whitespace, file-name, file-size, and repository diff checks.
- Confirmed the workflow uses `fetch-depth: 0`, `contents: write`, and `pull-requests: write` as required for incremental updates and pull-request creation.
- Confirmed the commit was created with `git commit -s`.

## Checklist (Required)

- [x] All code changes pass the pre-commit checks.
- [x] Commits are signed off using `git commit -s`.
- [x] The PR title is properly classified.

## PR Type

[Doc] Documentation updates or fixes

## Review notes

This PR adds automation only; it does not change runtime implementation code. Before merging, please verify the model provider, model identifier, and repository Secret configuration. The workflow will not generate updates until `OPENROUTER_API_KEY` is configured in the Fork or the provider settings are changed to match the repository's approved inference service.