### PR TITLE
[Doc] Add Torch XMLIR runtime wiki

### DIFF
--- a/openwiki/index.md
+++ b/openwiki/index.md
@@ -30,8 +30,8 @@ post-import 补丁和安装期文件覆盖，把 vLLM 的 CUDA 代码路径改�
 
 理解本仓库最重要的一句话：**它对 vLLM 自称自己是 CUDA**
 （`device_name = "cuda"`、`dispatch_key = "CUDA"`、`dist_backend = "nccl"`），
-底层由 `torch_xmlir`（xpytorch）把 `torch.cuda.*` 映射到 XPU。
-所有"为什么这里写着 cuda"的疑问都由此解释。
+底层由 [`torch_xmlir` 运行时与 PyTorch 兼容层](torch-xmlir/README.md)把 `torch.cuda.*` 映射到 XPU。
+所有"为什么这里写着 cuda"的疑问都由此解释。该子 Wiki 记录 XMLIR 运行时构建的行为快照；本 Wiki 仍以 vLLM-Kunlun 源码事实为准。
 
 ## 从哪里开始读
 
@@ -39,6 +39,7 @@ post-import 补丁和安装期文件覆盖，把 vLLM 的 CUDA 代码路径改�
 | --- | --- |
 | 插件怎么被加载、四种覆盖手段的区别 | [architecture.md](architecture.md) |
 | `KunlunPlatform` 对 vLLM 承诺了什么、强制改写了哪些配置 | [platform-contract.md](platform-contract.md) |
+| `torch.cuda` 如何映射到 XPU、Dispatcher 和运行时如何工作 | [torch-xmlir/README.md](torch-xmlir/README.md) |
 | torch.compile / 图捕获在 XPU 上怎么跑 | [kunlun-graph.md](kunlun-graph.md) |
 | 4 个 attention backend、KV cache 布局、前缀缓存 | [attention-backend.md](attention-backend.md) |
 | GDN / FLA / Mamba 线性注意力路径 | [linear-attention.md](linear-attention.md) |

--- a/openwiki/kunlun-graph.md
+++ b/openwiki/kunlun-graph.md
@@ -30,8 +30,8 @@ claims: .claims/kunlun-graph.json
 - `get_piecewise_backend_cls()` → `vllm.compilation.cuda_piecewise_backend.CUDAPiecewiseBackend`（`platforms/kunlun.py#L128-L130`）
 - `get_static_graph_wrapper_cls()` → `vllm.compilation.cuda_graph.CUDAGraphWrapper`（`#L132-L134`）
 
-真正的 XPU 化发生在两个更低的层次：`torch_xmlir` 提供 CUDA graph 的
-shim，以及本仓库替换掉 `vllm.compilation.wrapper` 这个模块。
+真正的 XPU 化发生在两个更低的层次：[`torch_xmlir` 的 CUDA Graph shim](torch-xmlir/05-device-runtime.md)
+以及本仓库替换掉的 `vllm.compilation.wrapper` 模块。`torch_xmlir` 对 `torch.compile` 和 Dynamo 的运行时快照见 [torch-xmlir/08-compile-dynamo.md](torch-xmlir/08-compile-dynamo.md)。
 
 ## 2. `compilation/wrapper.py`：被裁剪过的 dynamo
 

--- a/openwiki/platform-contract.md
+++ b/openwiki/platform-contract.md
@@ -37,7 +37,7 @@ dispatch_key = "CUDA"
 
 `device_type` property 也返回 `"cuda"`（`#L31-L38`）。
 这套伪装让 vLLM 里所有 `torch.cuda.*` / NCCL / Ray GPU 资源声明原封不动可用，
-底层由 `torch_xmlir` 转到 XPU。
+底层由 [`torch_xmlir` 运行时与 PyTorch 兼容层](torch-xmlir/README.md)转到 XPU。
 
 但身份判定函数是**诚实的**：
 
@@ -75,7 +75,7 @@ dispatch_key = "CUDA"
 
 1. **"Kunlun Graph" 不是一个新类。**`get_piecewise_backend_cls` 与
    `get_static_graph_wrapper_cls` 都返回上游 CUDA 的实现，图捕获走的是
-   `torch_xmlir` 的 CUDA graph shim。详见 [kunlun-graph.md](kunlun-graph.md)。
+   [`torch_xmlir` 的 CUDA Graph shim](torch-xmlir/05-device-runtime.md)。vLLM 侧的图执行约束详见 [kunlun-graph.md](kunlun-graph.md)。
 2. **`get_device_total_memory` 返回宿主内存**，不是显存。凡是用它推算
    KV cache 容量的上游逻辑在这里都不可信，实际容量靠
    `--gpu-memory-utilization` 手工调（tutorial 里的取值在 0.95~0.97）。

--- a/openwiki/torch-xmlir/01-architecture.md
+++ b/openwiki/torch-xmlir/01-architecture.md
@@ -1,0 +1,124 @@
+# 01 · 总体架构
+
+[← 返回首页](README.md)
+
+## 四层劫持
+
+昆仑芯适配层的核心设计决策是：**不新增 PyTorch 设备类型，直接冒充 CUDA**。
+全包搜索 `privateuse1` / `rename_privateuse1_backend` / `_register_device_module`
+只命中 profiler 插件里两处字符串处理（`symbrewrite/plugins/profiler/statistic_dump.py:121,137`），
+没有任何自定义 `c10::DeviceType` 或 `DeviceGuardImplInterface` 注册。**[已验证]**
+
+代价是必须在四个层面同时伪装：
+
+```
+┌─ L4  Python 符号层 ── builtins.__import__ hook + symbrewrite 改写 torch.* 属性
+│                       见 02-import-hook.md / 03-symbrewrite.md
+├─ L3  Dispatcher 层 ── 注销 DispatchKey::CUDA 上的官方 kernel，换成 XPU kernel
+│                       见 04-dispatch-hijack.md
+├─ L2  ATen/C++ 层 ──── XMLIR Python extension 内 codegen 的 RegisterCUDA.cpp + custom_ops
+│                       见 06-custom-ops-nn.md
+└─ L1  驱动 ABI 层 ──── CUDA ABI 兼容库 → Kunlun XPU 驱动与运行时垫片
+```
+
+L1 的直接后果：`torch.cuda.Stream` / `Event` / caching allocator / CUDA Graph
+**全部是未经修改的官方 PyTorch 代码**，只是底下的 `cudaStreamCreate` 打到了昆仑运行时。
+这也是为什么 `torch.cuda.get_device_name(0)` 返回 `'GPU'`、
+`get_device_capability(0)` 返回 `(8, 6)` —— 这些值来自垫片，不是 torch_xmlir 编的。**[已验证]**
+
+## `import torch` 的完整启动时序
+
+用户代码里 **不需要** `import torch_xmlir`。整条链由 `.pth` 触发：
+
+| # | 动作 | 位置 |
+|---|---|---|
+| 1 | 解释器启动执行 `.pth` → `xpytorch_import_hook.hook_torch()` | `site-packages/torch_xmlir.pth:1` |
+| 2 | `builtins.__import__ = _custom_import` | `xpytorch_import_hook.py:151` |
+| 3 | 首次 `import torch`（或 torch_xmlir/torchvision/transformers）触发 bootstrap | `xpytorch_import_hook.py:30,37` |
+| 4 | 强制注入 5 个 CUDA 兼容环境变量 | `xpytorch_import_hook.py:48-72` |
+| 5 | `torch_plugin.initialize_runtime()` 预载 xcudart 垫片 | `xpytorch_import_hook.py:75-77` |
+| 6 | `import torch`（官方包，此时 CUDA 垫片已就位） | `xpytorch_import_hook.py:78` |
+| 7 | `import torch_xmlir` → 进入下面的 8~15 | `xpytorch_import_hook.py:80` |
+| 8 | `op_deregister_C.deregister_all_op("CUDA", "aten", {...})` 注销官方 CUDA kernel | `$PKG/__init__.py:26-40` |
+| 9 | `import torch_xmlir.xpu`、`from . import _XMLIRC`（44MB pybind 扩展） | `$PKG/__init__.py:51-55` |
+| 10 | `init()`：关 nvfuser/GPU fusion、`_XMLIRC._init_xpu_backend()`、`init_op_select()` | `$PKG/__init__.py:150-168` |
+| 11 | `XPU_RUN_MODE` 若设置 → 写硬件寄存器切精度模式 | `$PKG/__init__.py:170-176` |
+| 12 | `_XMLIRC._xpu_init_caching_allocator()` | `$PKG/__init__.py:200` |
+| 13 | `load_custom_ops_library(custom-op component)` | `$PKG/__init__.py:215` |
+| 14 | `from torch_xmlir.distributed import tensor` 注册 DTensor handler | `$PKG/__init__.py:218` |
+| 15 | `initialize_plugin_with_xflags()` 按 xflags 导入 symbrewrite 插件 | `$PKG/__init__.py:275` |
+| 16 | 回到 hook：`enable_rewrite_for_module("torch")` 落地全部符号改写 | `xpytorch_import_hook.py:95` |
+
+第 13 步必须在第 14 步之前 —— DTensor 注册代码在模块导入期就引用
+`torch.ops.custom_ops.*`，`$PKG/__init__.py:217` 的注释明确说明了这个顺序依赖。**[源码]**
+
+## 版本门控：本构建上哪些代码根本不跑
+
+`init()` 里有三处版本判断，在 torch 2.9 下的实际结果 **[已验证]**：
+
+```python
+# $PKG/__init__.py:181-185
+digit_version = int("".join(list(filter(str.isdigit, torch.__version__))[0:3]))
+if digit_version >= 200:
+    if digit_version < 250:
+        _apply_patches_201()
+```
+
+`"2.9.0+cu129"` 取数字前 3 位 → `"290"` → `290`。所以：
+
+| 门控 | 条件 | 实际结果 | 后果 |
+|---|---|---|---|
+| `_apply_patches_1121()` | `"1.12.1" in torch.__version__` | **不执行** | — |
+| `_apply_patches_201()` | `200 <= dv < 250` → `290` | **不执行** | `_patched_functions.py` 里 1122 行的 `broadcast_object_list` / `barrier` / `all_gather_object` 等 distributed 补丁全部休眠 |
+| `_apply_patches_201_dynamo()` + `xmlir` backend 注册 | `not WITHOUT_MLIR` | **不执行** | 见下 |
+| `enable_pytorch_storage_replacement()` | `torch.__version__.find("cu") == -1` | **不执行**（版本串含 `cu129`） | storage 替换未启用 |
+
+`WITHOUT_MLIR` 是一个已确认的 latent bug：
+
+```python
+# $PKG/__init__.py:47
+WITHOUT_MLIR = bool(os.environ.get("WITHOUT_MLIR", "0"))
+```
+
+`bool("0")` 是 `True`，所以 `WITHOUT_MLIR` **默认永远为真**（运行时确认 `torch_xmlir.WITHOUT_MLIR == True`）。
+整个 `dynamo/` 后端注册路径（`__init__.py:187-197`）从不执行。
+详见 [08-compile-dynamo.md](08-compile-dynamo.md) 和 [12-pitfalls.md](12-pitfalls.md)。**[已验证]**
+
+## 本构建上真正生效的 Python 层改写
+
+运行时探测结果 **[已验证]**：
+
+| 符号 | 实际指向 |
+|---|---|
+| `torch.compile` | `symbrewrite.plugins.torch.mock_torch.empty_decorator`（空装饰器！） |
+| `torch.nn.Linear` | `torch_xmlir.nn.linear.Linear` |
+| `torch.nn.functional.linear` | `torch_xmlir.nn.linear.linear` |
+| `torch.backends.cudnn.enabled` | `False` |
+| `torch.distributed.ProcessGroupNCCL` | `torch.distributed.ProcessGroupXCCL` |
+| `torch.distributed.is_nccl_available()` | `True`（硬编码 lambda） |
+| `torch.jit.script` | `mock_torch.empty_decorator` |
+
+## 模块规模速览
+
+243 个 `.py` 文件、约 43k 行 Python，加 23 个 `.so`（最大 `XPU API component` 287MB、
+`XPU BLAS component` 259MB、`XDNN component` 249MB）。按行数：
+
+| 模块 | 行数 | 状态 | 页面 |
+|---|---|---|---|
+| `symbrewrite/` | 13259 | **核心，活跃** | [03](03-symbrewrite.md) |
+| `nn/` | 5614 | 部分活跃（Linear 默认生效） | [06](06-custom-ops-nn.md) |
+| `distributed/` | 3878 | `tensor/` 活跃，其余死代码 | [07](07-distributed.md) |
+| `test_utils/` | 3669 | 测试生成工具 | — |
+| `core/` | 2758 | XLA 时代遗留，大量 `NotImplementedError` | [05](05-device-runtime.md) |
+| `utils/` | 2454 | 活跃（custom_op_loader / version / cpp_extension） | [11](11-debug-tools.md) |
+| `debug/` | 2292 | 全部 opt-in | [11](11-debug-tools.md) |
+| `xflags/` | 2014 | 活跃（其中 1806 行是 vendored tabulate） | [03](03-symbrewrite.md) |
+| `optimizer/` | 1861 | opt-in | [09](09-amp-optimizer.md) |
+| `dynamo/` | 1284 | **死代码**（缺 `torch_xmlir.ir`） | [08](08-compile-dynamo.md) |
+| `xpu/` | 1052 | 部分活跃（`memory.py` 整体不可用） | [05](05-device-runtime.md) |
+| `amp/` | 701 | 无人 import，opt-in 死路径 | [09](09-amp-optimizer.md) |
+| `pd/` | 43 | — | — |
+
+---
+
+下一页：[02-import-hook.md](02-import-hook.md) · 环境变量总表：[10-env-vars.md](10-env-vars.md)

--- a/openwiki/torch-xmlir/02-import-hook.md
+++ b/openwiki/torch-xmlir/02-import-hook.md
@@ -1,0 +1,143 @@
+# 02 · 导入 hook：整条链的起点
+
+[← 首页](README.md) · [← 01 架构](01-architecture.md) · [→ 03 符号改写](03-symbrewrite.md)
+
+这一层回答一个问题：为什么用户代码里 **只写 `import torch`**，昆仑芯的补丁就已经生效了。
+
+## 触发器：`.pth` 文件
+
+`site-packages/torch_xmlir.pth` 只有一行，Python 解释器启动时由 `site` 模块自动执行
+（`.pth` 中以 `import` 开头的行会被 exec）：
+
+```python
+import os, sys;exec('import xpytorch_import_hook\nxpytorch_import_hook.hook_torch()')
+```
+
+这意味着 **只要这个 conda 环境的解释器一启动**，hook 就装好了 —— 哪怕脚本完全不 import torch。**[源码]**
+
+## 安装：替换 `builtins.__import__`
+
+`site-packages/xpytorch_import_hook.py`（151 行）：
+
+```python
+# xpytorch_import_hook.py:13-14
+if not hasattr(builtins, "__origin__import__"):
+    builtins.__origin__import__ = builtins.__import__
+
+# xpytorch_import_hook.py:147-151
+def hook_torch():
+    disable_xpytorch = int(os.environ.get("DISABLE_XPYTORCH", "0"))
+    if disable_xpytorch:
+        return
+    builtins.__import__ = _custom_import
+```
+
+注意实现方式：**替换 `builtins.__import__` 函数**，而不是 `sys.meta_path` 上装
+`MetaPathFinder`/`Loader`。这是全局的、粗粒度的，也是后面一系列怪异行为的根源。**[源码]**
+
+原函数被存到 `builtins.__origin__import__`（一组下划线），用于逃生（见下）。
+
+`DISABLE_XPYTORCH=1` 是整个适配层的总开关，在两处被检查：
+`xpytorch_import_hook.py:148` 和 `$PKG/__init__.py:49`。设置后 hook 不装、
+`_XMLIRC` 不导入、`init()` 不跑。
+
+## 触发条件与一次性 bootstrap
+
+```python
+# xpytorch_import_hook.py:30-34
+trigger_hook_list = ["torch", "torch_xmlir", "torchvision", "transformers"]
+is_trigger = any(
+    module_name == hook or module_name.startswith(hook + ".")
+    for hook in trigger_hook_list
+)
+```
+
+`transformers` 出现在这个列表里有历史原因，行 29 的注释：
+「升级到 transformers 4.42.3 后遇到 import hook 问题，因此需要加入此列表」。**[源码]**
+
+bootstrap（`:37-106`）只跑一次，由模块级 `START` 标志守卫。它做的事按顺序：
+
+1. 注入环境变量（下一节）
+2. `import torch_plugin; torch_plugin.initialize_runtime()` —— 预载 xcudart 垫片（`:75-77`）
+3. `import torch` → `import torch_xmlir`（`:78-80`）
+4. `try: import pyarrow except ImportError: pass`（`:83-86`）—— 注释里挂了一个内部 ku 文档链接，
+   典型的「某个库的加载顺序会炸，先 import 一下压住」workaround
+5. 取两个注册表单例，`enable_rewrite_for_module("torch")`（`:93-95`）
+6. 对其它已注册且已在 `sys.modules` 里的顶层模块，**先 `del sys.modules[m]` 再重新 import**（`:96-106`）
+
+第 6 步是最激进的一步：
+
+```python
+# xpytorch_import_hook.py:96-106
+for i in SYMBOL_REWRITE_REGISTER.reg.keys():
+    module_list = [m for m in sys.modules if (i == m or m.startswith(i + "."))]
+    if i != "torch" and module_list:
+        SKIP_LIST.append(i)
+        for m in module_list:
+            del sys.modules[m]
+        for m in module_list:
+            importlib.import_module(m)
+        SYMBOL_REWRITE_REGISTER.enable_rewrite_for_module(i)
+```
+
+目的是让补丁落在「干净的模块对象」上。副作用是：如果用户在 `import torch` 之前已经
+`import transformers` 并持有了里面的类引用，那些引用会指向被丢弃的旧模块对象。**[静态推断]**
+
+## 强制注入的环境变量
+
+bootstrap 里有 5 个 `if X not in os.environ` 的强制设置，全部带中文注释说明动机。
+这些是**理解昆仑芯行为的关键**，因为它们改变了官方 CUDA runtime 的语义：
+
+| 变量 | 强制值 | 行 | 注释给出的原因 |
+|---|---|---|---|
+| `CUDART_DUMMY_REGISTER` | `1` | `:48-49` | 强制 `__cudaRegister***` 返回成功；不设置的话官方 torch 在 KL3 上会触发底层 runtime 报错 |
+| `CUDART_MODULE_LOADING` | `LAZY` | `:51-52` | 惰性加载 CUDA module |
+| `CUDA_DEVICE_MAX_CONNECTIONS` | `8` | `:58-59` | 单进程单卡场景下把并行流上限拉满；注释点名「llama 70b 多流优化至少需要 5 个流，默认 4 发挥不出优势」 |
+| `CUDA_DEVICE_ORDER` | `OAM_ID` | `:64-68` | 统一各机型拓扑表征。**仅当** `CUDA_VISIBLE_DEVICES` 恰好等于字符串 `"0,1,2,3,4,5,6,7"` 时才设置 |
+| `XPU_FORCE_SHARED_DEVICE_CONTEXT` | `1` | `:71-72` | 共享 device context |
+
+`CUDA_DEVICE_ORDER` 那个条件是精确字符串比较 —— 写成 `"0,1,2,3,4,5,6,7 "`（带空格）
+或者只用 4 张卡，就不会设置，拓扑可能和 8 卡跑法不一致。**[源码]**
+
+## 稳态：每次 import 做什么
+
+bootstrap 之后，`_custom_import` 的每次调用（`:111-139`）逻辑很短：
+
+- 若模块名落在符号改写注册表的某个 bucket，且顶层模块不在 `SKIP_LIST` 里
+  → import 它，然后 `enable_rewrite_for_module`（`:116-122`）
+- 若模块名落在模块替换注册表 → `replace_module`（`:127-139`）
+- 最后一律转交 `builtins.__origin__import__`（`:141-143`）
+
+`SKIP_LIST` 提供「只改一次」语义。所有异常都被 `try/except` 包住，
+只打 `WARNING: hook error!` 到 stderr（`:123-125`, `:137-139`）——
+**补丁失败不会让程序崩，只会让你静默地跑在未打补丁的 torch 上**。这是调试时值得警惕的一点。
+
+## 逃生舱：临时卸掉 hook
+
+因为 hook 会递归进 torch 内部造成麻烦，有一个装饰器专门用来临时还原：
+
+```python
+# $PKG/symbrewrite/plugins/torch/mock_torch.py:109-128
+def with_import_hook_disabled(func):
+    def wrapper(*args, **kwargs):
+        import builtins
+        import_backup = getattr(builtins, "__import__", None)
+        if hasattr(builtins, "__origin__import__"):
+            builtins.__import__ = builtins.__origin__import__
+        try:
+            result = func(*args, **kwargs)
+            ...
+        finally:
+            if import_backup is not None:
+                builtins.__import__ = import_backup
+```
+
+用在 `torch._export.aot_compile`（`plugins/torch/__init__.py:121-125`）和
+「关闭 mock 时的真实 `torch.compile`」（`:136-139`）。**[源码]**
+
+注意名字区分：hook 自己用 `__origin__import__`，symbrewrite 存原始符号用
+`__origin_<name>`，两套约定互不相干。
+
+---
+
+下一页：[03-symbrewrite.md](03-symbrewrite.md) —— 符号改写引擎与插件系统

--- a/openwiki/torch-xmlir/03-symbrewrite.md
+++ b/openwiki/torch-xmlir/03-symbrewrite.md
@@ -1,0 +1,255 @@
+# 03 · symbrewrite：符号改写引擎与插件系统
+
+[← 首页](README.md) · [← 02 导入 hook](02-import-hook.md) · [→ 04 Dispatcher 劫持](04-dispatch-hijack.md)
+
+`symbrewrite/` 是全包最大的模块（13259 行）。名字容易误导：
+
+> **它不是符号表重写，也不是字节码改写。就是 monkeypatch。**
+
+具体只有两种操作：**[源码]**
+
+- **符号替换** — `setattr(父模块或类, 叶子名, 新对象)`，同时把原对象存到 `__origin_<叶子名>`
+- **模块替换** — `sys.modules[源名] = 目标模块`，于是后续 `import apex` 拿到昆仑的替身
+
+（唯一一处 `ctypes.CDLL` 出现在 NVML 垫片调用里，是叶子细节，不是机制本身。）
+
+## 插件作者 API
+
+`$PKG/symbrewrite/__init__.py`（28 行，全文即 API）：
+
+```python
+def SYMBOL_REPLACE(symbol, obj, match_module=None):
+    return SymbolReplaceEntry("K_SYMBOL_REPLACE").register(symbol, obj, match_module)
+
+def MODULE_REPLACE(src, dst):
+    return SymbolReplaceEntry("K_MODULE_REPLACE").register(src, dst)
+
+def MODULE_DPES(model, deps):
+    return SymbolRewriteRegister().add_module_deps(model, deps)
+```
+
+- `SYMBOL_REPLACE("torch.nn.Linear", MyLinear)` — 点分路径字符串 → 对象
+- `MODULE_REPLACE("apex", "torch_xmlir.symbrewrite.plugins.apex")`；`dst=""` 会造一个空的
+  `types.ModuleType` 桩（`module_replace.py:73-78`）
+- `MODULE_DPES("torch", ["torch", "torch.distributed.run"])` — 声明「打补丁前这些子模块必须先 import」
+
+注意 `SymbolReplaceEntry.register` **返回 `None`**（`symbrewrite/__init__.py:27-28`）。
+插件里那些 `symbol_replacements += [SYMBOL_REPLACE(...), ...]` 构造出来的其实是一串
+`None`，注册完全靠副作用完成。**[源码]**
+
+## 打补丁的核心代码
+
+`SymbolRewriteRegister`（`symbrewrite/symbol_rewrite.py:22-171`，`@Singleton`）
+按点分路径第一段分 bucket。实际的 setattr：
+
+```python
+# $PKG/symbrewrite/symbol_rewrite.py:96-110
+symb_list = source_symbol.split(".")
+obj_ = sys.modules[symb_list[0]]
+skip = False
+for symb in symb_list[1:-1]:
+    try:
+        obj_ = getattr(obj_, symb)
+    except Exception as e:
+        print(f"WARNING: replace {source_symbol} error: {e}, skip!", file=sys.stderr)
+        skip = True
+if not skip:
+    setattr(obj_, symb_list[-1], target)
+    setattr(obj_, f"__origin_{symb_list[-1]}", source)
+```
+
+三个要点：
+
+1. **`__origin_` 是 mock 拿回原实现的唯一途径**。例如
+   `torch.distributed.__origin_init_process_group(...)`（`plugins/torch/mock_torch.py:69`）、
+   `ProcessGroup.__origin_barrier`（`:425`）、
+   `torch.nn.functional.__origin_linear`（`nn/linear.py:114`）。
+2. `setattr` 无条件执行，所以 symbrewrite **也能新增本来不存在的属性**。
+   profiler 插件就靠这个给 `EventList` 加了个 `dump` 方法（见 [11](11-debug-tools.md)）。
+3. 中间层 getattr 失败只 skip 加打警告 —— 又一条静默失败路径。
+
+两个额外机制在 `enable_rewrite_for_module`（`:112-142`）：
+
+- **延迟构造**：`if hasattr(target, "is_wrapper") and target.is_wrapper: target = target()`（`:132-133`）。
+  插件用它把替换用的 `nn.Module` 类定义在函数体里，只在补丁真正生效时才构造。
+  例：`wrapper_mock_RMSNorm.is_wrapper = True`（`plugins/transformers/mock_transformers.py:26`）。
+- **调用追踪**：`LOG_SYMBOL_REPLACE=1` 时每次调用都打印调用方 `file:line` 和替换实现的
+  `file:line`（`:134-135` → `symbrewrite/event.py:7-39`）。**排查「到底走的是官方实现还是昆仑实现」时最有用的开关。**
+
+成功时两个注册表都会往 stderr 打彩色横幅 `SYMBOL_REWRITE <module> success` /
+`MODULE_REPLACE <module> success`（本机启动可见 `SYMBOL_REWRITE torch success`）。**[已验证]**
+
+## xflags 插件开关系统
+
+18 个插件，每个是 `symbrewrite/plugins/` 下一个子目录，由 `.xflags` 文件控制开关。
+
+### 文件格式
+
+行式 `name=value`，解析在 `xflags/xflags_cli.py:85-103`：
+
+```python
+for line in lines:
+    if "=" not in line or "#" in line:
+        continue
+    parts = line.strip().split("=")
+    if len(parts) == 2:
+        name, value = parts[0].strip(), parts[1].strip()
+        flags[name] = value
+```
+
+两个坑：**含 `#` 的行整行被丢**（所以 `foo=True # 注释` 会静默失效），
+`=` 超过一个的行被跳过。值以字符串存，`get_flag`（`:66-74`）做大小写不敏感的
+`"true"`/`"false"` → bool 转换，未知名字返回 `False`。**[源码]**
+
+### 默认值（本构建实际状态）
+
+`symbrewrite/plugins/plugins.default.xflags` 全文：
+
+```
+# 列表从上到下插件优先级依次降低
+# 如果插件中出现重复改写，低优先级插件中改写被忽略
+torch=True
+deepspeed_0_14_4=False
+torchbenchmark=False
+torch_vision=True
+torchaudio=True
+reproduce=False
+flash_attn=False
+flash_attn_2_4_2=False
+profiler=False
+apex=False
+transformers_4_32_1=False
+transformers_4_42_3=False
+transformers_4_43_3=False
+transformers_4_49_0=False
+transformers_4_52_3=False
+mmsegmentation_1_0_0=False
+swift=False
+transformers=True
+```
+
+`plugins.xflags`（用户态文件）与之逐字节相同（仅少两行注释）。所以**默认开启的只有
+`torch`、`torch_vision`、`torchaudio`、`transformers` 四个**。**[已验证]**
+
+注意：**flash_attn 默认是关的**。要用昆仑的 FA 实现必须 `XFLAGS --enable flash_attn`。
+
+### 优先级机制
+
+`initialize_plugin_with_xflags()`（`$PKG/__init__.py:95-143`）在导入前把注册表顺序
+`reverse()`（`:121`），从后往前导入。配合注册表「越靠前优先级越高」的约定，
+结果是 **`torch` 插件最后注册、覆盖一切**。**[源码]**
+
+第三方插件走命名约定：任何顶层可导入模块名以 `xpytorch_plugin` 开头的都会被无条件
+导入（`:134-143`），且在 `load_flags` 里被自动注册为 `True`（`xflags_cli.py:61-64`）。
+
+整个调用被 try/except 包住（`:274-281`），插件加载失败只 warn。
+
+### `XFLAGS` 命令行
+
+console_script，装在 `<env>/bin/XFLAGS`，实现 `xflags/xflags_cli.py:173-205`。
+无子命令，四个选项：
+
+| 选项 | 效果 |
+|---|---|
+| `XFLAGS --list` | 打印 ASCII logo + `XFLAG-NAMES / STATUS / DEFAULT` 三列表格（绿=开，红=关） |
+| `XFLAGS --enable a,b` | 逗号分隔批量开启；未知名字抛 `ValueError` |
+| `XFLAGS --disable a,b` | 批量关闭 |
+| `XFLAGS --reset` | 用 default 覆盖用户文件 |
+
+两个注意点 **[源码]**：
+
+- 用户文件 `plugins.xflags` **写在 site-packages 内部**（`xflags_cli.py:32-37` 用
+  `importlib.resources.path` 定位），不是 `$HOME`。所以 `XFLAGS --enable` 需要对已安装包的写权限，
+  且**会被重装/升级覆盖**。容器里改了要注意持久化。
+- `--reset` 与 `--enable` 同时给会互相打架：`:198` 先把 default 写盘，
+  `:201` 的 `update_flags()` 又用**加载 reset 之前**的内存状态覆盖回去，等于 reset 被丢弃。
+
+新增但没写进 flags 文件的插件目录会被自动注册为 `"False"`（`xflags_cli.py:47-53`），即默认关。
+
+## 18 个插件速查
+
+| 插件 | 行数 | 默认 | 干什么 |
+|---|---|---|---|
+| `torch` | 2894 | **开** | 主战场，~35 处改写，详见下节 |
+| `flash_attn` | 2143 | 关 | 整模块替换，FA API → `custom_ops.mha_varlen_fwd/bwd` |
+| `flash_attn_2_4_2` | 2139 | 关 | 同上，少 `flash_attn_kvpacked_func` |
+| `profiler` | 1626 | 关 | 给 `EventList` 加 `dump` + 3 个离线 CLI，见 [11](11-debug-tools.md) |
+| `apex` | 604 | 关 | 整模块替换 `amp_C`/`apex`/`fused_weight_gradient_mlp_cuda` |
+| `transformers` | 232 | **开** | Qwen2/2.5-VL/3/3-VL/3.5/3.5-MoE 的 RMSNorm + RoPE 融合，15 处 |
+| `torchaudio` | 250 | **开** | `amplitude_to_DB` / `mask_along_axis(_iid)` |
+| `torch_vision` | 187 | **开** | **实际什么都不改** —— 6 处替换全被注释掉（`plugins/torch_vision/__init__.py:13-36`） |
+| `mmsegmentation_1_0_0` | 389 | 关 | `SyncBatchNorm` + `Dropout2d`（fp16 bug workaround） |
+| `reproduce` | 336 | 关 | 确定性复现；**import 即生效**（`__init__.py:38`） |
+| `torchbenchmark` | 336 | 关 | 伪造 14 个 `pynvml` 函数 |
+| `transformers_4_42_3` | 204 | 关 | BERT attn、Llama RMSNorm/RoPE、DataLoader/DDP 包装 |
+| `deepspeed_0_14_4` | 161 | 关 | FusedAdam 映射；故意让 `assert_no_cuda_mismatch` 抛异常 |
+| `transformers_4_49_0` | 111 | 关 | Qwen2 RMSNorm+RoPE |
+| `swift` | 61 | 关 | `SwiftSft._get_data_collator`，前 2 步定长 padding 预热 |
+| `transformers_4_52_3` | 56 | 关 | `check_torch_load_is_safe` 等 |
+| `transformers_4_32_1` | 143 | 关 | Baichuan2-13B attention |
+| `transformers_4_43_3` | 41 | 关 | `is_torch_sdpa_available` 等桩 |
+
+## `torch` 插件改了什么
+
+`plugins/torch/__init__.py:21-125` 无条件注册的部分，按意图分组 **[源码]**：
+
+**NCCL → 昆仑集合通信**（详见 [07](07-distributed.md)）：三处 `ProcessGroupNCCL` 别名、
+`is_nccl_available → lambda: True`、`init_process_group`/`new_group`/`get_backend` 包装。
+
+**关掉 GPU codegen 路径**：`torch.jit.script → empty_decorator`（`:22-25`）、
+`torch.jit.fuser → empty_with_decorator`（`:34-37`）、
+`torch.backends.cudnn.enabled → False`（`:78-82`，注释：「防止官方 torch dispatch 到 cudnn 算子」）。
+
+**CUDA IPC**：`reduce_tensor` / `rebuild_cuda_tensor` / `init_reductions` 换成走
+`_XMLIRC._share_cuda_` / `_new_shared_cuda` 的版本（`:98-109`）。协议与官方完全一致，
+只有两个碰驱动 handle 的原语不同。对应 Python 侧实现在 `$PKG/multiprocessing.py:101-203`。
+
+**NVML**：`torch.cuda._raw_device_count_nvml` 和 `torch.cuda.utilization` 通过 `ctypes.CDLL`
+加载随运行时提供的 NVML 兼容库（`mock_torch.py:437-504`），`nvmlUtilization_t` 结构体在 Python 里重新声明了一遍。
+
+**杂项**：`torch.cuda._sleep` / `torch._C._cuda_sleep` → `_XMLIRC._xpu_sleep`（`:26-33`）；
+`Logger.set_runtime_stats_and_log → empty_func`（`:70-73`）。
+
+环境变量门控的块（默认值见 [10](10-env-vars.md)）：
+
+| 变量 | 默认 | 效果 |
+|---|---|---|
+| `XMLIR_ENABLE_MOCK_TORCH_COMPILE` | `true` | **`torch.compile` 变成空装饰器**（`:128-139`） |
+| `XMLIR_ENABLE_LINEAR_FC_FUSION` | `1` | 替换 `nn.Linear` / `F.linear`（`:141-146`） |
+| `XPYTORCH_RUN_ENHANCE` | `0` | 替换 `torch.distributed.run.main` |
+| `XMLIR_FORCE_USE_XPU_GRAPH` | `0` | 替换 `torch.cuda.CUDAGraph` / `graph` |
+| `TORCH_C10D_USE_RANDOM_SLEEP` | `0` | rendezvous 加 rank 错峰 sleep |
+| `TORCH_NN_INIT_IS_GPU_ALIGNED` | `0` | 启用 14 处 GPU 位对齐 RNG 改写（下节） |
+
+### 最特殊的一块：GPU 位对齐 RNG
+
+`TORCH_NN_INIT_IS_GPU_ALIGNED=1` 时，`nn.init.{normal_,uniform_,xavier_*,kaiming_*}`、
+`torch.{rand,randn,randperm,manual_seed}`、`torch.cuda.manual_seed*`、`F.dropout`、
+`nn.Dropout` 全被换成纯 Python/XPU 的 Philox 实现（`mock_torch_init.py`，1207 行）。
+
+目标写在 `mock_torch_init.py:3-20`：实现尝试与目标 CUDA GPU 的 RNG 输出逐位对齐到 `<1e-6`。
+因为 CUDA 的 RNG 输出依赖线程几何，所以需要知道目标卡的 SM 数；可通过
+`GPU_NAME` 或 `GPU_SM_COUNT`+`GPU_THREADS_PER_SM` 指定。
+
+`RANDPERM_KEY_BITS` 用于选择两条 `randperm` key 生成路径：`"32"` 使用 `uint4` 与 unroll 4，`"64"` 使用 `ulonglong2` 与 unroll 2（`gpu_config_manager.py:22-25`，`mock_torch_init.py:50-65`）。
+
+`SET_PHILOX_VERSION` 可选 `xpu`（默认）/`python`/`cpp`；`cpp` 走
+`$PKG/RNG compatibility component`。该组件的加载被
+`$PKG/__init__.py:283-299` 单独守卫，注释说明原因：**它链的是 LLVM `libomp`，
+而 sklearn 链 GNU `libgomp`，同进程共存可能 segfault**，所以默认不加载。**[源码]**
+
+### torchrun 增强（`XPYTORCH_RUN_ENHANCE=1`）
+
+比官方 torchrun 多三件事 **[源码]**：
+
+1. 按 `xpu-smi topo -mo` 解析出的 NUMA 节点给每个 worker 绑 CPU（`enhance_context.py:20-44`）
+2. 用 `SIGKILL` 代替优雅退出（`:58-72`, `:89-98`）
+3. `XTORCHRUN_CLEAN` 非 0 时，启动前清理占着 `/dev/xpu` 的残留进程
+   （`enhance_launch_torch2_5.py:142-156`）
+
+第 3 点值得警惕：实现是 `lsof | grep /dev/xpu | ... | xargs kill -9`，
+**会杀掉本机上除自己以外任何持有 XPU 设备的进程**。多人共用节点时不要开。
+
+---
+
+下一页：[04-dispatch-hijack.md](04-dispatch-hijack.md)

--- a/openwiki/torch-xmlir/04-dispatch-hijack.md
+++ b/openwiki/torch-xmlir/04-dispatch-hijack.md
@@ -1,0 +1,167 @@
+# 04 · Dispatcher 劫持：偷走 DispatchKey::CUDA
+
+[← 首页](README.md) · [← 03 符号改写](03-symbrewrite.md) · [→ 05 设备与运行时](05-device-runtime.md)
+
+Python 层的 monkeypatch 只能改几十个符号。真正让**上千个 aten 算子**跑到昆仑芯上的是这一层。
+
+## 步骤一：注销官方 CUDA kernel
+
+`$PKG/__init__.py` 的**第 26 行**，比 `import _XMLIRC` 还早：
+
+```python
+# $PKG/__init__.py:26-40
+from . import op_deregister_C
+
+ignore_deregister_op = {
+    "aten::record_stream",
+}
+
+res = op_deregister_C.deregister_all_op("CUDA", "aten", ignore_deregister_op)
+assert res, "Deregister cuda aten ops error"
+
+nested_op_list = {"aten::to_padded_tensor"}
+op_deregister_C.deregister_list_ops("NestedTensorCUDA", nested_op_list)
+
+sparse_cuda_op_list = {"aten::_coalesce"}
+op_deregister_C.deregister_list_ops("SparseCUDA", sparse_cuda_op_list)
+```
+
+把 `DispatchKey::CUDA` 上 `aten` 命名空间的**所有** kernel 从 dispatcher 里摘掉，
+只留 `aten::record_stream` 一个例外。另外单点注销 `NestedTensorCUDA::to_padded_tensor`
+和 `SparseCUDA::_coalesce`。**[源码]**
+
+Dispatcher helper extension 导出的 C++ 符号：
+
+```
+torch_xmlir::deregister_all_op(std::string, std::string, std::unordered_set<std::string>)
+torch_xmlir::deregister_list_ops(...)
+```
+
+**[.so 内]** dispatcher 内部到底怎么摘除注册项的，Python 侧看不到。
+
+注意 `assert res`（`:33`）—— 这一步失败会直接让 `import torch` 抛 AssertionError。
+
+## 步骤二：重新注册 XPU kernel
+
+这是 codegen 生成的 C++，编译到 XMLIR Python 扩展中。运行时 `torch._C._dispatch_dump('aten::add.Tensor')` 显示 CPU 注册来自 PyTorch 的 ATen 实现，而 CUDA 注册来自 XMLIR 的 `aten_codegen/generated/RegisterCUDA.cpp`。**[已验证]**
+
+`RegisterCUDA.cpp` 的路径串只出现在 XMLIR Python 扩展中，不出现在其他计算组件中。由此可见，ATen 层注册集中在该扩展，计算实现位于下游编译组件。**[已验证]**
+
+调试意义：**排查算子问题时 `_dispatch_dump` 是最直接的判据**。
+看到 `RegisterCUDA.cpp` 表示走昆仑 kernel，看到 PyTorch 构建目录下的实现则表示走官方实现。
+
+## 步骤三：CUDA ABI 垫片
+
+运行时通过一组 CUDA ABI 兼容组件将 CUDA 驱动、运行时和管理接口转接到 Kunlun XPU 实现。兼容组件提供 CUDA 驱动、CUDA 运行时和 NVML 接口，并在底层调用 XPU 驱动与运行时。**[已验证]**
+
+兼容组件中可见异步 launch 与 wait 相关符号，以及驱动版本错误信息。**[已验证]**
+
+这一层的存在解释了 [05](05-device-runtime.md) 的核心结论：
+**`torch.cuda` 的流、事件、显存分配器、CUDA Graph 全是官方 PyTorch 原码**。
+
+## 步骤四：backend init
+
+`init()` 里与 dispatcher 相关的部分：
+
+```python
+# $PKG/__init__.py:161-168
+if parse_version(torch.__version__) < Version("2.2.0"):
+    torch._C._jit_set_nvfuser_enabled(False)
+torch._C._jit_texpr_set_fallback_allowed(True)
+torch._C._jit_override_can_fuse_on_gpu(False)
+
+_XMLIRC._init_xpu_backend()
+atexit.register(_prepare_to_exit)
+init_op_select()
+```
+
+关掉 GPU 上的 JIT fusion（融合出来的 kernel 是 CUDA 代码，昆仑跑不了），
+初始化后端，注册退出钩子。**[.so 内]** `_init_xpu_backend` / `_prepare_to_exit` /
+`_xpu_init_caching_allocator` 在 `XMLIR Python extension` 里确认存在，实现不可见。
+
+## op_select：逐算子分派策略
+
+`$PKG/_op_select.py` 有两个职责。
+
+### 职责一：预载 xtrans 库 —— **已被注释掉**
+
+```python
+# $PKG/_op_select.py:44-50
+def load_xtrans():
+    try:
+        for path in (api_path, llvm15_path, xtrans_path):
+            _load_shared_library_if_exists(path)
+    except Exception as e:
+        warnings.warn(f"Failed to load optional xtrans component: {e}")
+```
+
+`$PKG/__init__.py:19` import 了它，但 `:21` 的调用是 `# load_xtrans()`。
+而且三个目标里 `optional xtrans component` **本构建没有发货**，
+`_load_shared_library_if_exists`（`:39-41`）会用 `os.path.exists` 静默跳过。
+所以 `XPU API component` / `LLVM runtime component` 的 `RTLD_GLOBAL` 预载从不发生。**[源码]**
+
+### 职责二：注册 op-select 配置（这个是活的）
+
+```python
+# $PKG/_op_select.py:53-58
+def init_op_select():
+    torch_xmlir._XMLIRC._forceRegisterOpsectTrans()
+    config_path = os.getenv("XMLIR_XTRANS_OP_CONFIG", DEFAULT_CONFIG_PATH)
+    data = load_yaml(config_path)
+    processed_data = process_data(data)
+    register_ops(processed_data)
+```
+
+`register_ops`（`:33-36`）逐条推到 C++：
+
+```python
+torch_xmlir._XMLIRC._registerOPSelectConfig(opname, select_type, dtype)
+```
+
+配置文件 `$PKG/op_config.yml`（可用 `XMLIR_XTRANS_OP_CONFIG` 换掉），有效内容：
+
+```yaml
+blacklist:
+  - opname: empty_strided
+  - opname: nonzero
+  - opname: native_batch_norm
+  - opname: convolution_backward
+no_guard_op:
+  - opname: fill_
+```
+
+文件前 5 行是注释掉的模板，记录了另外两个类别 `force_dispatch_trans` 和
+`force_fallback_trans`。四个类别名在 `XMLIR Python extension` 里都能逐字匹配到。**[已验证]**
+
+按名字与相邻环境变量（`XMLIR_XTRANS_OP_PRIOR`、`XMLIR_XTRANS_REGISTER_OPSELECT`）推断：
+`blacklist` 把算子排除出 xtrans 路径（所以这四个算子会回落），
+`no_guard_op` 对 `fill_` 跳过 device guard，两个 `force_*_trans` 分别把算子钉死在
+dispatch-translation / fallback-translation。dtype 字段支持逐 dtype 粒度
+（模板示例是 `add` 配 `dtype: [float16]`）。**[静态推断]** —— 精确语义在 C++ 里，未验证。
+
+## eager fallback
+
+包里有 `eager-fallback component`（496KB），且 `XMLIR Python extension` 内有这些环境变量字符串
+**[.so 内]**：
+
+| 变量 | 名字暗示的作用 |
+|---|---|
+| `XMLIR_ENABLE_FALLBACK_TO_CPU_BOOL` | 允许算子回落到 CPU |
+| `XMLIR_D_FORCE_FALLBACK_STR` | 强制指定算子回落（`validate_aten` 报错时会提示用它，见 [11](11-debug-tools.md)） |
+| `XMLIR_DEBUG_FALLBACK_ALL` / `XACC_DEBUG_FALLBACK_ALL` | 全量回落调试 |
+| `XMLIR_DUMP_FALLBACK_OP_LIST_BOOL` / `XMLIR_FALLBACK_OP_LIST_FILE_PATH` | 导出回落算子清单 |
+| `XMLIR_XDNN_PYTORCH_CHECK_ENABLE_FALLBACK_BOOL` | XDNN 侧回落检查 |
+
+**精度对不上先怀疑某个算子，用 `XMLIR_D_FORCE_FALLBACK_STR='<op>'` 把它按到 CPU 上验证**
+—— 这是 `validate_aten` 内建的诊断建议（`debug/validate_aten/validate/contexts.py:566-569`）。
+
+## 特殊 dispatch 点
+
+`XMLIR Python extension` / `custom-op component` 里有一个值得单独点出的符号：
+`wrapper_CUDA___fused_sdp_choice`。这说明 **SDPA（`scaled_dot_product_attention`）
+的后端选择是在 C++ dispatcher 层截获的**，不在 Python 层，
+可用 `XMLIR_FUSED_SDP_CHOICE` 调整。**[.so 内]**
+
+---
+
+下一页：[05-device-runtime.md](05-device-runtime.md)

--- a/openwiki/torch-xmlir/05-device-runtime.md
+++ b/openwiki/torch-xmlir/05-device-runtime.md
@@ -1,0 +1,297 @@
+# 05 · 设备、流、显存与运行时
+
+[← 首页](README.md) · [← 04 Dispatcher 劫持](04-dispatch-hijack.md) · [→ 06 融合算子](06-custom-ops-nn.md)
+
+本页最重要的一条结论，先说：
+
+> **`torch.cuda.*` 基本没有被重映射。它是原封不动的官方 PyTorch，跑在 CUDA ABI 垫片上。**
+> `torch_xmlir.xpu.*` 是一套**平行的、另起名字的**设备 API，没有被拼接进 `torch.cuda`。
+
+运行时验证 **[已验证]**：
+
+```
+cuda avail True   count 8
+torch.cuda.Stream       -> <class 'torch.cuda.streams.Stream'>      # 官方
+torch.cuda.Event        -> <class 'torch.cuda.streams.Event'>       # 官方
+torch.cuda.memory_stats -> torch/cuda/memory.py                     # 官方
+torch.cuda.CUDAGraph    -> <class 'torch.cuda.graphs.CUDAGraph'>    # 官方
+get_device_name(0)       -> 'GPU'          # 来自垫片，不是 torch_xmlir
+get_device_capability(0) -> (8, 6)         # 同上
+```
+
+两套 API 底下是**同一个** device context，互相可见 **[已验证]**：
+
+```
+torch_xmlir.xpu.set_device(3)  →  torch.cuda.current_device() == 3
+torch.cuda.set_device(5)       →  torch_xmlir.xpu.current_device() == 5
+torch.zeros(4, device='cuda').device  →  cuda:5
+```
+
+## `torch_xmlir.xpu` 设备 API
+
+`$PKG/xpu/device.py`（292 行），全部薄封装 `_XMLIRC` **[源码]**：
+
+| 函数 | 行 | 底层 pybind 调用 |
+|---|---|---|
+| `is_available()` | 109 | `_xpu_get_devices_number() > 0` |
+| `device_count()` | 113 | `_xpu_get_devices_number()` |
+| `current_device()` | 117 | `_xpu_get_device_id()` |
+| `set_device(d)` | 121 | `_xpu_set_default_device(str)` |
+| `synchronize()` | 132 | `_xpu_synchronize_default_stream()` |
+| `get_device_properties(d)` | 137 | `_xpu_get_device_properties(d)` |
+| `get_device_name(d)` | 146 | 上者的 `.name` |
+| `get_device_capability(d)` | 150 | 上者的 `.major`/`.minor` |
+
+`set_device` 有个值得注意的分支 —— 写进去的**设备类型串取决于运行模式**：
+
+```python
+# $PKG/xpu/device.py:121-129
+def set_device(device):
+    device_index = _get_device_index(device, optional=False)
+    device_type = "xla"
+    if param_scope.xacc.eager("false") == "true":
+        device_type = "xpu"
+    device_str = device_type + ":{}".format(device_index)
+    torch_xmlir._XMLIRC._xpu_set_default_device(device_str)
+    device_str = torch_xmlir._XMLIRC._xpu_get_default_device()
+    return torch.device(device_str)
+```
+
+默认（lazy/XLA 模式）产出 `xla:N`；`hyperparameter` 的 `param_scope` 里
+`xacc.eager == "true"` 时产出 `xpu:N`。运行时确认 `torch_xmlir.xpu.set_device(1)`
+返回 `device(type='xla', index=1)`。**[已验证]**
+
+而顶层的 `torch_xmlir.device()`（`$PKG/__init__.py:228-268`）**硬断言** `device_type == "xpu"`
+（`:264`），返回 `device(type='xpu', index=0)`。两个同名概念不一致，注意别混。
+
+`_XMLIRC._xpu_get_device_properties(0)` 的 repr 对自己的不匹配很坦诚 **[已验证]**：
+
+```
+_XpuDeviceProperties(name='KL3', major=0(N/A for XPU), minor=0(N/A for XPU),
+                     total_memory=98304MB, multi_processor_count=12)
+```
+
+所以 `torch_xmlir.xpu.get_device_capability()` 返回 `(0, 0)`，
+而 `torch.cuda.get_device_capability()` 返回 `(8, 6)`。**依赖 capability 做分支的库要小心。**
+
+## `torch.cuda` 里真正被换掉的三个
+
+`plugins/torch/__init__.py` 无条件替换的只有 **[源码]**：
+
+| 符号 | 行 | 换成 |
+|---|---|---|
+| `torch.cuda._sleep`、`torch._C._cuda_sleep` | 26-33 | `_XMLIRC._xpu_sleep` |
+| `torch.cuda._raw_device_count_nvml` | 110-113 | `mock_torch.mock_raw_device_count_nvml`（ctypes → NVML 垫片） |
+| `torch.cuda.utilization` | 114-117 | `mock_torch.mock_torch_utilization` |
+
+其余 `torch.cuda.*` 全是原版。
+
+## 流与事件：Python 侧完全没有实现
+
+全包搜 `class .*Stream` / `class .*Event` 只命中 docstring 和一个 benchmark 用的
+`FakeCudaEvent`（`plugins/torchbenchmark/mock_torch_benchmark.py:125`）。**[已验证]**
+
+映射发生在 C/C++。`XMLIR Python extension` 引用了这些 CUDA runtime 符号 **[.so 内]**：
+
+```
+cudaStreamCreate / Destroy / Query / Synchronize / WaitEvent
+cudaEventCreate / CreateWithFlags / Destroy / ElapsedTime / Query / Record / Synchronize
+cudaIpcGetEventHandle / cudaDeviceSynchronize / cudaHostPointerGetAttributes
+```
+
+以及 XPU 原生的 `xpu_stream_destroy`、`xpu_event_create/destroy/record/wait`、
+`stream_synchronize`。这些最终由 CUDA ABI 兼容库解析到 Kunlun XPU 运行时。
+**翻译逻辑完全在编译产物中，不可见。**
+
+Python 侧唯一可见的同步原语是 `_XMLIRC._xpu_synchronize_default_stream()`，
+暴露为 `xpu/device.py:132 synchronize()` 和 `:291 xpu_synchonize_default_stream()`
+（注意后者拼写少个 `r`，是源码里的笔误）。
+
+相关 `.so` 内环境变量 **[.so 内]**：`XMLIR_DIST_SINGLETON_STREAM`、
+`XMLIR_DIST_USE_DEFAULT_STREAM`、`XMLIR_OP_USE_DEFAULT_STREAM`、`XPU_SUPPORT_IPC_EVENT`。
+
+## CUDA Graph
+
+`$PKG/xpu/graphs.py`（143 行）提供 `CUDAGraph`（`:8`）和 `graph`（`:80`）。
+
+```python
+# $PKG/xpu/graphs.py:8-36
+class CUDAGraph(torch_xmlir._XMLIRC._CUDAGraph):
+    def __new__(cls):
+        return super().__new__(cls)
+    def capture_begin(self, pool=None, capture_error_mode="global"):
+        super().capture_begin(pool=pool, capture_error_mode=capture_error_mode)
+```
+
+所有方法都是纯 docstring 转发，Python 里没加任何 XPU 特有逻辑。
+`_CUDAGraph` 绑的是 **PyTorch 自己的 `at::cuda::CUDAGraph`** —— `XMLIR Python extension` 里有
+mangled 符号 `_ZN2at4cuda9CUDAGraph13capture_beginESt4pairIyyE21cudaStreamCaptureMode` 等。
+即 graph capture 是官方 ATen 代码跑在昆仑 `cudaStreamCapture*` 垫片上。**[已验证]**
+
+`graph`（`:80`）是官方 `torch.cuda.graph` 的逐字拷贝，内部还是用真的
+`torch.cuda.Stream()`（`:116`）、`torch.cuda.synchronize()`、`torch.cuda.empty_cache()`（`:127-138`）。
+
+**默认不安装**：
+
+```python
+# $PKG/symbrewrite/plugins/torch/__init__.py:157-164
+use_xpu_graph = int(os.getenv("XMLIR_FORCE_USE_XPU_GRAPH", 0))
+if use_xpu_graph:
+    import torch_xmlir.xpu.graphs as xpu_graphs
+    symbol_replacements += [
+        SYMBOL_REPLACE("torch.cuda.CUDAGraph", xpu_graphs.CUDAGraph),
+        SYMBOL_REPLACE("torch.cuda.graph", xpu_graphs.graph),
+    ]
+```
+
+而且 `xpu/graphs.py` 不在 `xpu/__init__.py` 的星号导入里，要显式 import。**[源码]**
+
+## 显存：`xpu/memory.py` 在本构建整体不可用
+
+这是本次分析里最值得警惕的发现之一。`$PKG/xpu/memory.py`（441 行）声明了一整套
+CUDA 形状的显存 API 并写了 `__all__`（`:11-30`），但**底层 pybind 符号有四个不存在** **[已验证]**：
+
+```
+empty_cache      → AttributeError: module 'torch_xmlir._XMLIRC' has no attribute '_xpu_empty_cache'
+memory_stats     → AttributeError: ... '_xpu_memory_stats'
+memory_snapshot  → AttributeError: ... '_xpu_memory_snapshot'
+mem_get_info     → AttributeError: ... '_mem_get_info'
+```
+
+对包内 23 个 `.so` 逐一 grep `_xpu_empty_cache` / `_xpu_memory_stats` / `_mem_get_info` /
+`_xpu_set_per_process_memory_fraction` / `_xpu_memory_snapshot`：**零命中**。
+
+因为 `memory_allocated`（`:223`）、`max_memory_allocated`、`memory_reserved`、
+`memory_cached`、`memory_summary`（`:308`）等全部经由 `memory_stats` →
+`memory_stats_as_nested_dict`（`:145`），**整个模块都会抛 `AttributeError`**。
+
+好消息是这只在一个开关后面才被接进 `torch.cuda`：
+
+```python
+# $PKG/symbrewrite/plugins/torch/mock_allocator.py:6-11
+XMLIR_DISABLE_CUDA_ALLOCATOR = os.environ.get("XMLIR_DISABLE_CUDA_ALLOCATOR") == "1"
+
+def return_allocator_register():
+    if XMLIR_DISABLE_CUDA_ALLOCATOR:
+        allocator_apis = [ ... 14 个 SYMBOL_REPLACE ... ]
+        return allocator_apis
+    return []
+```
+
+**结论：不要设 `XMLIR_DISABLE_CUDA_ALLOCATOR=1`** —— 会把 14 个
+`torch.cuda.memory_*` 指到这些坏掉的函数上。默认不设时，用的是**官方 PyTorch CUDA
+caching allocator**，`PYTORCH_CUDA_ALLOC_CONF` 按官方语义正常生效
+（torch_xmlir 的 Python 代码里完全没引用它）。**[已验证]**
+
+`xpu/memory.py` 里唯一能用的是 `use_l3`（`:434-441`），一个把 `use_l3 = True`
+推进 `param_scope` 的上下文管理器，供 C++ kernel 读取。
+
+另有一条独立可用的路径：`core/xpu_model.py:1107 get_memory_info(device)` 调
+`_XMLIRC._xpu_memory_info(str(device))`，返回 `{kb_free, kb_total}` —— 与坏掉的
+`_mem_get_info` 是不同符号。**[静态推断]** 未实际调用验证。
+
+### `_XMLIRC` 自己的 allocator
+
+`$PKG/__init__.py:200` 调 `_XMLIRC._xpu_init_caching_allocator()`，这个符号**存在**。
+行为在 C++ 里。从 `.so` 字符串表能看到它读的旋钮 **[.so 内]**：
+
+| 变量 | 名字暗示 |
+|---|---|
+| `XMLIR_CACHING_ALLOC_ENABLED` | XMLIR caching allocator 总开关 |
+| `XMLIR_D_XPU_L3_SIZE` | L3 scratch 大小 |
+| `XMLIR_D_XPU_ENABLE_L3_SHARE` | L3 共享 |
+| `XMLIR_F_XPU_RESERVED_L3_INT` | 预留 L3 字节数 |
+| `XMLIR_F_XPU_RESERVED_WORKSPACE_INT` | 预留 workspace 字节数 |
+| `XMLIR_LRU_CACHE_SIZE` | LRU cache 容量 |
+| `XMLIR_MEMCPY_RETRY_SYNC` | memcpy 重试/同步行为 |
+| `XMLIR_EMPTY_OP_INIT_ZERO` | `empty` 系列分配是否置零 |
+| `XMLIR_DISK_CACHE_DIR` / `XMLIR_PERSISTENT_CACHE_ENABLED` | 编译图磁盘缓存 |
+
+默认值与解析方式**未验证** —— 只是字符串表证据。
+
+## L3 内存
+
+昆仑芯有片上 L3 scratch，是这套栈里 GPU 没有的概念。三个接触点：
+
+- `torch_xmlir.xpu.use_l3()` 上下文管理器（`xpu/memory.py:434`）
+- `nn/linear.py:23` 的 `USE_L3` 环境变量：非空时把 legacy Linear 的输出 buffer 分配到 L3（`:49-51`）
+- C++ 侧 `XMLIR_D_XPU_L3_SIZE` / `XMLIR_D_XPU_ENABLE_L3_SHARE` / `XMLIR_F_XPU_RESERVED_L3_INT`
+- `plugins/torchbenchmark/test_torch_benchmark.py:41-43` 读伪造 memory-info 上的
+  `totalL3Memory` / `usedL3Memory` / `freeL3Memory`
+
+## XPU3 运行模式：会写硬件寄存器
+
+`$PKG/_xpu3_run_mode.py`（107 行）通过两个 CLI 工具直接读写**硬件寄存器**，
+切换 matmul/FP 流水的精度模式。
+
+```python
+# $PKG/_xpu3_run_mode.py:15-20
+self._mode_map = {
+    "TRAIN-BF16": "3",
+    "TRAIN-FP16": "0",
+    "INFER-BF16": "-1",
+    "INFER-FP16": "-1",
+}
+```
+
+两个 INFER 模式写的是同一个值，寄存器层面无法区分。**[源码]**
+
+- 工具：运行时提供的寄存器读取与写入工具。分析环境确认这些工具存在并可被调用。**[已验证]**
+- 寄存器：实现会写入多组硬件寄存器，具体地址和拓扑映射不在本文公开。
+- 设备选择（`:56-64`）：默认 `0..7`；有 `LOCAL_RANK` 就只改那一张；
+  否则按 `CUDA_VISIBLE_DEVICES` 的逗号数量
+
+触发点在 `init()`：
+
+```python
+# $PKG/__init__.py:170-176
+global xpu_run_mode
+if xpu_run_mode is not None:
+    assert isinstance(xpu_run_mode, str)
+    xpu_run_mode = xpu_run_mode.upper()
+    set_xpu3_run_mode(xpu_run_mode)
+    check_xpu3_run_mode(xpu_run_mode)
+```
+
+**注意事项** **[源码]**：
+
+1. 只有显式设置 `XPU_RUN_MODE` 才会写寄存器。
+2. 这是**在 import 期修改多张卡的共享硬件状态**。同一节点上并发跑多个任务时，
+   一个进程设 `XPU_RUN_MODE` 会影响所有选中的设备。
+3. 拼错的模式名会被**静默忽略** —— `write()` 遇到未知 mode 只 warn 就 return（`:72-76`），
+   `check()` 也 warn 后 return。所以 `XPU_RUN_MODE=TRAIN_BF16`（下划线而非连字符）不会报错，
+   只是什么都没做。
+4. `check()` 读回不匹配时抛 `RuntimeError("XPU run mode check failed.")`（`:92-93`）。
+5. `_get_device` 声明时没有 `self` 也没有 `@staticmethod`，靠在类上访问才能工作（`:14`）。
+
+关于「XPU3 vs P800」：该文件没有公开的代次分支逻辑。本文分析的运行时构建包含 P800 专用内核产物，因此 **该构建面向 P800，`_xpu3_run_mode.py` 是继承下来的 XPU3 代次寄存器接口**。**[静态推断]**
+
+## `core/`：XLA 时代的化石
+
+`core/`（2758 行）来自 torch_xla 血统，现在大部分是死的 **[源码]**：
+
+| 文件 | 行数 | 状态 |
+|---|---|---|
+| `core/xpu_builder.py` | 1260 | XLA/HLO 风格图构建 DSL，~110 个方法，全部落到 `_XMLIRC._xpu_op_*` |
+| `core/xpu_model.py` | 1191 | 运行时/分布式模块。**`mark_step` 在 `:678` 无条件 `raise NotImplementedError`**，`xpu_device` 在 `:184` 同样 raise |
+| `core/functions.py` | 164 | autograd 感知的集合通信包装 + `nms` + `distributed_mm` |
+| `core/xpu_op_registry.py` | 95 | `register(name, opfn)` 用户自定义算子注册，op 名前缀 `"xla::_op_"` |
+| `core/xpu_env_vars.py` | 42 | 22 个 XRT/TPU 风格环境变量名常量，其中 **19 个无人消费**，纯 torch_xla 遗留 |
+
+因为 `optimizer_step` 在 `:919`/`:947` 调 `mark_step`，**整条 lazy-tensor
+`optimizer_step` 路径在本构建不可用**。
+
+`core/` 里还活着的环境变量（经 `utils/utils.py:175-182` 的 `getenv_as` 读取）：
+
+| 变量 | 位置 | 默认 | 含义 |
+|---|---|---|---|
+| `ALLREDUCE_FUSION` | `xpu_model.py:801` | `True` | all-reduce 前做梯度分桶 |
+| `ALLREDUCE_BUCKET_SIZE` | `:802-804` | 32MB | 桶大小 |
+| `ALLREDUCE_CHECK` | `:809,838` | `False` | 调试：拿 gloo CPU all-reduce 对账 |
+| `XLA_SYNC_WAIT` | `:696,716` | `False` | 阻塞同步（`:716` 在 `get_xpu_data_ptr` 里是活的） |
+| `XRT_SHARD_WORLD_SIZE` / `_ORDINAL` / `_LOCAL_ORDINAL` | `:113,129,145` | `1`/`0`/`-1` | 复制组 world size 与 ordinal |
+| `RATE_TRACKER_SMOOTHING` | `:269` | `0.4` | `RateTracker` 的 EMA 系数 |
+
+---
+
+下一页：[06-custom-ops-nn.md](06-custom-ops-nn.md)

--- a/openwiki/torch-xmlir/06-custom-ops-nn.md
+++ b/openwiki/torch-xmlir/06-custom-ops-nn.md
@@ -1,0 +1,237 @@
+# 06 · custom_ops 与 nn/ 融合算子
+
+[← 首页](README.md) · [← 05 设备与运行时](05-device-runtime.md) · [→ 07 分布式](07-distributed.md)
+
+## 自定义算子组件
+
+`$PKG/__init__.py:215` 会加载自定义算子组件。`utils/custom_op_loader.py:17` 是对 `torch.ops.load_library` 的断言包装。
+
+加载后，算子挂在 `torch.ops.custom_ops.*` 命名空间下。分析环境从编译组件的字符串表中提取到 **108 个 `custom_ops::` schema**。**[已验证]**
+
+该组件依赖多个计算、GEMM、DNN、Flash Attention、集合通信和运行时组件。**[.so 内]** 数值实现位于这些编译组件中，Python 侧只能看到 schema 名和调用点。
+
+`$PKG/__init__.py:218` 紧接着 `from torch_xmlir.distributed import tensor`，
+顺序必须如此 —— DTensor 注册代码在导入期就引用 `torch.ops.custom_ops.*`（见 [07](07-distributed.md)）。
+
+## 唯一默认生效的 nn 替换：Linear
+
+```python
+# $PKG/symbrewrite/plugins/torch/__init__.py:141-146
+linear_fc_fusion_enable = int(os.getenv("XMLIR_ENABLE_LINEAR_FC_FUSION", 1))
+if linear_fc_fusion_enable:
+    symbol_replacements += [
+        SYMBOL_REPLACE("torch.nn.Linear", linear.Linear),
+        SYMBOL_REPLACE("torch.nn.functional.linear", linear.linear),
+    ]
+```
+
+默认 **开**，运行时确认 `torch.nn.Linear.__module__ == 'torch_xmlir.nn.linear'`。**[已验证]**
+
+注意 `int(os.getenv(...))` —— 传非数字值（如 `XMLIR_ENABLE_LINEAR_FC_FUSION=false`）会抛 `ValueError`。
+
+### 三条分派路径
+
+`nn/linear.py:102-138` 的 `_linear` 是真正的决策点 **[源码]**：
+
+```python
+def _linear(input, weight, bias=None, *, out=None) -> Tensor:
+    if out is not None or force_nn_linear:
+        return torch._C._nn.linear(input, weight, bias, out=out)
+
+    if os.getenv("XMLIR_USE_HYDRA_LINEAR", "1") == "1":
+        with stateful_config.make_tensors_stateful(input, weight):
+            return hydra_linear(input, weight, bias)
+    else:
+        if not input.is_cuda:
+            return torch.nn.functional.__origin_linear(input, weight, bias)
+        ...
+        output = LinearFunction.apply(input.reshape(-1, input.shape[-1]), weight, bias)
+        return output.view(input.shape[:-1] + (weight.shape[0],))
+```
+
+| 条件 | 走哪条 |
+|---|---|
+| `FORCE_NN_LINEAR` 非空，或给了 `out=` | 官方 `torch._C._nn.linear`（最高优先级 kill switch） |
+| `XMLIR_USE_HYDRA_LINEAR=1`（**默认**） | `hydrax.xaccelerator.linear.linear` |
+| `XMLIR_USE_HYDRA_LINEAR=0` | 包内 `LinearFunction` → `torch.ops.custom_ops.linear` |
+
+**关键发现：默认路径不在 torch_xmlir 里。** 真正的 fast-FC GEMM 位于独立的 `hydrax` 包：`hydrax/xaccelerator/linear/_linear.py:118 LinearFunction` → `_utils.py:26 fc_fusion_wrapper` → `hydrax.Hydra.*fc_fusion`。反向拆成 `linear_bwd_dgrad` / `linear_bwd_wgrad` / `linear_bwd_bgrad`。**排查 Linear 性能或精度问题时还需要检查 hydrax。**
+
+`XMLIR_USE_HYDRA_LINEAR` 是**精确字符串比较 `== "1"`**，写 `"true"` 无效。
+
+legacy 路径（`XMLIR_USE_HYDRA_LINEAR=0`）在 autocast 需要 cast 任一操作数时会退回官方
+`torch._C._nn.linear`（`nn/linear.py:118-131`）。
+
+`XMLIR_DYNAMO_WORKAROUND=1` 且无 `out=` 时，走自定义 op
+`torch.ops._dynamo_workaround.linear`（定义在 `nn/linear.py:141-147`，
+注册了 `CUDA`/`AutogradCUDA`/CPU），让 dynamo 能 trace（`:162`）。
+
+一个行为提示：`Linear.reset_parameters`（`nn/linear.py:233-241`）是官方实现的逐字拷贝，
+所以 `config.weight_initializer_enable` 这个名字虽然叫「初始化器使能」，**对这里毫无影响**。
+
+## `nn/` 融合算子全表
+
+全部经 `torch.ops.custom_ops.*` 调用 **[源码]**。除 Linear 外**都需要用户显式 import**
+或由某个 symbrewrite 插件接入。
+
+### 归一化
+
+| 类 | 位置 | custom_ops |
+|---|---|---|
+| `RMSNormFunction` / `RMSNormLayer` | `nn/rms_norm.py:6,40` | `rms_layer_norm` / `rms_layer_norm_backward` |
+| `DropoutAddLayernormFunction` | `nn/dropout_add_layernorm.py:12` | `dropout_add_layernorm_forward` / `_backward` |
+| `DropoutAddRMSLayernormFunction` | `nn/dropout_add_rms_layernorm.py:12` | `dropout_add_rms_layernorm_forward` / `_backward` |
+
+`rms_norm.py:17` 里 `rstd` 恒按 `float32` 分配；`:12-16` 算出来的 `stats_dtype` 是死代码。
+
+**普通 LayerNorm 在 `nn/` 里没有替换。** `custom_ops::te_layer_norm` 存在但没有 Python 包装。
+apex 插件（`plugins/apex/normalization/fused_layer_norm.py:23-31`）明确回落到
+`torch.ops.aten.native_layer_norm`，注释：「APEX's FusedLayerNormAffineFunction is not
+supported in KL yet」，只有 RMS 变体复用了 `torch_xmlir.nn.rms_norm.RMSNormFunction`。
+
+### RoPE 家族（5 个文件 8 个实现）
+
+| 类 | 位置 | custom_ops |
+|---|---|---|
+| `FusedRoPEFunc` / `FusedRope` | `nn/rope.py:7,118` | `fused_rope_forward` / `_backward`（支持 BLHD/BHLD/LBHD/THD、interleaved） |
+| `RotaryPosEmbFunction` | `nn/rotary_pos_emb.py:8` | `rotary_pos_emb` / `_backward` |
+| `RotaryPosEmbQKFunction` | `nn/rotary_pos_emb.py:50` | `rotary_pos_emb_qk` / `_qk_backward` |
+| `RotaryPosEmbIdxFunction` | `nn/rotary_pos_emb_index.py:6` | `rotary_pos_emb_index` / `_index_backward` |
+| `RotaryNoFreqsPosEmbAABBFunction` | `nn/rotary_no_freqs_pos_emb.py:6` | `rotary_no_freqs_pos_emb_forward` / `_backward` |
+| `RotaryNoFreqsPosEmbABABFunction` | `nn/rotary_no_freqs_pos_emb.py:45` | `rotary_no_freqs_pos_emb_abab` / `_abab_backward` |
+| `TeRotaryPosEmbFunction` | `nn/te_rotary_pos_emb.py:8` | `te_rotary_pos_emb` / `_backward` |
+| `PrecomputeRotaryEmbeddingFunction` | `nn/precompute_rotary_embedding.py:12` | `precompute_rotary_embedding_forward` / `_backward` |
+
+⚠️ `nn/rotary_pos_emb_index.py:18,73` 用 `layout is "BLHD"` —— **字符串用 `is` 比较**，
+依赖 CPython interning，不保证成立。见 [12](12-pitfalls.md)。
+
+### Attention 相关
+
+`nn/` 里 **没有 SDPA，也没有 flash attention**。有的是：
+
+| 类 | 位置 | custom_ops |
+|---|---|---|
+| `ScaledSoftmaxFunction` | `nn/scaled_softmax.py:5` | `scaled_softmax_forward` / `_backward` |
+| `SoftmaxWithMaskFunction` | `nn/softmax_with_mask.py:5` | `softmax_with_mask` / `_backward`（mask 按 `mask.to(dtype) * (-10000.0)` 处理，`:15`） |
+| `BmmFunction` | `nn/bmm.py:12` | `findmax` + `bmm_with_max` |
+| `BaddbmmFunction` | `nn/baddbmm.py:12` | `findmax` + `baddbmm_with_max` |
+
+`bmm`/`baddbmm` 是量化实现：先跑 `custom_ops.findmax` 求 per-tensor scale 到一个 64 元素
+float buffer，除非 `XDNN_FC_GEMM_DTYPE == "float32"` 才跳过（`nn/bmm.py:31`, `nn/baddbmm.py:22`）。
+
+**Flash attention 在插件里**（默认关，需 `XFLAGS --enable flash_attn`）：
+`plugins/flash_attn/mock_flash_attn_interface.py:63,135` 调
+`torch.ops.custom_ops.mha_varlen_fwd` / `mha_varlen_bwd`，其 kernel 位于编译组件中。
+`XMLIR_FA_ACCUM_TYPE`（`float`|`float16`，默认 `float`）选 softmax-LSE 累加 dtype。
+定长入口会自己合成 `cu_seqlens`（`:34-39`）。
+
+**SDPA 在 C++ 层截获** —— `wrapper_CUDA___fused_sdp_choice`，见 [04](04-dispatch-hijack.md)。
+
+### 激活与逐元素
+
+| 类 | 位置 | custom_ops | 备注 |
+|---|---|---|---|
+| `SwiGLUFunction` | `nn/swiglu.py:6` | `swiglu_forward` / `_backward` | 带 `axis` 和 `turn`（哪一半过 SiLU）；`SwiGLUCpu`（`:68`）是 CPU 参考实现 |
+| `GeluWithBiasFunction` | `nn/gelu_with_bias.py:12` | `gelu_with_bias` | **只有前向**（`:21` 注明 backward 未实现） |
+| `T2iModulateFunction` | `nn/t2i_modulate.py:12` | `t2i_modulate` / `_backward` | DiT/PixArt 的 `x*(1+scale)+shift` |
+| `DropoutAddFunction` | `nn/dropout_add.py:12` | `dropout_add_forward` / `_backward` | |
+| `BiasDropoutAddFunction` | `nn/bias_dropout_add.py:12` | `bias_dropout_add_forward` | backward 复用 `dropout_add_backward` |
+
+### 其它
+
+- **ResNet unit 融合**：`nn/resnet_unit_fusion.py`（642 行，3 个 Function）和
+  `nn/resnet_unit_fusion_frozen_bn.py`（650 行，3 个）。Conv+BN+ReLU(+shortcut) 融合。
+  两个设计约束写在代码里：custom-op 框架**没有 C++ shape inference，所以形状在 Python 里算**
+  （`:91-92` → `conv2d_shape_infer:10`），BN 参数必须 fp32（`check_bn_dtype_fp32:40`）。
+  上一个 unit 返回的 `reserve_space` 会作为下一个的 `x_maxptr` 传入（`:82`），是量化 scale 串联方案。
+- **Paged KV cache**：`nn/alloc_extend.py:60` → `custom_ops.alloc_extend_forward`，仅前向。
+- **checkpoint**：`nn/checkpoint.py:112` 带 XPU RNG 状态保存/恢复的激活重算。
+- **clip_grad**：`nn/clip_grad.py:69` 把 `clip_grad_norm` 拆成 pow/sum/pow，**避开 `torch.norm`**。
+  同样思路的第二、三份拷贝在 `optimizer/BertAdam.py:59-120`。
+- **mmcv**：`nn/mmcv_ops/mmcv_scatter_points.py`（96 行）只覆盖 `dynamic_scatter`；
+  `mean`/`sum` 的 backward **直接 raise**（`:83-86`），只有 `max` 实现了。
+  更广的 mmcv 算子（deform_conv、ms_deform_attn、roi_align、nms_rotated、ball_query…）
+  在 `.so` 里有 C++ 实现但没有 Python 包装。
+
+### Loss 算子
+
+`nn/` 里**没有**。`.so` 里有 `custom_ops::hard_softmax_with_cross_entropy`、
+`te_cross_entropy`、`sigmoid_focal_loss_forward/backward`，但没有 Python 调用点。**[已验证]**
+
+## `config.py`：13 个 flag，只有 2 个有人用
+
+`Config`（`config.py:4`）13 个布尔属性，`config = Config.from_env()` 在
+`config.py:163` **模块导入期实例化** —— `import torch_xmlir` 之后再改环境变量无效。**[源码]**
+
+### 直接来自环境变量
+
+| 属性 | 环境变量 | 默认 |
+|---|---|---|
+| `disable_cast_cache` | `DISABLE_CAST_CACHE` | `0` |
+| `use_fast_bf16_fc` | `XMLIR_ENABLE_FAST_FC` | `0` |
+| `enable_param_state` | `XMLIR_LINEAR_CACHE_PARAM` | `1` |
+| `enable_activ_state` | `XMLIR_LINEAR_CACHE_ACTIV` | `0` |
+| `use_fast_bf16_fc_fwd_out` | `XMLIR_ENABLE_FAST_FC_FWD_OUT` | `0` |
+| `use_fast_bf16_fc_bwd_dw` | `XMLIR_ENABLE_FAST_FC_BWD_DW` | `0` |
+| `use_fast_bf16_fc_bwd_dx` | `XMLIR_ENABLE_FAST_FC_BWD_DX` | `0` |
+| `batch_parallel_enabled` | `XMLIR_BATCH_PARALLEL` | `0` |
+| `parallel_save_memory_enabled` | `XMLIR_PARALLEL_SAVE_MEMORY` | **`true`** |
+
+### 派生（无独立环境变量）
+
+| 属性 | 推导 | 行 |
+|---|---|---|
+| `weight_mix_precision` | `fwd_out != bwd_dx`（XOR） | `:129` |
+| `weight_initializer_enable` | `fwd_out or bwd_dx` | `:130` |
+| `use_fast_bf16` | `fwd_out or bwd_dw or bwd_dx` | `:131-135` |
+| `use_cast_fc_fusion` | **硬编码 `0`**，与环境无关 | `:136` |
+
+### 覆盖关系（两条，都是坑）
+
+**(a) `XMLIR_ENABLE_FAST_FC` 是总开关，会屏蔽三个分方向变量**（`config.py:94-127`）：
+
+```python
+if use_fast_bf16_fc:
+    use_fast_bf16_fc_fwd_out = True
+    use_fast_bf16_fc_bwd_dw  = True
+    use_fast_bf16_fc_bwd_dx  = True
+    enable_param_state = os.getenv("XMLIR_LINEAR_CACHE_PARAM", "1").lower() in (...) and not disable_cast_cache
+    enable_activ_state = os.getenv("XMLIR_LINEAR_CACHE_ACTIV", "0").lower() in (...) and not disable_cast_cache
+else:
+    use_fast_bf16_fc_fwd_out = ...  # 分别读三个变量
+    enable_param_state = False
+    enable_activ_state = False
+```
+
+两个后果：
+1. 开了总开关就**不能再单独关掉某一个方向** —— 三个分变量根本不读。而且三者全 True 让
+   `:129` 的 XOR 恒为 False，`weight_mix_precision` 在总开关模式下永远拿不到。
+   混精度只能靠「总开关关闭 + 单独设分方向变量」达到。
+2. 总开关关闭时，**两个 cast cache flag 被强制 False**（`:126-127`），
+   无视 `XMLIR_LINEAR_CACHE_PARAM`。由于后者默认 `"1"`，参数 cast cache **看起来默认开、
+   实际在原生环境里是关的**。
+
+**(b) `DISABLE_CAST_CACHE` 是硬否决**（`:106`, `:114`），压过 `XMLIR_LINEAR_CACHE_*`。
+
+### 谁在真正读这些 flag
+
+对整个 site-packages grep 每个属性名：**只有 2 个有消费者** ——
+`enable_param_state` 和 `enable_activ_state`，都在 `nn/linear.py:19-20` 喂给 hydrax 的
+`StatefulConfig`。另外 11 个属性**零消费者**。**[已验证]**
+
+但环境变量本身不是死的，只是别人绕过 `Config` 直接读 **[已验证]**：
+
+- `transformer_engine/pytorch/module/linear.py:294,299,503,509`、`layernorm_linear.py:322,565`、
+  `grouped_linear.py:916`、`cpp_extensions/gemm.py:135` 读 `XMLIR_ENABLE_FAST_FC` 和
+  `XMLIR_BATCH_PARALLEL`，而且**解析方式不一致** —— `gemm.py:135` 用
+  `in ("true","1","True")` 且无默认值，大小写敏感。
+- `hydrax/xaccelerator/linear/_mixed_precision_linear.py:169-173` 读全部四个 `XMLIR_ENABLE_FAST_FC*`
+  加 `DISABLE_CAST_CACHE`；`hydrax/xaccelerator/cache.py:156` 读 `DISABLE_CAST_CACHE`。
+- `DISABLE_CAST_CACHE` 与 `XDNN_FC_GEMM_DTYPE` 都出现在编译组件的字符串表中，说明 C++ 侧也会读取这些变量。
+
+**结论：`config.py` 是一个被生态绕过的历史遗留注册表，唯一还在履行的职责是 linear cast-cache 策略。
+调 fast-FC 时应该直接设环境变量，并且注意 TE / hydrax 各自的解析差异。**
+
+---
+
+下一页：[07-distributed.md](07-distributed.md)

--- a/openwiki/torch-xmlir/07-distributed.md
+++ b/openwiki/torch-xmlir/07-distributed.md
@@ -1,0 +1,283 @@
+# 07 · 分布式：kccl / bccl / DTensor / DDP
+
+[← 首页](README.md) · [← 06 融合算子](06-custom-ops-nn.md) · [→ 08 编译](08-compile-dynamo.md)
+
+先说一个反直觉的事实：**`$PKG/distributed/` 这 3878 行 Python 里没有一行 XCCL/BKCL 代码，
+也没有一个环境变量。** 通信后端完全在 C++，Python 侧的接入靠 symbrewrite 插件。
+
+## NCCL → kccl/bccl 的三层改名
+
+### 第一层：类别名
+
+```python
+# $PKG/symbrewrite/plugins/torch/__init__.py:50-60
+SYMBOL_REPLACE("torch.distributed.ProcessGroupNCCL", torch.distributed.ProcessGroupXCCL),
+SYMBOL_REPLACE("torch._C._distributed_c10d.ProcessGroupNCCL", torch.distributed.ProcessGroupXCCL),
+SYMBOL_REPLACE("torch.distributed.distributed_c10d.ProcessGroupNCCL", torch.distributed.ProcessGroupXCCL),
+```
+
+三个 import 位置全覆盖。运行时确认
+`torch.distributed.ProcessGroupNCCL is torch.distributed.ProcessGroupXCCL`。**[已验证]**
+
+配套：`torch.distributed.is_nccl_available → lambda: True`（`:83-86`，运行时确认返回 `True`）。
+
+### 第二层：backend 字符串双向翻译
+
+```python
+# $PKG/symbrewrite/plugins/torch/mock_torch.py:21-31
+ENABLE_NEW_PG = os.environ.get("XMLIR_ENABLE_NEW_PG", "1").lower() in ("1","true","yes","on")
+
+def _get_backend_name():
+    """Get the backend name based on ENABLE_NEW_PG environment variable"""
+    return "kccl" if ENABLE_NEW_PG else "bccl"
+```
+
+- `mock_init_process_group`（`:46-69`）和 `mock_new_group`（`:153-179`）
+  把所有 str 参数里的 `"nccl"` 子串替换成 `"kccl"`/`"bccl"`
+- `mock_get_backend`（`:72-77`）**反向**映射回 `"nccl"`，让用户代码里
+  `if dist.get_backend() == "nccl"` 依然成立
+- `mock_dist_name`（`:430-434`）把 `"custom"` 也报成 `"nccl"`
+- `mock_barrier`（`:420-427`）在 custom backend 上裸调时注入 `BarrierOptions(device=cuda)`
+
+**这是「兼容性伪装」的典型手法：对内改名，对外装作没改。** 好处是绝大多数框架代码
+不用改；代价是日志和报错信息可能自相矛盾。**[源码]**
+
+### 第三层：C++ 里的两套 ProcessGroup
+
+XMLIR Python 扩展中同时存在**两个**实现 **[已验证]**：
+
+| 代次 | C++ 类 | 注册函数 | backend 名 | 源码路径（编进 .rodata） |
+|---|---|---|---|---|
+| 新 | `torch_xmlir::kccl::ProcessGroupXCCL` | `torch_kccl_python_init` | `kccl` | 新 ProcessGroup 实现 |
+| 旧 | `c10d::ProcessGroupXCCL` | `torch_xccl_python_init` | `bccl` | 旧 ProcessGroup 实现 |
+
+对 `torch_kccl_python_init` 的反汇编可以看到注册序列 **[已验证]**：
+
+```
+ProcessGroupXCCL::cclInitOnce()
+PyImport_ImportModule("torch.distributed")
+  .attr("Backend").attr("register_backend")
+  cpp_function(createKLProcessGroup)   # args: dist_backend_options, pg_options
+  (... "kccl" ..., extended_api=...)
+PyImport_ImportModule("torch._C").attr("_distributed_c10d")
+  pybind11::class_<torch_xmlir::kccl::ProcessGroupXCCL>(scope, "ProcessGroupXCCL")
+```
+
+即：`torch.distributed.Backend.register_backend("kccl", createKLProcessGroup, extended_api=...)`，
+然后把类绑成 `torch._C._distributed_c10d.ProcessGroupXCCL`。
+`torch.distributed.ProcessGroupXCCL` 在 `import _XMLIRC` 之后即可解析
+（运行时确认可访问），早于插件加载。**[已验证]**
+
+集合通信组件中**没有** `ProcessGroupXCCL` 符号，说明它只提供底层集合通信能力。PyTorch 侧的集合操作位于 XMLIR 的编译组件中。**[已验证]**：
+
+```
+torch_xmlir::kccl::ProcessGroupXCCL::allreduce_impl(at::Tensor&, char const*, c10d::AllreduceOptions const&)
+…::gather_impl(…, BKCLDataType, void*, c10::cuda::CUDAStream&, int, int)
+…::scatter_impl / alltoall_base / recvAnysource
+…::initXCCLComm / getXCCLComm / groupStart / endCoalescing / abortComms / runHookLoop / workEnqueue
+```
+
+注意签名里的 `c10::cuda::CUDAStream` —— **ABI 层面直接暴露了 CUDA dispatch key 劫持**。
+
+`.so` 内的通信相关环境变量（名字推断，默认值未验证）**[.so 内]**：
+`TORCH_XCCL_NAN_CHECK`、`TORCH_XCCL_AVOID_RECORD_STREAMS`、
+`TORCH_XCCL_DEFAUTL_PG_TIMEOUT_MILSEC`（拼写错误在二进制里）、
+`TORCH_XCCL_ENV_STORE_KEY_WITH_PG_NAME`、`TORCH_XCCL_ENV_WAIT_GDB`、
+`XMLIR_XCCL_USE_ASYNC_OP`、`XMLIR_DIST_ASYNC_ISEND_IRECV`、
+`XMLIR_DIST_CHECK`、`XMLIR_DIST_CHECK_INF_NAN(_ASYNC)`、`XMLIR_DIST_CHECK_INF_NAN_SAVE_DIR`。
+
+## `distributed/tensor/`：真正在干活的部分
+
+`$PKG/distributed/` 四个子树里，只有 `tensor/`（约 3200 行）是活的、承重的。
+它的全部工作是：**让昆仑的 out-variant 自定义 kernel 在 DTensor dispatch 下存活**。
+
+由 `$PKG/__init__.py:218` 的 `from torch_xmlir.distributed import tensor` 触发，
+`tensor/__init__.py` 星号导入 5 个模块，导入即注册。**[源码]**
+
+模块命名有误导性：`_random_ops.py` 放 dropout，`_pointwise_ops.py` 放 RoPE/SwiGLU，
+`_tensor_ops.py` 放优化器和 MoE 路由。
+
+### 三种注册机制
+
+**(a) `register_op_strategy` —— 只有 1 个算子**（`_matrix_ops.py:23-24`）：
+
+```python
+@register_op_strategy(torch.ops.custom_ops.linear.default)
+def custom_linear_op_strategy(op_schema: OpSchema) -> OpStrategy:
+```
+
+从**输出**placement 反推输入 placement（`:67-97`）：
+`Shard(1)` out → column-parallel（`Replicate` × `Shard(1)`，bias `Shard(0)`）；
+`Shard(0)` out → data-parallel；`Partial` out → row-parallel 需 reduce。
+读 `op_schema.kwargs_schema["out"]`（`:56`），所以调用时必须带 `out=`。
+
+**(b) `register_sharding` —— 只有 1 个算子**，且只允许 replicate（`_math_ops.py:16-23`）：
+
+```python
+@register_sharding(torch.ops.custom_ops.findmax.default)
+def custom_findmax_sharding(input, max=None):
+    acceptable_shardings = []
+    replicate_only = ([Replicate()], [Replicate()])
+    acceptable_shardings.append(replicate_only)
+    return acceptable_shardings
+```
+
+**(c) 主力机制 —— 直接改 DTensor 的私有 handler dict（29 个算子）**：
+
+```python
+# $PKG/distributed/tensor/_math_ops.py:841-845
+# Register all custom handlers into DTensor's OpDispatcher. (see _dispatch.py line 148).
+_custom_handlers = dtensor.DTensor._op_dispatcher._custom_op_handlers
+_custom_handlers[
+    torch.ops.custom_ops.multi_tensor_l2norm.default
+] = _multi_tensor_l2norm_handler
+```
+
+引用的 hook 是真实存在的：`torch/distributed/tensor/_dispatch.py:148-149`
+`if op_call in self._custom_op_handlers: return self._custom_op_handlers[op_call](...)`。**[已验证]**
+
+注册清单：
+
+| 文件 | 行 | handler |
+|---|---|---|
+| `_matrix_ops.py` | 491-492 | `mha_varlen_fwd`、`mha_varlen_bwd` |
+| `_pointwise_ops.py` | 1083-1111 | `fused_rope_forward/backward`、`fused_rope_thd_forward/backward`、`multi_tensor_scale`、`rotary_no_freqs_pos_emb_forward/backward`、`rotary_pos_emb`、`rotary_pos_emb_backward`、`swiglu_forward/backward`（11 个） |
+| `_math_ops.py` | 843-868 | `multi_tensor_l2norm`、`rms_layer_norm(_backward)`、`scaled_softmax_forward/backward`、`softmax_with_mask(_backward)`、`te_layer_norm(_backward)`、`tensor_checksum`（10 个） |
+| `_tensor_ops.py` | 490-501 | `optimizer_AdamW`、`combine_convert`、`dispatch_convert`、`multi_tensor_adam` |
+| `_random_ops.py` | 173-178 | `dropout_add_forward`、`dropout_add_backward` |
+
+### 为什么必须用 handler 而不是 strategy
+
+因为这些 kernel 是 out-variant / void 返回的原地算子，**违反 PyTorch 的原地命名约定
+（没有 `_` 后缀、返回 void）**，DTensor 默认传播机制无法把变更写回。
+`_tensor_ops.py:24-32` 说得很直白：
+
+```
+This op mutates mom1, mom2, and param inplace, but since it does not
+follow PyTorch's inplace naming convention (no '_' suffix, returns void),
+DTensor's default dispatch cannot propagate inplace mutations back to
+the original DTensors. This handler:
+  1. Redistributes all data tensors to match param's placement
+  2. Calls the underlying op on local tensors
+  3. Reverse-redistributes inplace-mutated tensors back to their original
+     placements when redistribution created new local tensors
+```
+
+每个 handler 都是同一套骨架，建在 `_tensor_utils.py`（72 行，
+`find_mesh` / `redistribute_dt` / `writeback_output`）之上：
+选锚点 placement（几乎总是取**输出** buffer 的）→ `redistribute_dt` 每个参数 →
+在裸 local tensor 上调 `op_call` → `writeback_output` 反向 redistribute 并 `copy_` 回去。
+
+### 切分约束（重要）
+
+每个 kernel 的维度约束都写在 docstring 里，不满足时回落到 `Replicate` **[源码]**：
+
+- **RoPE**：head_dim 永不可切（`_pointwise_ops.py:663-669`）
+- **softmax / RMSNorm**：最后一维永不可切（`_math_ops.py:347-353`, `178-190`）
+- **`mha_varlen_fwd`：三个维度全都不能切**，原因写得异常坦诚（`_matrix_ops.py:167-173`）：
+
+```
+Sharding constraints:
+  - T (dim 0): CANNOT be sharded — lod_seqlens index into T
+  - D (dim 2): CANNOT be sharded — dot product couples all D elements
+  - H (dim 1): CANNOT be sharded — the kernel writes softmax_lse using a
+               global head-index offset baked into its accumulation logic;
+               running with a local head_num produces incorrect lse values
+               for any rank whose local heads don't start at index 0.
+```
+
+- **`dispatch_convert`**：kernel 里有全局 running counter，强制全 replicate（`_tensor_ops.py:216-228`）
+
+**用 DTensor + 昆仑融合算子做张量并行时，这张约束表是必读的** ——
+很多你以为能切的维度其实会被静默 replicate，性能不符合预期时先查这里。
+
+31 个引用到的 `custom_ops` 算子已确认全部存在于自定义算子编译组件中。**[已验证]**
+
+## 集合通信调用点
+
+`distributed/` 里只有 `dist.all_reduce`，6 处，全是「local kernel 算完后补一次 reduce」**[源码]**：
+
+| 位置 | 做什么 |
+|---|---|
+| `_math_ops.py:118-121` | `multi_tensor_l2norm`：`square_()` → `all_reduce(SUM)` → `sqrt_()`（正确合并 per-rank 偏 L2 范数） |
+| `_math_ops.py:300-301` | `rms_layer_norm_backward`：`dweight` 做 `SUM`，最后一维被 reshard 成 Replicate 时跳过 |
+| `_math_ops.py:744-746` | `te_layer_norm_backward`：`dgamma`/`dbeta` 做 `SUM` |
+| `_math_ops.py:828-836` | `tensor_checksum`：`has_nan_or_inf`/`max_val`/`max_history` 做 `MAX`，`min_*` 做 `MIN` |
+
+**P2P 在 `distributed/` 里完全没有。** `send`/`recv`/`isend`/`irecv`/`batch_isend_irecv`
+一个都不出现。P2P 依赖 C++ 的 `ProcessGroupXCCL::send/recv/recvAnysource` 实现，加一个 Python 补丁：
+
+```python
+# $PKG/symbrewrite/plugins/torch/mock_batch_isend_irecv.py:74
+# XMLIR_DIST_DISABLE_ASYNC_ISEND_IRECV 为真时才替换
+```
+
+替换实现（`:16-69`）把 `_coalescing_manager` 桩成裸 `yield`（`:32-34`），逐个发起 op ——
+**这是个刻意关闭 coalescing/overlap 的正确性逃生阀**，不是优化。默认 `"0"` 不启用。
+
+## 通信-计算重叠
+
+`distributed/` 里的 handler **全部同步**：redistribute → kernel → 阻塞 all_reduce → writeback。
+
+重叠机制在别处：
+
+- `nn/parallel/distributed.py` 有分桶 reducer（`_compute_bucket_assignment_by_size` @ `:549`，
+  `_rebuild_buckets` @ `:892`），但 `:1009` 记了一条缺口：
+  `# TODO: need support ProcessGroupXCCL::WorkXCCL::getFuture`，
+  紧跟 `raise RuntimeError("xpu not support dist._register_comm_hook")` ——
+  **DDP comm hook 在这个后端上不可用**。
+- C++ 侧有 coalescing（`groupStart` / `endCoalescing` / `workEnqueue`）
+- `xpytorch_import_hook.py:58-59` 把 `CUDA_DEVICE_MAX_CONNECTIONS` 拉到 8，
+  注释明说是为了多流重叠（「llama 70b 多流优化至少需要 5 个流」）
+
+## `distributed/` 的死代码（三个子树）
+
+| 路径 | 行数 | 状态 |
+|---|---|---|
+| `distributed/distributed.py` | 130 | **broken**。`:119`/`:122` 调 `_XMLIRC._xpu_sync_multi` 和 `._xpu_reset_tokens`，两个符号在 XMLIR Python 扩展中都**不存在**。`_sync_params_and_buffers` 在 `__init__` 里无条件调用（`:57`），所以**构造这个类就会 AttributeError**。`torch_xmlir.nn.parallel.DistributedDataParallel` 也存在独立导入问题，见下一节。 |
+| `distributed/utils.py` | 45 | torch `_pack_kwargs`/`_unpack_kwargs` 的拷贝，`__all__ = []`，无人引用 |
+| `distributed/fsdp/` | 465 | **什么都没 patch**。`wrap.py` 是 PyTorch ~1.12/1.13 `fsdp.wrap` 的逐字拷贝（Facebook BSD 头 `:1-4`），签名是老 API（`unwrapped_params` 而非 `nonwrapped_numel`），与 torch 2.9 的 `_Policy` 体系不兼容。存在的唯一合理理由是让 `ParamExecOrderWrapPolicy` 还能 import —— 它已从上游 torch 移除。全 site-packages grep 无人引用；也找不到任何 `_flat_param` / `fully_shard` / `FullyShardedDataParallel` 符号 |
+
+**即：本适配层没有对 FSDP 做任何专门适配。** FSDP 能不能用取决于官方实现在
+CUDA 伪装下是否恰好工作，本次未验证。
+
+`distributed/__init__.py:11` 还有个明显 bug：
+
+```python
+__all__ = ["DistributedDataParallel, tensor"]   # 一个含逗号的字符串，不是两个元素
+```
+
+所以 `from torch_xmlir.distributed import *` 一个名字都导不出来。**[源码]**
+
+## `nn/parallel/`：XLA 时代的 DDP，静态推断已 import 不进来
+
+`nn/parallel/`（2175 行）是 PyTorch 1.6~1.8 时代 `torch/nn/parallel/` 的移植，
+目标设备类型硬编码为 `"xla"` —— 早于 CUDA key 劫持的产物。**[源码]**
+
+适配要点：
+
+- `data_parallel.py:99,184` `device_type = "xla"`；`comm.py:91` 断言 `inp.device.type == "xla"`
+- 集合通信走 `_XMLIRC._broadcast` / `_scatter` / `_gather` 等（`comm.py:47,49,68,208,220,257,264`）
+- **没有 D2D 路径**：`broadcast` 绕主机内存（`comm.py:43-44`
+  `# TODO:When inter-card D2D is supported, remove the following line` / `tensor = tensor.cpu()`），
+  `gather` 同（`:249`）
+- `reduce_add`（`:71`）NCCL 快路径被注释掉（`:113-116`），改成串行 `+`/`add_`
+- DDP 在 XPU 上拒绝 `gradient_as_bucket_view=True`（`distributed.py:395-402`），
+  注释：「1:xpu not support is_alias_of；2:xpu view not share storage, can not save memory use」，
+  且 `:411` 无条件强制 `False`
+- bucket rebuild 被注释掉（`:640-642`）
+- `_dump_DDP_relevant_env_vars`（`:40-92`）读约 38 个 `NCCL_*` 变量**仅用于打日志**，不影响行为
+- 默认 `bucket_cap_mb=50`（`:347`），broadcast bucket 250MB（`:424`）
+
+**[静态推断]** `distributed.py:15` 做 `import torch_xmlir.distributed as dist`，`:17` 调
+`dist.is_available()`，但 `torch_xmlir/distributed/__init__.py` 只导出
+`DistributedDataParallel` 和 `tensor` —— 没有 `is_available`、`Reducer`、`ReduceOp`、
+`_compute_bucket_assignment_by_size`（`:549` 用到）、`_broadcast_coalesced_with_group`（`:1018` 用到）。
+静态看 `import torch_xmlir.nn.parallel` 应在 `:17` 抛 `AttributeError`。
+旁证：全 site-packages 无人 import 它，没有插件替换
+`torch.nn.parallel.DistributedDataParallel`，`nn/__init__.py:9` 的 `DataParallel`
+re-export 也被注释掉了。**因此两个遗留 DDP 实现均不应视为可用。官方 `torch.nn.parallel.DistributedDataParallel` 在 CUDA 兼容层下是否可用，本次未验证。**
+
+---
+
+下一页：[08-compile-dynamo.md](08-compile-dynamo.md)

--- a/openwiki/torch-xmlir/08-compile-dynamo.md
+++ b/openwiki/torch-xmlir/08-compile-dynamo.md
@@ -1,0 +1,236 @@
+# 08 · torch.compile 与 dynamo
+
+[← 首页](README.md) · [← 07 分布式](07-distributed.md) · [→ 09 AMP 与优化器](09-amp-optimizer.md)
+
+本页两条结论，都不太好听：
+
+> **1. 本构建上 `torch.compile` 是一个空装饰器。它不编译任何东西。**
+> **2. `dynamo/`（1284 行）是死代码，缺少的依赖模块没有随包发货。**
+
+## `torch.compile` 被替换成空装饰器
+
+```python
+# $PKG/symbrewrite/plugins/torch/__init__.py:128
+# XMLIR_ENABLE_MOCK_TORCH_COMPILE 默认 "true"
+```
+
+`:132` 把 `torch.compile` 换成 `mock_torch.empty_decorator`。运行时确认 **[已验证]**：
+
+```
+torch.compile -> torch_xmlir.symbrewrite.plugins.torch.mock_torch  empty_decorator
+```
+
+也就是说，用户代码里的 `@torch.compile` 或 `model = torch.compile(model)`
+**静默地什么都不做，模型以 eager 模式运行**。不报错、不警告。
+
+这在工程上是可以理解的选择（编译路径不成熟，宁可静默 eager 也别炸），
+但**调优时必须知道**：你以为在测编译性能，其实测的是 eager。
+
+要关掉这个 mock：`XMLIR_ENABLE_MOCK_TORCH_COMPILE=false`。此时走的是
+`with_import_hook_disabled` 包过的**真实官方 `torch.compile`**（`:136-139`），
+即 Inductor 路径 —— 而 Inductor 会生成 Triton CUDA kernel，在昆仑上能否工作本次未验证。
+
+## `dynamo/` 为什么是死代码
+
+三重死亡 **[已验证]**：
+
+**(1) 依赖模块不存在。** `dynamo/` import `torch_xmlir.ir` 和 `torch_xmlir.dialects`
+（`dynamo/xmlir_builder.py:30-31`、`dynamo/ir.py:6-7`、`dynamo/affine.py:50`），
+而这两个模块**都不存在** —— 没有 `ir.py`、没有 `dialects/`，
+`xmlir-1.0.0.1.dist-info/RECORD` 里也没有对应条目。**MLIR/xgraph 层没有随包发货。**
+
+**(2) 用了 torch 2.9 已删除的 API：**
+
+| API | 位置 |
+|---|---|
+| `torch._dynamo.config_utils.install_config_module` | `dynamo/builder_config.py:8` |
+| `torch._dynamo.utils.fake_mode_from_tensors` | `dynamo/xmlir_builder.py:14` |
+| `torch.fx.experimental.symbolic_shapes.{magic_methods, method_to_operator}` | `dynamo/xmlir_builder.py:9-13` |
+
+**(3) 门控 bug 意外救了它。** `$PKG/__init__.py:47`：
+
+```python
+WITHOUT_MLIR = bool(os.environ.get("WITHOUT_MLIR", "0"))
+```
+
+`bool("0") is True` —— 所以 `WITHOUT_MLIR` **默认永远为真**
+（运行时确认 `torch_xmlir.WITHOUT_MLIR == True`）。于是 `if not WITHOUT_MLIR:` 下面的
+所有东西从不执行，包括 `_apply_patches_201_dynamo()` 和 backend 注册：
+
+```python
+# $PKG/__init__.py:187-197
+if not WITHOUT_MLIR:
+    from ._dynamo_patched_functions import _apply_patches_201_dynamo
+    _apply_patches_201_dynamo()
+
+    from torch_xmlir.dynamo import compile_fx
+    from torch._dynamo import register_backend
+
+    @register_backend
+    def xmlir(*args, **kwargs):
+        return compile_fx(*args, **kwargs)
+```
+
+**讽刺之处：正是这个 bug 让 `import torch` 不至于因为 (1)(2) 而崩掉。**
+如果哪天有人「修好」了 `WITHOUT_MLIR` 的解析，这个包会立刻 import 失败。
+见 [12-pitfalls.md](12-pitfalls.md)。
+
+`if not WITHOUT_MLIR` 还守着 `:201-202` 的
+`_XMLIRC._xpu_set_xmlir_opt_path(...)` —— 也从不执行。
+
+## `dynamo/` 的设计（供参考，当前不可运行）
+
+即使不能跑，架构值得记录，因为它揭示了昆仑原本的编译路线。
+
+### 后端名与三条注册路径
+
+后端名是 **`xmlir`**（靠 `register_backend` 读函数名）。三条入口：
+
+1. `torch.compile(m, backend="xmlir")` —— 走 `register_backend`（`__init__.py:195-197`）
+2. patch 过的 `torch.compile` 自己特判字符串并直接构造 `XMLIRCompiler`
+   （`_dynamo_patched_functions.py:121-124`）
+3. `torch.compile(fn, backend=XMLIRCompiler())` —— 包内测试生成器用的就是这个
+   （`test_utils/automated_test/dynamo_parser.py:78`）
+
+### 不是适配 Inductor，是替换 Inductor
+
+`dynamo/` 里没有任何 Inductor codegen / scheduling / Triton 定制。
+`_dynamo_patched_functions.py:117-120` 把 `backend="inductor"` 原样留给官方
+`_TorchCompileInductorWrapper`。XPU 路径是完全独立的后端，终点是 C++ 编译调用而不是 Triton：
+
+```python
+# $PKG/dynamo/xmlir_builder.py:371-378
+def compile_ir_module(self, func_name, ir_module_str):
+    # Here we use graph id as ir module id, beacause dynamo has cached graph by guarded code.
+    exector = torch_xmlir._XMLIRC.compile(ir_module_str)
+
+    def exector_wrap(*args):
+        return exector(list(args))
+
+    return exector_wrap
+```
+
+MLIR module 以**字符串**形式交给扩展，之后的解析、优化、XPU codegen、返回 executor
+全在 `XMLIR Python extension`（44MB）和 `XMLIR runtime component` / `JIT compiler component` 里。**[.so 内]**
+
+### 流水线
+
+`compile_fx`（`xmlir_builder.py:417-454`）是 AOTAutograd 的薄封装：
+从 `get_aot_compilation_context()` 读模型名和 graph index（`:422`），
+围绕 `FXGraph2IRModule().compile_to_fn` 建 `fw_compiler`/`bw_compiler`，
+返回 `aot_autograd(...)` 且 `keep_inference_input_mutations=True`（`:453`）。
+分解表和 partitioner 都用 AOTAutograd 默认值 —— `:449` 标了 TODO。
+
+`GraphIRLowering`（`:80-356`）是一个 `torch.fx.Interpreter`，边遍历边发射 MLIR。
+算子名映射是机械的：
+
+```python
+# $PKG/dynamo/xmlir_builder.py:219-231
+if isinstance(node.target, torch._ops.OpOverload):
+    schema = node.target._schema
+    namespace, _, unqualified_name = schema.name.partition("::")
+    mlir_op_name = f"xgraph.{namespace}.{unqualified_name}"
+    if schema.overload_name != "":
+        mlir_op_name += f".{schema.overload_name}"
+    assert ir.Context.current.is_registered_operation(
+        mlir_op_name
+    ), f"Unregistered operation: {mlir_op_name}"
+```
+
+即 `aten::add.Tensor` → `xgraph.aten.add.Tensor`。
+
+三类节点特殊处理：`operator.getitem` 靠 env 别名解决不发 op（`:207-209`）；
+SymInt magic method 变成 `xgraph.builtin_op` 并把算子名做首个 `ConstantStrOp`（`:259-281`）；
+其余落到 `lowerings` 表（`:282-299`，`dynamo/lowering.py` 只有 3 条：
+`scalar_tensor`、`sym_size`、`sym_stride`）。
+`call_module` / `call_method` 直接 assert —— 图必须先被 AOTAutograd 完全展平。
+
+### 动态 shape 是半成品
+
+```python
+# $PKG/dynamo/ir.py:199-207
+def _symbolic_shape_to_xmlir_ams(self, x) -> str:
+    if self.is_symbolic:
+        # TODO: replace "?" by affine_expr
+        affine_expr = SymExprToAffineExpr(x).convert()
+        return "?"
+```
+
+**算出 affine 表达式然后丢掉。** `affine.py` 整整 316 行 sympy→AffineExpr 机制
+（`SymExprToAffineExpr`，`:276-316`）只为喂这个被丢弃的值，等于全部未使用。
+
+### `dynamo/passes/`：唯一一个 pass
+
+`ReplaceMisSemanticOp`（`passes/replace_missemantice_op.py:35`）。
+对 16 个白名单二元算子（`converse_binary_patttern_list`，`:16-32`：
+`add`/`add_`/`sub`/`sub_`/`mul`/`mul_`/`div` × 5 overload/`remainder`/`pow`/`pow_`，
+全是 `.Tensor` 变体），逐位置参数对照 schema 声明类型。
+schema 要 Tensor 而图给了 Python 标量时，插入节点：
+
+```python
+# $PKG/dynamo/passes/replace_missemantice_op.py:117-134
+if is_tensor(expected_type) and is_scalar(arg):
+    dtype = get_type(arg)
+    device = torch.device("cpu")
+    scalar_tensor: torch.fx.Node = self.module.graph.call_function(
+        the_function=aten.scalar_tensor,
+        args=(arg,),
+        kwargs={"dtype": dtype, "device": device, "layout": None, "pin_memory": False},
+    )
+    counters["xacc"]["scalar_tensor_nodes"] += 1
+    arguments[i] = scalar_tensor
+    n.prepend(scalar_tensor)
+```
+
+dtype 推断 `int→int64` / `float→float32` / `bool→bool` / else 默认（`:99-108`），
+device 硬编码 `cpu`（`:119`）。改写计数进 `torch._dynamo.utils.counters["xacc"]`。
+docstring（`:36-46`）说明动机：`aten.add.Tensor(tensor, 1)` 转 xgraph 时会类型不匹配。
+
+这个 pass 和 `dynamo/lowering.py` 里的 `aten.scalar_tensor` 条目是**同一个 workaround 的两半**。
+
+⚠️ `__all__ = ["ReplaceMisSemanticeOp"]`（`:6`）多了个 `e`，与类名不符，`import *` 会失败。
+
+两个本该有的 pass 明确缺席：`FakeTensorProp` 在 `xmlir_builder.py:397` 被注释掉
+（shape inference 挪进 `GraphIRLowering`，因为它在动态 shape 上会炸），且没有 decomposition pass。
+
+## `_dynamo_patched_functions.py` 的三个补丁
+
+全部由 `_apply_patches_201_dynamo()`（`:130-137`）应用，**本构建不执行**。
+文件头 `:66` 的注释写着「torch2.0.1 官方bug」，`:77` 的 TODO 说明整个文件都是 2.0.1 workaround。
+
+| # | 目标 | 方式 | 内容 |
+|---|---|---|---|
+| 1 | `torch.fx.experimental.proxy_tensor.set_meta` | `_patch`（`:131-133`） | 对真实（非 fake、非 sparse）tensor 不再返回 `None`，而是起一个 `FakeTensorMode(allow_fallback_kernels=True)` 造 `torch.empty_strided(...)`（`:41-45`），让 FX 节点拿到正确的 `meta["val"]` —— 这正是 `GraphIRLowering.to_xmlir_ir_type` 需要的。作者在 `:35-40` 自己标注了 hacky 且不感知 storage |
+| 2 | `aten.unsqueeze_.default` 的 Meta kernel | **直写 `py_kernels` dict**（`:135`），不可逆 | 用 `maybe_wrap_dim` + `inferUnsqueezeGeometry` + `as_strided` 三行重实现（`:70-74`）。注意 `:7` import 了 `register_meta` 却没用 |
+| 3 | `torch.compile` | `_patch`（`:137`） | torch 2.0.1 版 `torch.compile` 的拷贝加一个 `elif backend == "xmlir"` 分支（`:117-127`）。签名钉死在 2.0.1 形状（`:78-87`，`dynamic: bool = False`、无 `guard_filter_fn`/`backend_options`），在 torch 2.9 上会静默丢掉新 kwargs |
+
+补丁 3 即使执行也会被后来的 symbrewrite 覆盖 —— `plugins/torch/__init__.py:132`
+再一次替换 `torch.compile`。
+
+`_patch` 本身有签名校验（`_patched_functions.py:43-53`）：
+
+```python
+def _patch(fn, newfn):
+    xfingerprint = inspect.signature(fn)
+    fingerprint = inspect.signature(newfn)
+    if xfingerprint != fingerprint:
+        raise RuntimeError("Unable to patch {}, signature mismatch: {} vs {}".format(...))
+    newfn._orig = fn
+    return newfn
+```
+
+**这是个好设计** —— 签名漂移会立刻抛错而不是静默行为不一致。
+（对比 symbrewrite 的 `setattr`，完全不校验。）
+
+## 实际结论
+
+想在昆仑 P800 + torch 2.9 上用图编译：
+
+- `torch.compile` 默认无效，必须显式 `XMLIR_ENABLE_MOCK_TORCH_COMPILE=false` 才走官方 Inductor
+- 昆仑自研的 `xmlir` 后端在本构建**不可用**（缺 `torch_xmlir.ir` / `dialects`）
+- 真正生效的加速手段是 [06](06-custom-ops-nn.md) 里的 eager 融合算子
+  （Linear/hydrax、RoPE、RMSNorm、FA）和 [04](04-dispatch-hijack.md) 的 op_select
+
+---
+
+下一页：[09-amp-optimizer.md](09-amp-optimizer.md)

--- a/openwiki/torch-xmlir/09-amp-optimizer.md
+++ b/openwiki/torch-xmlir/09-amp-optimizer.md
@@ -1,0 +1,197 @@
+# 09 · AMP 与优化器
+
+[← 首页](README.md) · [← 08 编译](08-compile-dynamo.md) · [→ 10 环境变量](10-env-vars.md)
+
+## AMP：两套并行的 autocast 状态
+
+关键结论先说：
+
+> `torch_xmlir.amp.autocast` **只操作 `_XMLIRC` 自己的 autocast 状态，完全不碰 `torch.amp`**。
+> 而且它 **fp16 only**、**无人 import**。实际生效的是官方 `torch.amp.autocast("cuda")`。
+
+### `torch_xmlir.amp.autocast` 的实现
+
+```python
+# $PKG/amp/autocast_mode.py:64-89
+def __enter__(self):
+    if torch._jit_internal.is_scripting():
+        assert self.fast_dtype is not None
+        return self
+    self.prev_cache_enabled = torch_xmlir._XMLIRC.is_autocast_cache_enabled()
+    if self.device == "xla" or self.device == "xpu":
+        self.prev = torch_xmlir._XMLIRC.is_autocast_enabled()
+        self.prev_fastdtype = torch.float16
+        torch_xmlir._XMLIRC.set_autocast_enabled(self._enabled)
+        torch_xmlir._XMLIRC.autocast_increment_nesting()
+    torch_xmlir._XMLIRC.set_autocast_cache_enabled(self._cache_enabled)
+
+def __exit__(self, exc_type, exc_val, exc_tb):
+    ...
+    if self.device == "xla" or self.device == "xpu":
+        if torch_xmlir._XMLIRC.autocast_decrement_nesting() == 0:
+            torch_xmlir._XMLIRC.clear_autocast_cache()
+        torch_xmlir._XMLIRC.set_autocast_enabled(self.prev)
+    torch_xmlir._XMLIRC.set_autocast_cache_enabled(self.prev_cache_enabled)
+    return False
+```
+
+它是官方 `autocast` 的结构性克隆，把每个 `torch._C.*` 换成了 `torch_xmlir._XMLIRC.*`。**[源码]**
+
+8 个状态函数在 `XMLIR Python extension` 里，C++ namespace `torch_xmlir::amp`，
+translation unit `autocast.cpp`（符号表确认，含 mangled
+`_ZN11torch_xmlir3amp19is_autocast_enabledEv`）。**[已验证]** 逻辑不可见。
+
+三个使用陷阱 **[源码]**：
+
+1. `device_type` 默认 `"xpu"`（`:24`），**只接受 `"xla"`/`"xpu"`**，
+   传 `"cuda"` 在 `:39-41` 直接 raise。**不能当 `torch.amp.autocast("cuda")` 的 drop-in。**
+2. **只支持 fp16**：`:36-37` 硬编码 `self.fast_dtype = torch.float16`；
+   `:53-61` 强制 `supported_dtype = [torch.float16]`，遇 bf16 或 fp32
+   **只警告并静默关闭 autocast**。考虑到本构建整套 fast-FC 开关都是 bf16 导向的，
+   这强烈提示该路径已经过时。
+3. `cache_enabled` 默认取 `_XMLIRC` 当前值（`:42`），不是 `True`。
+
+### 没有算子精度策略表
+
+`amp/` 里**完全没有** `lower_precision_fp` / `fp32` / `promote` 之类的表，
+也没有 `KERNEL(...)` 注册。
+
+原因很直接：**XPU 偷了 CUDA dispatch key**（`$PKG/__init__.py:32`），
+所以生效的 cast 策略就是 libtorch 自己的 CUDA autocast 策略。
+
+旁证 **[源码]**：`nn/linear.py:122-123` 查的是
+`torch.is_autocast_enabled()` / `torch.get_autocast_gpu_dtype()` —— **torch 的状态，
+不是 `_XMLIRC` 的**；`hydrax/.../_linear.py:49-51` 用 `torch.get_autocast_dtype("cuda")`。
+
+**[静态推断]** 「XPU 侧完全不存在 cast 策略表」是符号/字符串扫描的负面结果，
+未反汇编确认，视为「很可能」而非「已证明」。
+
+### GradScaler
+
+`$PKG/amp/grad_scaler.py`（605 行）是官方 pre-2.0 `GradScaler` 的自包含拷贝
+（`class GradScaler(object)` @ `:42`，不继承任何东西）。
+默认值标准：`init_scale=2**16`、`growth_factor=2.0`、`backoff_factor=0.5`、
+`growth_interval=2000`（`:110-117`）。
+
+XPU 特有部分很小 **[源码]**：
+
+- 可用性判断用 `torch_xmlir.xpu.is_available()`（`:118`）
+- 类型断言期待 `"torch.xpu.FloatTensor"`（`:411`）
+- 两个数值 kernel **是未修改的官方 ATen 调用**：
+  `torch._amp_foreach_non_finite_check_and_unscale_`（`:242`）和
+  `torch._amp_update_scale_`（`:431`）—— 靠 CUDA key dispatch 落到昆仑，不走 custom op
+- 支持 `optimizer._step_supports_amp_scaling`（`:354-364`）
+
+### `amp/` 是死路径
+
+全 site-packages grep `torch_xmlir.amp` / `from torch_xmlir import amp`：
+唯一命中是它自己的警告字符串（`grad_scaler.py:120`）。
+`$PKG/__init__.py` 也不 import 它。**[已验证]**
+
+**实践建议：用官方 `torch.amp.autocast("cuda", dtype=torch.bfloat16)` +
+`torch.amp.GradScaler`，不要用 `torch_xmlir.amp`。**
+
+（另：`symbrewrite/plugins/apex/amp/` 与此无关，只有 10 行 `_amp_state` 桩。）
+
+## 优化器：11 个，分两档
+
+`$PKG/optimizer/__init__.py:11-21` 的 `__all__` 只导出 9 个 ——
+`fused_adam.FusedAdam` 和 `fused_lars.FusedLARS` **不在里面**，必须全路径 import。**[源码]**
+
+### 第一档：真融合（每 step 一个 XPU kernel）
+
+| 类 | 位置 | kernel |
+|---|---|---|
+| `FusedAdamW` | `fused_adamw.py:75` | `multi_tensor_adam`（快路径）/ `optimizer_AdamW`（回落） |
+| `FusedAdam` | `fused_adam.py:41` | `multi_tensor_adam` |
+| `ApexFusedAdamW` | `apex_fused_adamw.py:57` | `optimizer_AdamW`，逐参数 |
+| `FusedLAMB` | `fused_lamb.py:7` | `optimizer_LAMB` |
+| `FusedSGD` | `fused_sgd.py:6` | `optimizer_SGD` |
+| `FusedLARS` | `fused_lars.py:5` | `optimizer_LARS` |
+
+`FusedAdamW` 最完整，是唯一带真 multi-tensor-apply 快路径 + 守卫回落的：
+
+```python
+# $PKG/optimizer/fused_adamw.py:22-72（节选）
+# Fast path: single XPU kernel for all params when step is uniform and dtype=float32.
+# Only applicable on XPU/CUDA; multi_tensor_adam has no CPU implementation.
+all_same_step = len(set(state_steps)) == 1
+if (all_same_step
+    and params[0].dtype == torch.float32
+    and params[0].device.type != "cpu"):
+    n_list = [p.numel() if p.shape != torch.Size([]) else 1 for p in params]
+    torch.ops.custom_ops.multi_tensor_adam(
+        grads, params, exp_avgs, exp_avg_sqs, n_list,
+        lr, beta1, beta2, eps, weight_decay, state_steps[0],
+        1,  # adam_w_mode=True  (decoupled weight decay)
+        1,  # bias_correction=True
+    )
+    return
+# Fallback: per-param scalar kernel (different steps or non-fp32 dtype).
+```
+
+**全档 fp32 only** **[源码]**：
+
+- `FusedAdam` 对 fp16 抛 `"FusedAdam only support fp32 for now."`（`fused_adam.py:135`，
+  `:136` 有 fp16 moment 的 `##TODO`）
+- `ApexFusedAdamW` 抛 `"ApexFusedAdamW only support fp32."`（`apex_fused_adamw.py:256`），
+  并拒绝 `amsgrad` / `capturable` / `master_weights` / `adam_w_mode=False`（`:135-146`）
+- `FusedLAMB` 拒绝 `eager=False`（`fused_lamb.py:37-38`）
+
+⚠️ `fused_adam.py` 两个 bug（见 [12](12-pitfalls.md)）：`state` 从
+`for p in group["params"]` 循环泄漏出来（`:149`, `:166`），
+`state["step"] += 1` 只递增最后一个参数的 step 却拿这个值喂整组；
+且 fp16 在 `:135` 就 raise 了，`:148` 的 `if len(g_16) > 0` 分支不可达。
+
+一个有意思的时间线证据：`FusedSGD.__init__`（`fused_sgd.py:73-74`）断言
+`device.type == "cuda"` —— 写这个文件时 XPU 已经在冒充 CUDA 了。
+而 `nn/parallel/` 还在假设 `"xla"`。**同一个包里能读出两个时代的痕迹。**
+
+### 第二档：「XPU 友好」但不融合
+
+`Adam`（`adam.py:65`）、`AdamW`（`adamw.py:66`）、`SGD`（`sgd.py:6`）、
+`Lamb`（`lamb.py:24`）、`BertAdam`（`BertAdam.py:123`）**完全没有 custom op**。
+
+它们的适配是另一回事：**把每个会变成 host 侧标量的 Python 数值提升成单元素设备张量，
+避免 host↔device 同步**（lazy-tensor 时代的遗产）：
+
+```python
+# $PKG/optimizer/adam.py:34-37
+beta1_pow = torch.tensor([beta1**step], dtype=torch.float32).to(grad.device)
+beta2_pow = torch.tensor([beta2**step], dtype=torch.float32).to(grad.device)
+bias_correction1 = torch.sub(1.0, beta1_pow)
+bias_correction2 = torch.sub(1.0, beta2_pow)
+```
+
+`param.addcdiv_(exp_avg, denom, value=-step_size)` 也被拆成先算
+`coef = exp_avg / denom * (-step_size)` 再 `param.add_(coef)`
+（`adam.py:59-62`，同样模式见 `adamw.py:63`、`sgd.py:113,133`、`lamb.py:135-139`）。
+
+⚠️ **精度妥协有明确记录**：`lamb.py:118-128` 把
+`weight_norm == 0 or adam_norm == 0` 的守卫注释掉了，注释说
+「Hardcode here to avoid the cpu sync problem in lazytensor」——
+这让 `trust_ratio = weight_norm / adam_norm` **可能产出 inf/NaN**。
+`BertAdam.py:59-120` 为同样原因自带 `local_norm` / `local_clip_grad_norm_`；
+`nn/clip_grad.py:9` 的 `_decomposed_norm` 是同一思路的第三份拷贝。
+
+### 未被使用的 kernel
+
+`multi_tensor_l2norm`、`multi_tensor_scale`、`multi_tensor_cuda_lamb`、
+`optimizer_LAMB_fused` 在 `custom-op component` 里存在，但 `optimizer/` 里**没有 Python 调用者**。
+（其中 `multi_tensor_l2norm` / `multi_tensor_scale` 在 `distributed/tensor/` 里有 DTensor handler，
+见 [07](07-distributed.md)；apex 插件的 `amp_c/amp_c.py:89` 也用到。）
+
+### 各框架怎么接进来
+
+| 框架 | 位置 | 做法 |
+|---|---|---|
+| apex | `plugins/apex/optimizers/fused_adam.py:5` | `class FusedAdam(Adam, ApexFusedAdamW)`；不支持的 apex kwarg 抛 `NotImplementedError` |
+| apex | `plugins/apex/optimizers/fused_sgd.py:25` | 返回 `xmFusedSGD` |
+| DeepSpeed | `plugins/deepspeed_0_14_4/mock_deepspeed.py:4,113-114` | 把 `FusedAdamW` 和 `ApexFusedAdamW` 加进 `ZERO_SUPPORTED_OPTIMIZERS`；`FusedLamb` 无条件 raise（`:57-58`）；故意让 `assert_no_cuda_mismatch` 抛 `MissingCUDAException` 逼 DeepSpeed 走 no-CUDA 分支（`:61-64`） |
+| transformers | `plugins/transformers_4_42_3/__init__.py:8,12` | 替换成 `FusedAdamW`；另有 `MODULE_REPLACE("torch.optim.AdamW", "...FusedAdamW")`（`:10-13`，注意这是对一个**类路径**用了模块替换语义） |
+
+**注意所有这些插件默认都是关的**（见 [03](03-symbrewrite.md) 的 xflags 表）。
+
+---
+
+下一页：[10-env-vars.md](10-env-vars.md)

--- a/openwiki/torch-xmlir/10-env-vars.md
+++ b/openwiki/torch-xmlir/10-env-vars.md
@@ -1,0 +1,196 @@
+# 10 · 环境变量总表
+
+[← 首页](README.md) · [← 09 AMP 与优化器](09-amp-optimizer.md) · [→ 11 调试工具](11-debug-tools.md)
+
+分三部分：**A. 最该知道的**、**B. Python 侧完整表**、**C. 只在 `.so` 里的**。
+
+C 部分只有名字，**默认值和语义未验证** —— 是 `strings` 扫出来的字符串表证据。
+
+---
+
+## A · 最该知道的 12 个
+
+| 变量 | 默认 | 一句话 |
+|---|---|---|
+| `DISABLE_XPYTORCH` | `0` | **总开关**。设 1 则 hook 不装、`_XMLIRC` 不导入、`init()` 不跑，退回纯官方 torch |
+| `XMLIR_ENABLE_MOCK_TORCH_COMPILE` | `true` | **默认让 `torch.compile` 变空装饰器**。测编译性能前必须设成 `false`，见 [08](08-compile-dynamo.md) |
+| `XMLIR_ENABLE_LINEAR_FC_FUSION` | `1` | 替换 `nn.Linear`/`F.linear`。`int()` 解析，非数字值会抛 `ValueError` |
+| `XMLIR_USE_HYDRA_LINEAR` | `1` | Linear 走 hydrax 快 FC。**精确比较 `== "1"`**，写 `true` 无效 |
+| `XMLIR_ENABLE_FAST_FC` | `0` | bf16 fast-FC 总开关。**开了就屏蔽三个分方向变量**，见 [06](06-custom-ops-nn.md) |
+| `XPU_RUN_MODE` | 未设 | `TRAIN-BF16`/`TRAIN-FP16`/`INFER-BF16`/`INFER-FP16`。**会在 import 期写硬件寄存器，影响整机共享状态**；拼错静默忽略 |
+| `XMLIR_ENABLE_NEW_PG` | `1` | 通信后端选 `kccl`（新）vs `bccl`（旧） |
+| `LOG_SYMBOL_REPLACE` | `0` | 设 1 打印每次符号替换的调用点。**排查「走的是官方还是昆仑实现」的首选** |
+| `XMLIR_D_FORCE_FALLBACK_STR` | — | 强制指定算子回落到 CPU。**精度对不上时的核心诊断工具** |
+| `XMLIR_DISABLE_CUDA_ALLOCATOR` | 未设 | **不要设成 1** —— 会把 14 个 `torch.cuda.memory_*` 指到本构建已损坏的实现上，见 [05](05-device-runtime.md) |
+| `WITHOUT_MLIR` | `0` | **解析有 bug，永远为真**。见 [12](12-pitfalls.md) |
+| `XTORCHRUN_CLEAN` | `0` | 非 0 时启动前 `kill -9` 所有持有 `/dev/xpu` 的其它进程。**共享节点上不要开** |
+
+---
+
+## B · Python 侧完整表
+
+### B1 · 总控与启动（`$PKG/__init__.py`、`xpytorch_import_hook.py`）
+
+| 变量 | 位置 | 默认 | 含义 |
+|---|---|---|---|
+| `DISABLE_XPYTORCH` | `__init__.py:49`、`xpytorch_import_hook.py:148` | `0` | 总开关 |
+| `WITHOUT_MLIR` | `__init__.py:47` | `"0"` | 本意禁用 MLIR/dynamo。`bool("0")` → 永真，导致整条 dynamo 注册路径与 `_xpu_set_xmlir_opt_path` 从不执行 |
+| `XPU_RUN_MODE` | `__init__.py:48` → `_xpu3_run_mode.py` | `None` | 硬件精度模式，写 12 个寄存器 |
+| `TORCH_NN_INIT_IS_GPU_ALIGNED` | `__init__.py:288`、`plugins/torch/__init__.py:179` | `"0"` | 启用 GPU 位对齐 RNG（14 处改写）并加载 RNG 兼容组件。默认关闭，因为该组件依赖的 OpenMP 运行时可能与 sklearn 的 GNU OpenMP 运行时冲突并导致 segfault（`:283-286`） |
+| `XMLIR_PERSISTENT_CACHE_ENABLED` | `_utils.py:536` | `"false"` | 必须**恰好等于 `"true"`**（`"1"`/`"True"` 无效）。把 `<pkg>/builtin_modules/*` 拷进 `~/.xmlir`。本构建 `builtin_modules/` 不存在，函数在 `:547` 直接 return，是 no-op |
+| `XMLIR_XTRANS_OP_CONFIG` | `_op_select.py:55` | `<pkg>/op_config.yml` | op-select YAML 路径 |
+| `LOCAL_RANK` | `_xpu3_run_mode.py:58` | `None` | 限定寄存器只写这一张卡 |
+| `CUDA_VISIBLE_DEVICES` | `_xpu3_run_mode.py:59`、`xpytorch_import_hook.py:66` | `None` | 卡数回落判断 / `CUDA_DEVICE_ORDER` 条件 |
+
+**强制注入**（若未设置则由 hook 写入，见 [02](02-import-hook.md)）：
+
+| 变量 | 强制值 | 位置 |
+|---|---|---|
+| `CUDART_DUMMY_REGISTER` | `1` | `xpytorch_import_hook.py:48-49` |
+| `CUDART_MODULE_LOADING` | `LAZY` | `:51-52` |
+| `CUDA_DEVICE_MAX_CONNECTIONS` | `8` | `:58-59` |
+| `CUDA_DEVICE_ORDER` | `OAM_ID` | `:64-68`（仅当 `CUDA_VISIBLE_DEVICES == "0,1,2,3,4,5,6,7"`） |
+| `XPU_FORCE_SHARED_DEVICE_CONTEXT` | `1` | `:71-72` |
+
+### B2 · Linear / fast-FC / 量化
+
+| 变量 | 位置 | 默认 | 含义 |
+|---|---|---|---|
+| `XMLIR_ENABLE_LINEAR_FC_FUSION` | `plugins/torch/__init__.py:141` | `1` | 装 `nn.Linear`/`F.linear` 替换 |
+| `XMLIR_USE_HYDRA_LINEAR` | `nn/linear.py:14,112` | `"1"` | 1 → hydrax；else → 包内 `custom_ops.linear` |
+| `FORCE_NN_LINEAR` | `nn/linear.py:24` | 未设 | 任意真值 → 一律用官方 `torch._C._nn.linear`。最高优先级 kill switch |
+| `USE_L3` | `nn/linear.py:23` | 未设 | legacy 路径输出 buffer 分配到 L3 scratch（`:49-51`） |
+| `XMLIR_DYNAMO_WORKAROUND` | `nn/linear.py:25-28` | `"0"` | 走 `torch.ops._dynamo_workaround.linear` 便于图捕获 |
+| `XDNN_FC_GEMM_DTYPE` | `nn/bmm.py:9`、`nn/baddbmm.py:9` | 未设 | `"float32"` → 跳过 `findmax`；否则跑动态 scale。C++ 侧 `XDNN component` 也读 |
+| `DISABLE_CAST_CACHE` | `config.py:89` | `"0"` | 硬否决两个 cast cache flag |
+| `XMLIR_ENABLE_FAST_FC` | `config.py:94` | `"0"` | 总开关，见 [06](06-custom-ops-nn.md) 的覆盖关系 |
+| `XMLIR_LINEAR_CACHE_PARAM` | `config.py:101` | `"1"` | 缓存 cast 后权重。**仅在总开关开时才读**，否则强制 False |
+| `XMLIR_LINEAR_CACHE_ACTIV` | `config.py:109` | `"0"` | 缓存 cast 后激活，同上 |
+| `XMLIR_ENABLE_FAST_FC_FWD_OUT` | `config.py:118` | `"0"` | 前向输出 bf16。**总开关开时被忽略** |
+| `XMLIR_ENABLE_FAST_FC_BWD_DW` | `config.py:121` | `"0"` | 反向权重梯度，同上 |
+| `XMLIR_ENABLE_FAST_FC_BWD_DX` | `config.py:124` | `"0"` | 反向输入梯度，同上 |
+| `XMLIR_BATCH_PARALLEL` | `config.py:137` | `"0"` | batch 并行 |
+| `XMLIR_PARALLEL_SAVE_MEMORY` | `config.py:142` | `"true"` | 并行模式省显存。`config.py` 里唯一默认开的 |
+
+⚠️ `config = Config.from_env()` 在 `config.py:163` **模块导入期**执行，
+`import torch_xmlir` 之后改这些变量无效。且 TE / hydrax 各自直接读、解析方式不一致，
+详见 [06](06-custom-ops-nn.md) 末节。
+
+### B3 · 分布式
+
+| 变量 | 位置 | 默认 | 含义 |
+|---|---|---|---|
+| `XMLIR_ENABLE_NEW_PG` | `mock_torch.py:21` | `"1"` | `kccl`（新 `torch_xmlir::kccl` PG）vs `bccl`（旧 `c10d::ProcessGroupXCCL`） |
+| `XMLIR_DIST_DISABLE_ASYNC_ISEND_IRECV` | `mock_batch_isend_irecv.py:74` | `"0"` | 把 `batch_isend_irecv` 换成串行非 coalesce 循环（正确性逃生阀） |
+| `TORCH_C10D_USE_RANDOM_SLEEP` | `plugins/torch/__init__.py:166` | `"0"` | rendezvous 加 rank 错峰 sleep，缓解 TCPStore 创建风暴 |
+| `TORCHELASTIC_USE_AGENT_STORE` | `mock_torch.py:183` | 未设 | 由上者选中；走 agent store + `sleep(RANK//30+1)`（`:197-199`） |
+| `TORCHELASTIC_RESTART_COUNT` | `mock_torch.py:196` | — | 用作 `PrefixStore` 路径。**无默认值，该分支上缺失会 KeyError** |
+| `RANK` | `mock_torch.py:197` | `"0"` | 错峰 sleep 计算 |
+| `XPYTORCH_RUN_ENHANCE` | `plugins/torch/__init__.py:148` | `0` | 替换 `torch.distributed.run.main` 为 NUMA 绑核 + SIGKILL 版 |
+| `XTORCHRUN_CLEAN` | `enhance_launch_torch2_5.py:142`、`…2_0.py:201` | `"0"` | 启动前 `kill -9` 占用 `/dev/xpu` 的其它进程 |
+| `TORCH_NCCL_ASYNC_ERROR_HANDLING` | `enhance_launch_torch2_5.py:117` | `"1"` | 透传给 worker |
+| `NCCL_ASYNC_ERROR_HANDLING` | `enhance_launch_torch2_0.py:181` | `"1"` | torch < 2.3 的旧名 |
+| `OMP_NUM_THREADS` | `enhance_launch_torch2_5.py:121-122` | — | 已设置才透传 |
+| `ALLREDUCE_FUSION` | `core/xpu_model.py:801` | `True` | all-reduce 前分桶 |
+| `ALLREDUCE_BUCKET_SIZE` | `core/xpu_model.py:802-804` | 32MB | 桶大小 |
+| `ALLREDUCE_CHECK` | `core/xpu_model.py:809,838` | `False` | 拿 gloo CPU all-reduce 对账（调试） |
+| `XRT_SHARD_WORLD_SIZE` / `_ORDINAL` / `_LOCAL_ORDINAL` | `core/xpu_model.py:113,129,145` | `1`/`0`/`-1` | 复制组参数 |
+
+`nn/parallel/distributed.py:50-92` 读约 38 个 `NCCL_*` 变量，**仅用于打日志**，不影响行为。
+
+### B4 · RNG 位对齐（`TORCH_NN_INIT_IS_GPU_ALIGNED=1` 时才相关）
+
+| 变量 | 位置 | 默认 | 含义 |
+|---|---|---|---|
+| `SET_PHILOX_VERSION` | `mock_torch_init.py:46` | `"xpu"` | `xpu`/`python`/`cpp`；非法值静默回落 `xpu`（`:47-48`） |
+| `RANDPERM_KEY_BITS` | `mock_torch_init.py:54` | 见下 | `"32"` 或 `"64"`，用于选择不同的 key 生成实现。优先级：本变量 > `GPU_NAME` 配置 > `"64"` |
+| `GPU_NAME` | `gpu_config_manager.py:231` | — | 选择内置 GPU 配置，大小写不敏感 |
+| `GPU_SM_COUNT` | `gpu_config_manager.py:190` | — | 目标 GPU SM 数，须与下者成对给出 |
+| `GPU_THREADS_PER_SM` | `gpu_config_manager.py:200` | — | 每 SM 最大线程数。成对必需（`:209`），优先级高于 `GPU_NAME`（`:255-263`） |
+| `PHILOX_DEBUG` | `mock_torch_init.py:37` | `"0"` | Philox 调试打印 |
+
+### B5 · 日志、调试、可复现
+
+| 变量 | 位置 | 默认 | 含义 |
+|---|---|---|---|
+| `LOG_SYMBOL_REPLACE` | `symbol_rewrite.py:13`、`module_replace.py:14` | `0` | `=="1"` 时每次替换调用都追踪打印 |
+| `LOG_LEVEL` | `symbrewrite/logger.py:11` | `"INFO"` | logger 级别，变量名可由调用方覆盖 |
+| `FA_LOG_LEVEL` | `plugins/flash_attn/mock_flash_attn_interface.py:9` | `"INFO"` | flash-attn 专用 |
+| `XMLIR_FA_ACCUM_TYPE` | 同上 `:52,194` | `"float"` | `float`/`float16`，softmax-LSE 累加 dtype，非法值 assert |
+| `XPYTORCH_REPRODUCE_SEED` | `plugins/reproduce/__init__.py:13` | `42` | 确定性复现种子。**该插件 import 即生效**（`:38`） |
+| `MODELCMP_SAVEDIR` | `debug/model_comparator.py:54` | 未设 | 未设时 `save()` 是 no-op 直通 |
+| `SAVE_GRAPH_FMT` | `debug/graph_saver.py:22` | `"text"` | `text`/`dot`/`hlo`，其它值 raise |
+| `XLA_METRICS_FILE` | `debug/metrics_saver.py:35` | 未设 | metrics 报告输出。`STDERR` 分支因缺 `import sys` 会 NameError（`:65`） |
+| `XLA_EMIT_STEPLOG` | `core/xpu_model.py:680` | `False` | 每 `mark_step` 打日志 —— 不可达（`mark_step` 在 `:678` raise） |
+| `XLA_SYNC_WAIT` | `core/xpu_model.py:696,716` | `False` | 阻塞同步（`:716` 在 `get_xpu_data_ptr` 里是活的） |
+| `XLA_OP_PRINT_COMPUTATIONS` | `core/xpu_op_registry.py:52` | `False` | 首次编译时把 HLO 打到 stderr |
+| `RATE_TRACKER_SMOOTHING` | `core/xpu_model.py:269` | `0.4` | `RateTracker` EMA 系数 |
+| `DEBUG` | `utils/utils.py:330` | `"0"` | 非 0 时 `get_print_fn()` 返回 `eprint` |
+
+### B6 · 显存 / Graph
+
+| 变量 | 位置 | 默认 | 含义 |
+|---|---|---|---|
+| `XMLIR_DISABLE_CUDA_ALLOCATOR` | `mock_allocator.py:6` | 未设 | `=="1"` 重定向 14 个 `torch.cuda.memory_*`。**本构建下会导致 AttributeError** |
+| `XMLIR_FORCE_USE_XPU_GRAPH` | `plugins/torch/__init__.py:157` | `0` | 装 `xpu/graphs.py` 覆盖 `torch.cuda.CUDAGraph`/`graph` |
+| `PYTORCH_CUDA_ALLOC_CONF` | 官方 torch | — | **默认路径下按官方语义正常生效**（torch_xmlir 不引用它） |
+
+### B7 · 构建扩展（`utils/cpp_extension.py`）
+
+| 变量 | 位置 | 默认 | 含义 |
+|---|---|---|---|
+| `XPYTORCH_XTDK` | `:151,155,156` | 必需 | XTDK 工具链路径，`<xtdk>/bin/clang++` 作为编译器。缺失抛 `NotImplementedError` 并给下载链接 |
+| `XTRANS_PATH` | `:171,172,771,772` | 未设 | 编 `.cu` 时必需，提供 `bin/nvcc` 和 include |
+| `XPYTORCH_CPP_EXTENSION_CXX11_ABI` | `:723,727` | 未设 | 覆盖 `_GLIBCXX_USE_CXX11_ABI` |
+| `CONDA_PREFIX` | `:389,437`；`mock_torch.py:441,468` | 未设或环境前缀 | `xcudart/{include,lib}` 与 NVML 兼容库的查找前缀 |
+| `CC` | `:577` | 未设 | 作为 `-ccbin` 传入 |
+
+---
+
+## C · 只在 `.so` 里的（仅名字，语义未验证）
+
+以下字符串存在于 `XMLIR Python extension`（及部分在
+`XMLIR runtime component` / `PyTorch integration component`），Python 侧完全不出现。
+**[.so 内]** 默认值、解析方式、语义均**未验证**，仅供搜索定位。
+
+**回落与调试**：`XACC_DEBUG_FALLBACK_ALL`、`XACC_INSTALL_RUNTIME_HOOKER`、
+`XMLIR_DEBUG_FALLBACK_ALL`、`XMLIR_D_FORCE_FALLBACK_STR`、
+`XMLIR_ENABLE_FALLBACK_TO_CPU_BOOL`、`XMLIR_DUMP_FALLBACK_OP_LIST_BOOL`、
+`XMLIR_FALLBACK_OP_LIST_FILE_PATH`、`XMLIR_XDNN_PYTORCH_CHECK_ENABLE_FALLBACK_BOOL`、
+`XMLIR_D_ENABLE_BACKTRACE`、`XMLIR_D_FILE_LOG_BOOL`、`XMLIR_D_PT_XPU_DEBUG_BOOL`、
+`XMLIR_D_PT_XPU_DEBUG_FILE_STR`、`XMLIR_D_OP_COMPARISON_ERROR_COUNT_THRESHOLD_INT`、
+`XMLIR_D_OP_COMPARISON_SPECIFY_OP_STR`
+
+**显存 / L3 / 缓存**：`XMLIR_CACHING_ALLOC_ENABLED`、`XMLIR_DISABLE_CUDA_ALLOCATOR`、
+`XMLIR_D_XPU_L3_SIZE`、`XMLIR_D_XPU_ENABLE_L3_SHARE`、`XMLIR_F_XPU_RESERVED_L3_INT`、
+`XMLIR_F_XPU_RESERVED_WORKSPACE_INT`、`XMLIR_LRU_CACHE_SIZE`、`XMLIR_MEMCPY_RETRY_SYNC`、
+`XMLIR_EMPTY_OP_INIT_ZERO`、`XMLIR_DISK_CACHE_DIR`、`XMLIR_PERSISTENT_CACHE_ENABLED`、
+`XMLIR_ENABLE_H2D_SSE_COPY`
+
+**GEMM / FC 调优**：`XMLIR_FC_AUTOTUNE_BOOL`、`XMLIR_FC_AUTOTUNE_FILE_NAME`、
+`XMLIR_FC_AUTOTUNE_FILE_PATH`、`XMLIR_FC_AUTOTUNE_REQUESTED_ALGO_COUNT`、
+`XMLIR_FC_AUTOTUNE_TOPK_VALUE`、`XMLIR_FC_TRY_TIMES_PER_ALGO`、`XMLIR_FC_BIAS_FUSION`、
+`XMLIR_FC_TINTER_RES_TYPE`、`XMLIR_F_XPU_FC_GEMM_MODE`、`XMLIR_F_XPU_CONV_GEMM_MODE`、
+`XMLIR_CONV_GEMM_DTYPE`、`XMLIR_ENABLE_XBLAS_ADDMM`、`XMLIR_MATMUL_FAST_MODE`、
+`XMLIR_MATMUL_FAST_TUNE`、`XMLIR_MATMUL_SATBLE_MODE`（源串拼写为 SATBLE）
+
+**算子行为**：`XMLIR_BADDBMM_DISPATCH_VALUE`、`XMLIR_BMM_DISPATCH_VALUE`、`XMLIR_BMM_TO_MOE`、
+`XMLIR_FA_ACCUM_TYPE`、`XMLIR_FA_GEMM_TYPE`、`XMLIR_FUSED_SDP_CHOICE`、
+`XMLIR_F_FAST_INDEX_PUT`、`XMLIR_USE_LSTM_KERNEL`、`XMLIR_CUDNN_ENABLED`、
+`XMLIR_BF16_FIND_MAX_SDNN`、`XMLIR_ENABLE_FAST_BF16_INITIAL_SDNN`、`XMLIR_FORCE_USE_CPU_INIT`、
+`XMLIR_XTRANS_OP_PRIOR`、`XMLIR_XTRANS_REGISTER_OPSELECT`、`XMLIR_PASS_OPTIONS`、
+`XMLIR_F_XLA_TENSOR_UPDATE_SYNC_BOOL`、`XMLIR_F_XPU_ENABLED_BOOL`、`XMLIR_OP_USE_DEFAULT_STREAM`
+
+**通信**：`TORCH_XCCL_NAN_CHECK`、`TORCH_XCCL_AVOID_RECORD_STREAMS`、
+`TORCH_XCCL_DEFAUTL_PG_TIMEOUT_MILSEC`（拼写错误在二进制里）、
+`TORCH_XCCL_SHOW_EAGER_INIT_P2P_SERIALIZATION_WARNING`、
+`TORCH_XCCL_ENV_STORE_KEY_WITH_PG_NAME`、`TORCH_XCCL_ENV_WAIT_GDB`、
+`XMLIR_XCCL_USE_ASYNC_OP`、`XMLIR_DIST_ASYNC_ISEND_IRECV`、`XMLIR_DIST_SINGLETON_STREAM`、
+`XMLIR_DIST_USE_DEFAULT_STREAM`、`XMLIR_DIST_CHECK`、`XMLIR_DIST_CHECK_INF_NAN`、
+`XMLIR_DIST_CHECK_INF_NAN_ASYNC`、`XMLIR_DIST_CHECK_INF_NAN_SAVE_DIR`、`XMLIR_ENABLE_NEW_PG`
+
+**硬件 / 模拟**：`XPU_NUM_CLUSTER`、`XPU_NUM_SDNN`、`XPU_SIMULATOR_MODE`、`XPU_SUPPORT_IPC_EVENT`
+
+---
+
+下一页：[11-debug-tools.md](11-debug-tools.md)

--- a/openwiki/torch-xmlir/11-debug-tools.md
+++ b/openwiki/torch-xmlir/11-debug-tools.md
@@ -1,0 +1,282 @@
+# 11 · 调试、诊断与工具链
+
+[← 首页](README.md) · [← 10 环境变量](10-env-vars.md) · [→ 12 已知坑](12-pitfalls.md)
+
+## `validate_aten`：CPU vs XPU 逐算子双跑
+
+`$PKG/debug/validate_aten/`（约 1300 行）是**精度排查的主力工具**。
+整个实现建在 `TorchDispatchMode` 上（`validate/contexts.py:14`）。
+**全包没有用到 `TorchFunctionMode`。** **[已验证]**
+
+### 四个 Mode
+
+| 类 | 位置 | 作用 |
+|---|---|---|
+| `Validate` / `ValidateCoreContext` | `contexts.py:193` / `:417` | 双跑引擎 |
+| `Check` | `contexts.py:329` | 只在 XPU 上跑，扫结果里的 NaN/Inf（`:397-399`），可选 ipdb + `exit(-1)` |
+| `LoggingEachOp` | `contexts.py:63` | 逐算子打日志 |
+| `InsertDelimiters` | `contexts.py:83` | 每算子打 `[START_SYMBOL]/[END_SYMBOL]`，可选注册 fwd/bwd module hook（`:125-130`） |
+
+### 双跑流程
+
+`ValidateCoreContext.__torch_dispatch__`（`contexts.py:441-600`）**[源码]**：
+
+1. `OpStats.total_cnt` 自增；黑名单 / 全 CPU（`is_cpu_op`）/ meta（`is_meta_op`）跳过（`:457-473`）
+2. 深拷贝输入到 CPU：`tree_map(lambda x: tensor_utils.to_cpu_device(x, is_clone=True), xpu_args)`（`:492-497`），
+   另存一份 `saved_args` 供原地算子用（`:502-503`）
+3. **CPU 参考跑把 fp16/bf16 输入升到 fp32**（`:510`，实现 `:174-189`）。
+   注释给的两个理由：torch 2.0 有很多 aten 算子没有 fp16 版本；CPU fp16 本身也不准
+4. 两边种同一个种子：`seed = fix_seed()` → `op(*xpu_args)` → `fix_seed(seed)` → `op(*cpu_args)`（`:516-536`）。
+   CPU 侧抛异常会降级成 warning 并返回 XPU 结果（`:537-544`）
+5. `comparer(...)` 按 config 的 `atol`/`rtol`/`equal_nan` 比对（`:546-553`）。
+   比较顺序（`comparer.py:135-212`）：长度 → 非 tensor 逐元素 → shape（`:123`）→ dtype（`:128`）
+   → `allclose_comparer`（`:43-107`），后者手算 `|cpu-xpu| - rtol*|xpu|` 以便报出
+   **错误个数、最大差值下标、两侧具体值**
+6. 不一致时：打日志，**并提示用 `XMLIR_D_FORCE_FALLBACK_STR='<op>'` 把该算子按到 CPU**（`:566-569`），
+   可选打 Python 栈、可选 `codegen.gen_unittest(...)`（`:591`）、可选 ipdb（`:593-599`）
+7. `Validate.__exit__` 打一张表：`算子 / 双跑次数 / CPU XPU结果一致次数 / 不一致次数`（`:221`, `:246-249`）
+
+### 用法
+
+**不由环境变量启用，纯 opt-in。** 全包 grep `validate_aten` / `ValidateCoreContext`
+只命中它自己的文件 —— `debug/__init__.py` 是个裸 docstring，不 import 任何子模块。**[已验证]**
+
+```python
+from torch_xmlir.debug.validate_aten import Validate
+
+with Validate(atol=1e-5, rtol=1e-5, dump=True, whitelist=["aten.add.Tensor"]):
+    train_step()
+```
+
+构造参数（`contexts.py:193-207`）：`atol, rtol, equal_nan, pdb, dump, dump_dir,
+blacklist, whitelist, log_level, print_config, print_traceback, print_results`。
+
+- 黑名单在 `Context.__init__` 合并（`common/contexts.py:126-135`）：默认表 +
+  一个 `"用户自定义"` 桶
+- **`whitelist` 非空时完全覆盖黑名单**（`common/utils.py:8-16`）
+- ⚠️ `dump_dir` 默认 `validate_dump_<YYYY_MM_DD_HH_MM_SS>`，**如果已存在会被 `shutil.rmtree`**（`common/contexts.py:151-153`）
+
+默认黑名单（`validate/config.py:17-69`）按原因分组：非计算/搬运类算子、
+未初始化内存类（`aten.empty*`）、RNG 类（CPU 与 XPU 算法不同）、
+`aten.max_pool2d_with_indices[_backward]`。torch 2.0.x 额外加 `aten.gather.default`（`:72-75`）。
+
+### 复现脚本生成
+
+`codegen.gen_unittest`（`codegen.py:14-30`）在 `<dump_dir>/<id>-<op>/` 下写
+`cpu_args.pkl`、`cpu_kwargs.pkl`、`test.py`。生成的 `test.py` 用
+`torch.device("cuda")` 作为 XPU 设备（`codegen.py:76`，
+`tensor_utils.py:71: to_xpu_device = functools.partial(to_target_device, torch.device("cuda"))`）
+—— 与 CUDA key 劫持一致。
+
+### 一处必要的 hack
+
+`Check` 和 `ValidateCoreContext` 都临时 monkeypatch `torch.Tensor.record_stream`
+以绕过 dispatch（`contexts.py:418-439`，wrapper `TorchFuncMockNoDispatch` @ `:252-266`
+用 `_pop_mode_temporarily`），代码里引了 pytorch#94403。
+这也解释了为什么 `$PKG/__init__.py:29` 的 `ignore_deregister_op` 唯独保留了
+`aten::record_stream` —— 同一个问题的两端。
+
+### 已知缺陷
+
+`validate/contexts.py:2` 有 `from crypt import methods`、`:4` 有 `import nntplib`，
+两个都没用到，且 `crypt`/`nntplib` 在新版 CPython 已废弃/移除（3.10 上没问题，3.13 会炸）。
+`common/logger.py:1` import 了 `auto_param` 却不用。
+`get_module_index()`（`contexts.py:78-80`）改 `MODULE_COUNTER` 但没写 `global`，会 `UnboundLocalError`；
+`InsertDelimiters.__init__` 的 `elif isinstance(model, torch.nn.Module)` 分支（`:96-99`）
+在未定义的 `module` 上迭代 —— 所以 **`InsertDelimiters(model=...)` 是坏的，
+`InsertDelimiters()` 不带参数可用**。**[源码]**
+
+## XDNN 调试等级
+
+`$PKG/debug/dump_level.py`（117 行）**[源码]**：
+
+`dump_level.py` 定义 `trace`、`checksum`、`dump` 和 `profiling` 四个调试等级，并将其映射到运行时位掩码。具体掩码值不在本文公开。
+
+掩码经 `_XMLIRC._xpu_set_xdnn_debug_level` 推给运行时（`:46-47`）。两种用法：
+
+```python
+from torch_xmlir.debug.dump_level import dump_inner, dump_function
+
+with dump_inner(mode="trace,dump"):     # :94-105
+    step()
+
+@dump_function(mode="checksum")          # :108-117
+def f(): ...
+```
+
+另有 `set_xlog_level` / `unset_xlog_level`（走 `_XMLIRC._xpu_set_xlog_level`，
+不是环境变量，虽然 docstring 里提到 `XLOG_LEVEL`）。
+
+## profiler 工具链（插件，默认关）
+
+`XFLAGS --enable profiler` 后启用。运行时足迹只有一处注册：
+
+```python
+# $PKG/symbrewrite/plugins/profiler/__init__.py:9-16
+"resource": {
+    "cuda symbol replace": [
+        SYMBOL_REPLACE("torch.autograd.profiler_util.EventList.dump", dump),
+    ]
+},
+```
+
+⚠️ torch 2.9 的 `EventList` **有 `table` 但没有 `dump`**。所以这是一次**新增**而非替换 ——
+`get_source` 抛 `AttributeError`，被 `symbol_rewrite.py:91-94` 的裸 except 吞掉，
+结果 `__origin_dump = None`，`EventList.dump` 是新定义的。**[已验证]**
+
+### 四个组件
+
+| 文件 | 行数 | console_script | 作用 |
+|---|---|---|---|
+| `profiler/statistic_dump.py` | 436 | — | `dump` 的实现 |
+| `profiler/csv_diff.py` | 498 | `XPU_Profiler_Comparison` | baseline vs current CSV 对比 |
+| `profiler/trace_clean.py` | 314 | `XPU_Profiler_TraceClean` | 清理时间戳损坏的 Chrome trace 事件 |
+| `profiler/trace_merger.py` | 361 | `XPU_Profiler_TraceMerge` | 多 rank trace 合并成一条时间线 |
+
+**`statistic_dump.dump`** —— 把 `EventList.table` 的渲染器改成写文件。
+`save_format` ∈ `{"txt","csv","all"}`（`:78` 校验），输出到
+`output_dir or "torch_profiler_output"`，文件名
+`profiler_<%Y%m%d_%H%M%S>_<pid>.{txt,csv}`（`:96-98`），且有写权限预检（`:85-94`）。
+CUDA→XPU 适配在排序键里，把三套设备词汇统一到 torch 内部命名：
+
+```python
+# $PKG/symbrewrite/plugins/profiler/statistic_dump.py:116-122
+key=lambda e: getattr(
+    e,
+    sort_by.replace("cuda", "device")
+    .replace("xpu", "device")
+    .replace("privateuse1", "device"),
+),
+```
+
+默认 `sort_by="self_device_time_total"`、`row_limit=math.inf`（`:20-21`）。
+表头用 `use_device.upper()`，所以列名是 "Self XPU" 而非 "Self CUDA"（`:160`）。
+device time 汇总把 `CUDA` / `PrivateUse1` / `MTIA` 事件都算上，排除 user annotation（`:133-140`）。
+
+**`XPU_Profiler_Comparison`** —— 按 `Name` 列做 key（`csv_diff.py:11`），
+比 10 个指标（`DEFAULT_FIELDS`，`:13-24`）。注意**这些字段名仍是 CUDA 命名**
+（`Self CUDA`、`CUDA total`、`CUDA time avg`），即它消费的是「CUDA 标签的那份 CSV」。
+`parse_value`（`:75-100`）把 `12.3us`/`4.5ms`/`1.2s` 归一到微秒，`45.6%` 转 float。
+`--min-change 0.2` 只保留 `Self CUDA` 变化 ≥20% 的条目（`:176-184`）；
+baseline 为 0 的会保留而非丢弃（`:148-155`）。输出
+`diff_<YYYY-MM-DD-HH-MM-SS>_<PID>.{txt,csv}`（`:475-485`）。裸调打完整 help。
+
+**`XPU_Profiler_TraceClean`** —— 修复部分事件带垃圾 `ts` 的 trace
+（大概是未初始化的 XPU 时间戳）。启发式基于**位数**而非数值：
+`calculate_ts_digits` 数整数部分位数（`:7-38`），`determine_threshold` 建直方图并返回
+累计占比达到 `threshold_percentage`（默认 90）的最小位数（`:41-88`，
+完全没有 `ts` 时回落 15，`:68`），然后丢掉超宽的事件（`:91-196`）。
+兼容裸数组和 `{"traceEvents": [...]}` 两种形状，用 `data.copy()` 保留其它顶层键（`:113`），
+没有 `ts` 或 `ts` 非数值的事件一律保留（`:148-153`）。`--analyze` 只报分布不写文件（`:199-273`）。
+
+**`XPU_Profiler_TraceMerge`** —— 分布式 trace 合并。rank 来源优先
+`distributedInfo.rank`，回落文件名正则 `rank[-_]?(\d+)` / `TP[-_]?(\d+)` / `world[-_]?(\d+)`，
+最后取文件名里最后一个数字（`:92-100`）。
+`validate_same_execution`（`:138-209`）在这些情况下**直接 exit**：rank 重复、
+`world_size` 或 `backend` 不一致、rank 数超过 `world_size`、
+`default_pg` 的 rank 集合覆盖不了发现的 rank。
+每 rank `process_events`（`:212-247`）按该 rank 自己的 `min_ts` 做时间窗过滤、
+丢掉 `threading.py(` 前缀噪声、给 flow event id 加偏移防跨 rank 冲突、
+给每个 `pid` 加 `[Rank NN]` 前缀。flow-id 偏移在单独的预扫描里算（`:265-275`），
+正是因为 id 会跨 rank 重叠。合并时流式写 gzip 而不是在内存里拼大 dict（`:288-321`），
+每个 rank 处理完就 `del trace` —— 刻意的内存措施。已存在的输出文件不会被覆盖（`:339-342`）。
+
+## 其它调试工具（XLA 时代，多数已坏）
+
+| 文件 | 行数 | 状态 |
+|---|---|---|
+| `debug/graph_saver.py` | 38 | `save_tensors_graph()` dump lazy-tensor 图（text/dot/hlo），受 `SAVE_GRAPH_FMT` 控制 |
+| `debug/metrics.py` | 53 | `_XMLIRC._xpu_counter_*` / `_xpu_metric_*` / `_xpu_metrics_report` 的薄封装 |
+| `debug/metrics_saver.py` | 71 | ⚠️ `:65` 用了 `sys` 但没 import，`XLA_METRICS_FILE=STDERR` 会 `NameError` |
+| `debug/metrics_compare_utils.py` | 224 | ⚠️ `:197` 调不存在的 `_parse_metrics_report`（真名是 `:85` 的 `parse_metrics_report`），`compare_metrics` **是坏的** |
+| `debug/model_comparator.py` | 243 | 独立 CLI：`python -m torch_xmlir.debug.model_comparator DIR1 DIR2`。⚠️ `:169` 把 `collections.namedtuple(...)` 当元组构造器用了 4 个位置参数，所以 `_parse_path` 会 raise，不匹配时的 `tensor_file_compare` 也跟着炸 |
+
+## 版本自检
+
+```bash
+python -m torch_xmlir --doctor
+```
+
+`__main__.py:11-12` 调 `utils/version.py:60-68 get_version_string()`，
+在 `_versions.txt` 内容之外补上 `XTE`（transformer_engine）、
+`XFlashAttention`（flash_attn 的 importlib.metadata）、`Hydrax` 版本。
+
+⚠️ `__main__.py` 在**导入期**就解析 argv（`:7`），传未知参数会直接硬失败。**[源码]**
+
+`torch_xmlir.__version__` 是 `get_version_dict()` 的返回值，
+**是一个 `OrderedDict` 而不是字符串**（`utils/version.py:46-57`，`__init__.py:64`）。
+本机值见 [首页](README.md)。解析规则：跳过 `#` 行，按**第一个** `:` 切分（值里可以含冒号）。
+
+## 构建自定义 XPU 扩展
+
+`$PKG/utils/cpp_extension.py`（823 行），`__all__` = `["xpu_include_paths",
+"xpu_library_paths", "CppExtension", "XPUExtension", "BuildExtension"]`（`:34-40`）。
+
+`XPUExtension`（`:737`）硬链这些库（`:783-795`）：
+
+```
+c10, torch, torch_cpu, torch_python, XMLIRRuntime,
+xdnn_pytorch, xpuapi, xlog_adapter, xpurt, cudart
+```
+
+- 编译器发现需要 `XPYTORCH_XTDK`，缺失时抛 `NotImplementedError` 并给下载链接（`:155-170`）
+- `.cu` 源码额外需要 `XTRANS_PATH`（`:171-178`）
+- 除调用方自带 `-On` 外，xtdk 一律强制 `-O2`（`:806-819`）
+- dev 模式检测靠 `pip show xmlir` 找 `Editable project location`（`:343-359`），`functools.cache` 缓存
+
+## 其它 utils
+
+| 文件 | 行数 | 说明 |
+|---|---|---|
+| `utils/custom_op_loader.py` | 17 | `torch.ops.load_library` 的断言包装，见 [06](06-custom-ops-nn.md) |
+| `utils/version.py` | 68 | 上面已述 |
+| `utils/utils.py` | 410 | `getenv_as`（`:175-182`，`core/` 读环境变量都走它）、`SampleGenerator`、`TimedScope`、`get_free_tcp_ports`、`parallel_work` |
+| `utils/gcsfs.py` | 424 | `gs://` 文件系统垫片，全部走 `_XMLIRC._xpu_tffile_*`（`:38-44`）。**[.so 内]** |
+| `utils/serialization.py` | 132 | `save()`/`load()` 把 XPU tensor 溢出到同级 `<path>.tensors/` 目录存 CPU `.pt`；`:51-53` 用 `_XMLIRC._xpu_sync_multi` |
+| `utils/cached_dataset.py` | 169 | `CachedDataset` 文件/GCS 样本缓存 |
+| `utils/tf_record_reader.py` | 69 | `TfRecordReader` 走 `_XMLIRC._xpu_create_tfrecord_reader` 等 |
+| `utils/keyd_queue.py` | 125 | `KeydQueue` 按 key 寻址的阻塞队列 |
+| `utils/checkpoint_tagger.py` | 61 | 引用计数的 name→path 标签 + JSON 往返 |
+| `utils/data/distributed.py` | 138 | `DistributedSampler`，官方实现但换用 `torch_xmlir.distributed` 取 world size/rank（`:10,73-79`）。**不是 DataLoader 适配** |
+
+## 多进程与 CUDA IPC
+
+`$PKG/multiprocessing.py`（203 行）两半 **[源码]**：
+
+**进程启动器**（XLA 血统）：`spawn()`（`:30-64`）转发 `torch.multiprocessing.start_processes`，
+wrapper `_mp_start_fn`（`:19-27`）打印 `device=xpu:{index}` 且异常时 `exit(17)`；
+`MpSerialExecutor`（`:67-98`）是把「只让一个 rank 下载数据集」这类操作串行化的锁。
+
+**CUDA IPC 对**（由 `__init__.py:62` 导入命名空间）：
+
+```python
+# $PKG/multiprocessing.py:117-127
+(
+    device, handle, storage_size_bytes, storage_offset_bytes,
+    ref_counter_handle, ref_counter_offset, event_handle, event_sync_required,
+) = _XMLIRC._share_cuda_(storage)
+```
+
+`_reduce_cuda_tensor`（`:101-147`）返回 15 元组；`_rebuild_cuda_tensor`（`:150-203`）
+反向重建，零长度 storage 短路（`:168-169`），否则
+`torch.cuda._lazy_init()` + `_XMLIRC._new_shared_cuda(...)`（`:171-181`）。
+
+**适配策略：完整保留官方 CUDA IPC 协议和元组布局，只把两个碰驱动 handle 的原语
+（`_share_cuda_`、`_new_shared_cuda`）改路由到 `_XMLIRC`。** 实现在 `.so` 里。
+
+拒绝条件：非 leaf 的 `requires_grad` tensor（`:104-110`）、
+`storage.device.type != "cuda"`（`:111-112`）。
+
+真正把这两个函数接进 `ForkingPickler` 的是 symbrewrite
+（`plugins/torch/__init__.py:98-109` 替换 `reduce_tensor`/`rebuild_cuda_tensor`/`init_reductions`），
+`multiprocessing.py` 自己不注册。
+
+## `test_utils/`
+
+3669 行，包含 `automated_test/`（含 `dynamo_parser.py`，会生成
+`torch.compile(fn, backend=XMLIRCompiler())` 形式的测试）和 `random_test/`。
+本次未深入分析。
+
+---
+
+下一页：[12-pitfalls.md](12-pitfalls.md)

--- a/openwiki/torch-xmlir/12-pitfalls.md
+++ b/openwiki/torch-xmlir/12-pitfalls.md
@@ -1,0 +1,287 @@
+# 12 · 已知坑、死代码与 latent bug
+
+[← 首页](README.md) · [← 11 调试工具](11-debug-tools.md)
+
+按「会不会咬到你」排序。**遇到诡异行为时先扫这一页。**
+
+---
+
+## A · 行为陷阱（最可能咬人）
+
+### A1 · `torch.compile` 静默变成空装饰器
+
+`XMLIR_ENABLE_MOCK_TORCH_COMPILE` 默认 `true` → `torch.compile` 是
+`mock_torch.empty_decorator`（运行时确认）。**不报错、不警告，模型静默以 eager 运行。**
+
+**影响**：任何「编译前后性能对比」的结论都是错的。
+**规避**：`XMLIR_ENABLE_MOCK_TORCH_COMPILE=false`（此时走官方 Inductor，昆仑上是否可用未验证）。
+详见 [08](08-compile-dynamo.md)。**[已验证]**
+
+### A2 · 所有补丁失败都是静默的
+
+三处静默失败路径 **[源码]**：
+
+| 位置 | 行为 |
+|---|---|
+| `xpytorch_import_hook.py:123-125,137-139` | import hook 异常 → 只打 `WARNING: hook error!` 到 stderr |
+| `symbrewrite/symbol_rewrite.py:96-105` | 中间层 getattr 失败 → 打 warning 并 skip 这一条替换 |
+| `$PKG/__init__.py:274-281` | 整个插件初始化失败 → `traceback.print_exc()` + warn |
+
+**影响**：你可能在完全没打补丁的官方 torch 上跑，而只有 stderr 里一行 warning。
+**规避**：启动日志必须看。正常启动应该看到 `SYMBOL_REWRITE torch success`。
+用 `LOG_SYMBOL_REPLACE=1` 确认关键符号真的被替换了。
+
+### A3 · `xpu/memory.py` 整体不可用
+
+`_xpu_empty_cache` / `_xpu_memory_stats` / `_xpu_memory_snapshot` / `_mem_get_info`
+四个 pybind 符号在本构建的**任何** `.so` 里都不存在（23 个库逐一扫描确认）。
+整个 `torch_xmlir.xpu.memory` 模块（除 `use_l3`）都会抛 `AttributeError`。**[已验证]**
+
+**影响**：`XMLIR_DISABLE_CUDA_ALLOCATOR=1` 会把 14 个 `torch.cuda.memory_*` 指到这些坏函数上。
+**规避**：**不要设这个变量**。默认路径用官方 caching allocator，`PYTORCH_CUDA_ALLOC_CONF` 正常生效。
+详见 [05](05-device-runtime.md)。
+
+### A4 · `XPU_RUN_MODE` 在 import 期改共享硬件状态
+
+`$PKG/__init__.py:170-176` → `_xpu3_run_mode.py` 通过运行时提供的寄存器写入工具
+写 12 个硬件寄存器，默认作用于设备 `0..7`。**[源码]**
+
+三个后果：
+
+1. 同节点并发多任务时，一个进程设 `XPU_RUN_MODE` 会影响**所有选中设备**。
+   用 `LOCAL_RANK` 可以缩到单卡。
+2. **拼错的模式名被静默忽略** —— `write()` 遇未知 mode 只 warn 就 return（`:72-76`），
+   `check()` 也 warn 后 return。`XPU_RUN_MODE=TRAIN_BF16`（下划线）什么都不做，不报错。
+3. `INFER-BF16` 和 `INFER-FP16` 写同一个值 `-1`（`:15-20`），寄存器层面无法区分。
+
+### A5 · `config` 在 import 期冻结
+
+`config = Config.from_env()` 在 `config.py:163` 模块导入期执行。
+`import torch_xmlir` 之后再 `os.environ[...] = ...` 对这 13 个 flag **无效**。**[源码]**
+
+而且 TE 和 hydrax 各自直接读环境变量、解析方式不一致
+（`transformer_engine/.../gemm.py:135` 用 `in ("true","1","True")`，大小写敏感且无默认值）。
+详见 [06](06-custom-ops-nn.md)。
+
+### A6 · 精确字符串比较的开关
+
+这些开关**不接受常见的等价写法** **[源码]**：
+
+| 变量 | 判断 | 陷阱 |
+|---|---|---|
+| `XMLIR_USE_HYDRA_LINEAR` | `== "1"` | 写 `"true"` 无效，会走 legacy 路径 |
+| `XMLIR_PERSISTENT_CACHE_ENABLED` | `== "true"` | 写 `"1"` / `"True"` 无效 |
+| `XMLIR_ENABLE_LINEAR_FC_FUSION` | `int(...)` | 写 `"false"` 直接抛 `ValueError` |
+| `XMLIR_FORCE_USE_XPU_GRAPH` | `int(...)` | 同上 |
+| `XPYTORCH_RUN_ENHANCE` | `int(...)` | 同上 |
+| `CUDA_DEVICE_ORDER` 注入条件 | `CUDA_VISIBLE_DEVICES == "0,1,2,3,4,5,6,7"` | 多空格、4 卡、乱序都不触发 |
+
+### A7 · `XTORCHRUN_CLEAN` 会杀别人的进程
+
+`enhance_launch_torch2_5.py:142-156`（和 `…2_0.py:201`）的实现是
+`lsof | grep /dev/xpu | ... | xargs kill -9`，**会杀掉本机上除自己以外任何持有 XPU 设备的进程**。
+共享节点上不要开。需先 `XPYTORCH_RUN_ENHANCE=1` 才走到这里。**[源码]**
+
+### A8 · DTensor 切分约束会静默回落
+
+RoPE 的 head_dim、softmax/RMSNorm 的最后一维、`mha_varlen_fwd` 的**全部三个维度**
+都不可切，不满足时静默 `Replicate`。张量并行性能不达预期时先查
+[07](07-distributed.md) 的约束表。**[源码]**
+
+### A9 · `capability` 两套值不一致
+
+`torch.cuda.get_device_capability()` → `(8, 6)`（垫片编的），
+`torch_xmlir.xpu.get_device_capability()` → `(0, 0)`（`_XpuDeviceProperties` 里 major/minor
+标注 `N/A for XPU`）。依赖 capability 做分支的第三方库要注意。**[已验证]**
+
+### A10 · `dump_dir` 会被 rmtree
+
+`validate_aten` 的 `dump_dir` 默认 `validate_dump_<时间戳>`，
+**若目录已存在会被 `shutil.rmtree`**（`common/contexts.py:151-153`）。
+不要把它指向有用数据的目录。**[源码]**
+
+### A11 · `plugins.xflags` 写在 site-packages 内部
+
+`XFLAGS --enable` 修改的是 `<pkg>/symbrewrite/plugins/plugins.xflags`，
+不是 `$HOME` 下的文件。需要对已安装包的写权限，**且会被重装/升级覆盖**。
+容器镜像里改了要注意持久化。**[源码]**
+
+### A12 · `XFLAGS --reset` 与 `--enable` 同时给会互相打架
+
+`xflags_cli.py:198` 先把 default 写盘，`:201` 的 `update_flags()` 又用**加载 reset 之前**
+的内存状态覆盖回去 —— reset 等于被丢弃。**[源码]**
+
+---
+
+## B · 已确认的 latent bug
+
+### B1 · `WITHOUT_MLIR` 布尔解析（最讽刺的一个）
+
+```python
+# $PKG/__init__.py:47
+WITHOUT_MLIR = bool(os.environ.get("WITHOUT_MLIR", "0"))
+```
+
+`bool("0")` 是 `True`。**除了设成空字符串，任何值（包括 `"0"`）都让它为真。**
+运行时确认 `torch_xmlir.WITHOUT_MLIR == True`。**[已验证]**
+
+**讽刺之处**：正因为它永真，`dynamo/` 那条 import 必炸的路径（缺
+`torch_xmlir.ir` / `dialects`，且用了 torch 2.9 已删的 API）才从不执行。
+**「修好」这个 bug 会让整个包 import 失败。** 见 [08](08-compile-dynamo.md)。
+
+### B2 · `xpu/device.py:84` 正则的运算符优先级
+
+```python
+re.match(r"xla|xpu:(\d+)$", device_str)
+```
+
+`|` 结合比预期松，实际含义是 `xla` **或** `xpu:(\d+)$`。
+走 `"xla"` 分支时 `m.group(1)` 是 `None`，`:87` 执行 `int(None)`。
+运行时确认 `xpu_device_hw('xla')` 抛
+`TypeError: int() argument must be ... not 'NoneType'`。
+应写作 `r"(?:xla|xpu):(\d+)$"`。**[已验证]**
+
+### B3 · `_DEVICES` 格式与解析正则不匹配
+
+`_XMLIRC._xpu_get_devices()` 返回 `['XLA: 0', 'XPU: 0', 'XLA: 1', 'XPU: 1', ...]`
+（**冒号后有空格**），但 `parse_xpu_device`（`xpu/device.py:262`）用
+`r"(CPU|TPU|GPU|XPU):(\d+)$"`，`get_xpu_supported_devices`（`:285`）用 `kind + r":\d+$"`，
+两个都匹配不上。于是 `get_xpu_supported_devices()` 返回 `None`，
+导致 `xpu_replication_devices`（`:229`）在 `:244` 的 `len(None)` 处失败。**[已验证]**
+
+### B4 · `_DEVICES` 索引错位
+
+列表把 XLA 和 XPU 条目交错排列，所以索引 `N` 不是设备 `N`。
+`xpu_device_hw('xpu:0')` 返回 `'XLA'`（因为 `_DEVICES.value[0]` 是 `'XLA: 0'`）。**[已验证]**
+
+### B5 · `distributed/__init__.py` 的 `__all__`
+
+```python
+__all__ = ["DistributedDataParallel, tensor"]   # 一个含逗号的字符串
+```
+
+`from torch_xmlir.distributed import *` 一个名字都导不出来。**[源码]**
+
+### B6 · `fused_adam.py` 的 step 泄漏
+
+`optimizer/fused_adam.py:149,166` 的 `state` 从 `for p in group["params"]` 循环里泄漏出来，
+`state["step"] += 1` 只递增**最后一个参数**的 step，却把这个值喂给整个 param group。
+另外因为 fp16 在 `:135` 就 raise 了，`:148` 的 `if len(g_16) > 0` 分支不可达。**[源码]**
+
+### B7 · 字符串用 `is` 比较
+
+`nn/rotary_pos_emb_index.py:18,73` 的 `layout is "BLHD"`。
+依赖 CPython 字符串 interning，不保证成立。**[源码]**
+
+### B8 · `__all__` 拼写不匹配
+
+`dynamo/passes/replace_missemantice_op.py:6` 的
+`__all__ = ["ReplaceMisSemanticeOp"]` 多了个 `e`，类名是 `ReplaceMisSemanticOp`。
+`from ... import *` 会失败。**[源码]**
+
+### B9 · `metrics_saver.py` 缺 `import sys`
+
+`debug/metrics_saver.py:65` 用了 `sys`，所以 `XLA_METRICS_FILE=STDERR` 会 `NameError`。**[源码]**
+
+### B10 · `compare_metrics` 调不存在的函数
+
+`debug/metrics_compare_utils.py:197` 调 `_parse_metrics_report`，
+真名是 `:85` 的 `parse_metrics_report`。**该函数是坏的。[源码]**
+
+### B11 · `model_comparator.py` 误用 namedtuple
+
+`debug/model_comparator.py:169` 把 `collections.namedtuple(...)` 当元组构造器用了
+4 个位置参数，所以 `_parse_path` 会 raise，不匹配时的 `tensor_file_compare` 跟着炸。**[源码]**
+
+### B12 · `validate_aten` 的几处
+
+- `get_module_index()`（`validate/contexts.py:78-80`）改 `MODULE_COUNTER` 但没 `global` → `UnboundLocalError`
+- `InsertDelimiters.__init__` 的 `elif isinstance(model, torch.nn.Module)` 分支（`:96-99`）
+  在未定义的 `module` 上迭代 → **`InsertDelimiters(model=...)` 坏的**
+- `:2` `from crypt import methods`、`:4` `import nntplib` 未使用，且在 CPython 3.13 已移除
+
+**[源码]**
+
+### B13 · `_xpu3_run_mode.py` 的 `_get_device`
+
+声明时既没 `self` 也没 `@staticmethod`，只因为在类上访问才能工作（`:14`）。**[源码]**
+
+### B14 · `xpu_synchonize_default_stream` 拼写
+
+`xpu/device.py:291` —— `synchonize` 少个 `r`，是公开 API 名字的一部分。**[源码]**
+
+### B15 · `distributed/distributed.py` 构造即崩
+
+`:119`/`:122` 调 `_XMLIRC._xpu_sync_multi` 和 `._xpu_reset_tokens`，
+两个符号在 `XMLIR Python extension` 里都不存在（用 `_xpu_set_default_device` 等做对照命中确认）。
+`_sync_params_and_buffers` 在 `__init__` 里无条件调用（`:57`），
+所以**构造 `torch_xmlir.distributed.DistributedDataParallel` 就会 `AttributeError`**。**[已验证]**
+
+---
+
+## C · 死代码清单
+
+| 模块/函数 | 行数 | 为什么死 | 证据 |
+|---|---|---|---|
+| `dynamo/` 全部 | 1284 | 缺 `torch_xmlir.ir` / `dialects`；用了 torch 2.9 已删 API；且被 `WITHOUT_MLIR` 门死 | [已验证] |
+| `dynamo/affine.py` | 316 | 唯一消费者 `ir.py:199-207` 算完 affine 表达式就丢掉，直接 `return "?"` | [源码] |
+| `_dynamo_patched_functions.py` | 137 | 由 `WITHOUT_MLIR` 门死；文件头注释自称 torch 2.0.1 workaround | [已验证] |
+| `_patched_functions.py` 的 distributed 补丁 | ~1000 | `_apply_patches_201()` 只在 `200 <= dv < 250` 调用，torch 2.9 → `dv=290` | [已验证] |
+| `enable_pytorch_storage_replacement()` | — | 条件 `torch.__version__.find("cu") == -1`，版本串含 `cu129` | [已验证] |
+| `core/xpu_model.py:mark_step` | — | `:678` 无条件 `raise NotImplementedError`，连带 `optimizer_step`（`:919,947` 调它）整条路径不可用 | [源码] |
+| `core/xpu_model.py:xpu_device` | — | `:184` 同样 raise | [源码] |
+| `core/xpu_env_vars.py` 的 19 个常量 | — | 22 个里只有 `WORLD_SIZE`/`ORDINAL`/`LOCAL_ORDINAL` 被消费，其余是 torch_xla 遗留 | [源码] |
+| `xpu/memory.py` | 441 | 见 A3 | [已验证] |
+| `amp/` 全部 | 701 | 全 site-packages 无人 import；且 fp16 only、拒绝 `device_type="cuda"` | [已验证] |
+| `nn/parallel/` | 2175 | `distributed.py:17` 调不存在的 `torch_xmlir.distributed.is_available()`；无人 import | [静态推断] |
+| `distributed/distributed.py` | 130 | 见 B15 | [已验证] |
+| `distributed/fsdp/` | 465 | 老 API 拷贝，与 torch 2.9 FSDP 不兼容，无人引用。**本适配层对 FSDP 无任何专门适配** | [已验证] |
+| `distributed/utils.py` | 45 | `__all__ = []`，无人引用 | [源码] |
+| `_op_select.py:load_xtrans()` | — | `__init__.py:21` 的调用被注释掉；且 `optional xtrans component` 未发货 | [源码] |
+| `_utils.py:_init_graph_disk_cache()` | 33 | `<pkg>/builtin_modules/` 不存在，`:547` 直接 return，无论环境变量如何都是 no-op | [已验证] |
+| `plugins/torch_vision/` 的替换 | — | 6 处 `SYMBOL_REPLACE` **全被注释掉**（`__init__.py:13-36`），虽然默认 `True` 但什么都不改。`mock_torchvision.py` 里的实现还活着 | [源码] |
+| `config.py` 的 11 个属性 | — | 只有 `enable_param_state` / `enable_activ_state` 有消费者；`use_cast_fc_fusion` 硬编码 `0` 且无人读 | [已验证] |
+| `nn/rms_norm.py:12-16` 的 `stats_dtype` | — | 算完不用 | [源码] |
+| `optimizer/` 里 4 个 kernel | — | `multi_tensor_l2norm`（在 `optimizer/` 内）、`multi_tensor_cuda_lamb`、`optimizer_LAMB_fused` 在 `.so` 里有但 `optimizer/` 无调用者 | [源码] |
+| `nn/mmcv_ops/` | 96 | 无人 import（只有 wheel RECORD 里的条目）；`mean`/`sum` backward 直接 raise | [已验证] |
+| loss 类 custom_ops | — | `hard_softmax_with_cross_entropy`、`te_cross_entropy`、`sigmoid_focal_loss_*` 在 `.so` 里但无 Python 包装 | [已验证] |
+| 大量 mmcv custom_ops | — | `deform_conv`、`ms_deform_attn`、`roi_align`、`nms_rotated`、`ball_query`、`voxel_pooling_train` 等有 C++ 无 Python | [已验证] |
+
+---
+
+## D · 精度不对时的排查顺序
+
+综合各页信息，给一条实用路径：
+
+1. **确认补丁真的生效** —— 看启动日志有 `SYMBOL_REWRITE torch success`；
+   `LOG_SYMBOL_REPLACE=1` 确认关键符号
+2. **确认走的是哪条 Linear 路径** —— `XMLIR_USE_HYDRA_LINEAR` 默认走 **hydrax 包**，
+   不在 torch_xmlir 里。可用 `FORCE_NN_LINEAR=1` 退到官方实现做对照
+3. **确认 dispatch 目标** —— `torch._C._dispatch_dump('aten::xxx')`，
+   看是 `RegisterCUDA.cpp` 还是 `the PyTorch build directory`
+4. **逐算子双跑** —— `with Validate(atol=..., rtol=...)`，看 `__exit__` 打出的不一致表
+5. **定点回落** —— 对可疑算子设 `XMLIR_D_FORCE_FALLBACK_STR='<op>'` 按到 CPU 验证
+6. **检查 fast-FC 开关** —— `XMLIR_ENABLE_FAST_FC` 的覆盖关系（[06](06-custom-ops-nn.md)），
+   注意 TE / hydrax 的解析差异
+7. **检查 RNG 差异** —— 如果需要与 GPU 位对齐，`TORCH_NN_INIT_IS_GPU_ALIGNED=1` +
+   `GPU_NAME` / `RANDPERM_KEY_BITS`（[03](03-symbrewrite.md)）
+8. **检查 autocast dtype** —— `torch_xmlir.amp.autocast` 是 fp16 only 的死路径，
+   应该用官方 `torch.amp.autocast("cuda")`（[09](09-amp-optimizer.md)）
+9. **注意 `lamb.py:118-128`** —— trust_ratio 的零值守卫被刻意注释掉，可能出 inf/NaN
+
+## E · 关于代码的一个整体观察
+
+这个包里能读出**三个时代的地层** **[源码]**：
+
+| 时代 | 特征 | 代表 |
+|---|---|---|
+| XLA / lazy-tensor 时代 | 设备类型硬编码 `"xla"`，`mark_step`，XRT 环境变量，`core/xpu_builder.py` 的 HLO DSL | `core/`、`nn/parallel/`、`utils/gcsfs.py`、`_utils.py:469` 返回 `"xla"` |
+| MLIR / xgraph 时代 | `xgraph.aten.*` op 名、`_XMLIRC.compile(ir_str)`、affine 表达式 | `dynamo/`（依赖未发货） |
+| CUDA 劫持时代（当前） | 注销 `DispatchKey::CUDA`、CUDA ABI 垫片、`assert device.type == "cuda"` | `__init__.py:26-40`、`symbrewrite/`、`optimizer/fused_sgd.py:73-74` |
+
+同一个包里 `nn/parallel/comm.py:91` 断言 `"xla"` 而 `optimizer/fused_sgd.py:73` 断言 `"cuda"`
+——这是判断某段代码属于哪个时代（因而是否还活着）最快的启发式。
+
+---
+
+[← 返回首页](README.md)

--- a/openwiki/torch-xmlir/README.md
+++ b/openwiki/torch-xmlir/README.md
@@ -1,0 +1,58 @@
+# 昆仑芯 torch hook 层 Wiki（torch_xmlir / xmlir）
+
+自动生成的代码 wiki，覆盖 **昆仑芯 XPU 的 PyTorch 适配层**：它如何 hook 住官方 PyTorch，
+让写给 CUDA 的模型代码不改一行就跑在昆仑芯上。
+
+风格参考 [langchain-ai/openwiki](https://github.com/langchain-ai/openwiki)：互链页面 +
+每条事实带源码出处 + 明确区分「已验证 / 静态推断 / .so 内不可见」。
+
+## 分析范围与快照边界
+
+本文基于一个面向 Kunlun3 P800、使用 PyTorch 2.9 系列的 XMLIR 运行时快照进行分析。它是**独立分析快照**，不改变也不代表本仓库的默认安装组合。
+
+截至本文编写时，`ci/scripts/env/install_env.sh` 安装的是 `xpytorch-cp310-torch251`，并向 PyTorch 2.5.1 的 Dynamo 路径写入补丁。因此，本文中标记为 PyTorch 2.9 行为的结论**不能直接用于**该安装流程；将两者组合前应单独完成兼容性验证。
+
+文中 `$PKG` 指已安装的 `torch_xmlir` Python 包目录。包目录之外还涉及 `torch_xmlir.pth` 与 `xpytorch_import_hook.py`，它们位于 Python 的 site-packages 目录中。
+
+本文记录的是特定运行时构建的行为快照，不应将未标注为源码事实的结论直接外推到其他 XMLIR、驱动或 PyTorch 版本。
+
+## 一句话架构
+
+昆仑芯**不注册新设备类型**。它把自己伪装成 CUDA：在 C++ 层把 `DispatchKey::CUDA` 上的
+官方 aten kernel 全部注销再换成自己的，在 Python 层用 `builtins.__import__` hook
+批量改写 `torch.*` 符号，在系统层通过 CUDA 驱动与运行时 ABI 兼容接口完成转接。
+于是 `torch.cuda.is_available()` 返回 True，`.to("cuda")` 把张量搬到昆仑卡上。
+
+四层劫持详见 [01-architecture.md](01-architecture.md)。
+
+## 页面导航
+
+| 页面 | 内容 |
+|---|---|
+| [01-architecture.md](01-architecture.md) | 四层劫持总览、`import torch` 的完整启动时序、版本门控 |
+| [02-import-hook.md](02-import-hook.md) | `.pth` → `builtins.__import__` 替换、强制注入的 CUDA 环境变量 |
+| [03-symbrewrite.md](03-symbrewrite.md) | 符号改写引擎、`__origin_` 约定、xflags 插件系统与 `XFLAGS` CLI |
+| [04-dispatch-hijack.md](04-dispatch-hijack.md) | `op_deregister_C` 注销 CUDA kernel、CUDA ABI 垫片、op_select 策略 |
+| [05-device-runtime.md](05-device-runtime.md) | `xpu/` 设备/流/事件/显存/Graph、`torch.cuda.*` 的真实映射关系 |
+| [06-custom-ops-nn.md](06-custom-ops-nn.md) | `custom-op component` 与 `nn/` 融合算子（Linear、RoPE、RMSNorm、FA…） |
+| [07-distributed.md](07-distributed.md) | kccl/bccl 通信后端、DTensor 自定义 handler、DDP |
+| [08-compile-dynamo.md](08-compile-dynamo.md) | `torch.compile` 被空装饰器替换、`dynamo/` 死代码分析 |
+| [09-amp-optimizer.md](09-amp-optimizer.md) | autocast 双套状态、GradScaler、融合优化器 |
+| [10-env-vars.md](10-env-vars.md) | 环境变量总表（Python 可见 + `.so` 内字符串） |
+| [11-debug-tools.md](11-debug-tools.md) | `validate_aten` 双跑对齐、profiler 工具链、cpp_extension |
+| [12-pitfalls.md](12-pitfalls.md) | 已确认的死代码、latent bug、行为陷阱 |
+
+## 建议阅读顺序
+
+想搞懂「为什么我的 CUDA 代码能跑」→ 01 → 04 → 02 → 03。
+想调性能/精度 → 10 → 06 → 09 → 11。
+遇到诡异行为 → 12。
+
+## 事实可信度标记
+
+全文统一使用：
+
+- **[已验证]**：在分析环境中实际执行确认过，例如 Python 探测、`objdump` 或 `strings`。
+- **[源码]**：直接读到的 Python 源码，标注相对包路径和行号。
+- **[静态推断]**：由源码或符号表推理得出，未在运行时验证。
+- **[.so 内]**：逻辑位于编译产物中，Python 侧不可见，只能给出符号名。


### PR DESCRIPTION
## PR Description

### What problem does it solve?

The existing vLLM-Kunlun Wiki explains the plugin layer, but it does not explain the `torch_xmlir` runtime beneath it. That gap makes it harder to trace how vLLM's CUDA-facing paths reach Kunlun XPU at runtime.

### Why is this change needed?

This change adds a separate runtime Wiki for `torch_xmlir` and links it from the existing vLLM-Kunlun pages. The new pages document the import hook, symbol rewriting, CUDA dispatcher replacement, device and runtime behavior, custom operators, distributed runtime, compile behavior, AMP, environment variables, debugging tools, and known pitfalls.

### Overall approach

- Add the runtime Wiki under `openwiki/torch-xmlir/`.
- Keep the current root Wiki as the source of truth for vLLM-Kunlun plugin behavior, model support, and end-to-end inference behavior.
- Link the two layers from the root index, platform contract, and graph execution pages.
- Mark the runtime material as a version-specific analysis snapshot rather than vLLM-Kunlun source evidence.
- Remove absolute local paths, internal build identifiers, component-version details, and named binary artifacts before adding the documents to the public repository.

### Validation

- Ran the applicable pre-commit checks for all added and updated Markdown files.
- Passed Markdown formatting, whitespace, filename, file-size, YAML/TOML, and diff checks.
- Searched the new sub-Wiki for absolute paths and internal build markers after de-identification.
- Confirmed that the commit was created with `git commit -s`.

## Checklist (Required)

- [x] All code changes pass the pre-commit checks.
- [x] Commits are signed off using `git commit -s`.
- [x] The PR title is properly classified.

## PR Type

[Doc] Documentation updates or fixes

## Review notes

This is documentation only. The new runtime Wiki is based on a de-identified XMLIR runtime snapshot. Please review statements about CUDA compatibility, graph behavior, device runtime behavior, distributed communication, and environment variables before merging.