### PR TITLE
ci: backport automated issue and pull request labeling

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,53 @@
+# Keep broad refactors from accumulating noisy component labels.
+changed-files-labels-limit: 4
+max-files-changed: 150
+
+"area: kunlun-xpu":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "vllm_kunlun/**"
+          - "build.sh"
+          - "setup_env.sh"
+
+"area: ci":
+  - changed-files:
+      - any-glob-to-any-file:
+          - ".github/**"
+          - "ci.yml"
+          - ".pre-commit-config.yaml"
+
+"area: documentation":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/*.md"
+          - "docs/**"
+          - ".readthedocs.yaml"
+
+"area: tests":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "tests/**"
+          - "**/test_*.py"
+          - "**/*_test.py"
+
+"area: dependencies":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "requirements*.txt"
+          - "pyproject.toml"
+          - "setup.py"
+          - "setup.cfg"
+          - "uv.lock"
+
+"area: performance":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "benchmarks/**"
+          - "benchmark/**"
+          - "**/benchmark*.py"
+
+"area: examples":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "examples/**"
+          - "community/**"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,32 +1,32 @@
-"area: kunlun-xpu":
+"kunlun-xpu":
   - changed-files:
       - any-glob-to-any-file:
           - "vllm_kunlun/**"
           - "build.sh"
           - "setup_env.sh"
 
-"area: ci":
+"ci":
   - changed-files:
       - any-glob-to-any-file:
           - ".github/**"
           - "ci.yml"
           - ".pre-commit-config.yaml"
 
-"area: documentation":
+"documentation":
   - changed-files:
       - any-glob-to-any-file:
           - "**/*.md"
           - "docs/**"
           - ".readthedocs.yaml"
 
-"area: tests":
+"tests":
   - changed-files:
       - any-glob-to-any-file:
           - "tests/**"
           - "**/test_*.py"
           - "**/*_test.py"
 
-"area: dependencies":
+"dependencies":
   - changed-files:
       - any-glob-to-any-file:
           - "requirements*.txt"
@@ -35,14 +35,14 @@
           - "setup.cfg"
           - "uv.lock"
 
-"area: performance":
+"performance":
   - changed-files:
       - any-glob-to-any-file:
           - "benchmarks/**"
           - "benchmark/**"
           - "**/benchmark*.py"
 
-"area: examples":
+"examples":
   - changed-files:
       - any-glob-to-any-file:
           - "examples/**"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,7 +1,3 @@
-# Keep broad refactors from accumulating noisy component labels.
-changed-files-labels-limit: 4
-max-files-changed: 150
-
 "area: kunlun-xpu":
   - changed-files:
       - any-glob-to-any-file:

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -19,17 +19,17 @@ concurrency:
 
 jobs:
   label-by-files:
-    name: Label pull request by changed files
+    name: Synchronize pull request path labels
     needs: label-by-content
-    # Avoid applying a broad set of area labels to repository-wide refactors.
-    if: github.event_name == 'pull_request_target' && github.event.pull_request.changed_files <= 150
+    if: github.event_name == 'pull_request_target'
     runs-on: ubuntu-latest
     steps:
-      - name: Apply area labels
+      - name: Synchronize path labels
         uses: actions/labeler@b8dd2d9be0f68b860e7dae5dae7d772984eacd6d # v6
         with:
           configuration-path: .github/labeler.yml
-          sync-labels: false
+          # The labels in labeler.yml are workflow-managed component labels.
+          sync-labels: true
 
   label-by-content:
     name: Label issue or pull request by content
@@ -118,19 +118,21 @@ jobs:
 
             const rules = [
               { label: 'bug', patterns: [/\bbug\b/, /error/, /exception/, /crash/, /fail/, /regression/] },
-              { label: 'documentation', patterns: [/\bdocs?\b/, /documentation/, /readme/, /tutorial/] },
+              { label: 'documentation', issueOnly: true, patterns: [/\bdocs?\b/, /documentation/, /readme/, /tutorial/] },
               { label: 'feature request', patterns: [/feature request/, /propose a new feature/, /new feature/] },
               { label: 'enhancement', patterns: [/\benhancement\b/, /\bimprov(e|ement)\b/, /\boptimi[sz](e|ation)\b/, /改进/, /优化/, /support .*model/, /add .*support/] },
               { label: 'question', patterns: [/\bquestion\b/, /how do i/, /how can i/, /请问/, /咨询/] },
-              { label: 'performance', patterns: [/performance/, /benchmark/, /latency/, /throughput/, /speedup/, /性能/, /延迟/] },
-              { label: 'dependencies', patterns: [/dependenc/, /requirements/, /install/, /package/, /版本/] },
-              { label: 'ci', patterns: [/\bci\b/, /continuous integration/, /github actions/, /workflow/, /测试流水线/] },
-              { label: 'tests', patterns: [/\btest\b/, /pytest/, /unit test/, /integration test/, /e2e/, /测试/] },
-              { label: 'kunlun-xpu', patterns: [/kunlun/, /xpu/, /p800/, /mlu/, /昆仑/] }
+              { label: 'performance', issueOnly: true, patterns: [/performance/, /benchmark/, /latency/, /throughput/, /speedup/, /性能/, /延迟/] },
+              { label: 'dependencies', issueOnly: true, patterns: [/dependenc/, /requirements/, /install/, /package/, /版本/] },
+              { label: 'ci', issueOnly: true, patterns: [/\bci\b/, /continuous integration/, /github actions/, /workflow/, /测试流水线/] },
+              { label: 'tests', issueOnly: true, patterns: [/\btest\b/, /pytest/, /unit test/, /integration test/, /e2e/, /测试/] },
+              { label: 'kunlun-xpu', issueOnly: true, patterns: [/kunlun/, /xpu/, /p800/, /mlu/, /昆仑/] }
             ];
 
             for (const rule of rules) {
-              if (!labels.has(rule.label) && rule.patterns.some(pattern => pattern.test(`${title}\n${body}`))) {
+              if ((event === 'issues' || !rule.issueOnly) &&
+                  !labels.has(rule.label) &&
+                  rule.patterns.some(pattern => pattern.test(`${title}\n${body}`))) {
                 add.push(rule.label);
               }
             }

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -67,14 +67,13 @@ jobs:
               { name: 'question', color: 'd876e3', description: 'Further information is requested' },
               { name: 'feature request', color: '0e8a16', description: 'New feature proposal submitted through the issue form' },
               { name: 'needs review', color: 'fbca04', description: 'Issue or pull request is ready for maintainer review' },
-              // Area labels use a distinct, high-contrast palette to make review queues easy to scan.
-              { name: 'area: kunlun-xpu', color: '6f42c1', description: 'Kunlun XPU runtime, build, or integration code' },
-              { name: 'area: ci', color: '0969da', description: 'Continuous integration and repository automation' },
-              { name: 'area: documentation', color: '1a7f37', description: 'Documentation, tutorials, or README changes' },
-              { name: 'area: tests', color: 'bf8700', description: 'Unit, integration, or end-to-end tests' },
-              { name: 'area: dependencies', color: '8250df', description: 'Packaging, dependencies, or installation changes' },
-              { name: 'area: performance', color: 'cf222e', description: 'Performance, benchmark, latency, or throughput changes' },
-              { name: 'area: examples', color: '8c959f', description: 'Examples, demos, or community utilities' }
+              // Flat component labels mirror the project's concise label taxonomy.
+              { name: 'kunlun-xpu', color: '6f42c1', description: 'Kunlun XPU runtime, build, or integration code' },
+              { name: 'ci', color: '0969da', description: 'Continuous integration and repository automation' },
+              { name: 'tests', color: 'bf8700', description: 'Unit, integration, or end-to-end tests' },
+              { name: 'dependencies', color: '8250df', description: 'Packaging, dependencies, or installation changes' },
+              { name: 'performance', color: 'cf222e', description: 'Performance, benchmark, latency, or throughput changes' },
+              { name: 'examples', color: '8c959f', description: 'Examples, demos, or community utilities' }
             ];
 
             // Read the repository labels once per event rather than issuing one
@@ -123,11 +122,11 @@ jobs:
               { label: 'feature request', patterns: [/feature request/, /propose a new feature/, /new feature/] },
               { label: 'enhancement', patterns: [/\benhancement\b/, /\bimprov(e|ement)\b/, /\boptimi[sz](e|ation)\b/, /改进/, /优化/, /support .*model/, /add .*support/] },
               { label: 'question', patterns: [/\bquestion\b/, /how do i/, /how can i/, /请问/, /咨询/] },
-              { label: 'area: performance', patterns: [/performance/, /benchmark/, /latency/, /throughput/, /speedup/, /性能/, /延迟/] },
-              { label: 'area: dependencies', patterns: [/dependenc/, /requirements/, /install/, /package/, /版本/] },
-              { label: 'area: ci', patterns: [/\bci\b/, /continuous integration/, /github actions/, /workflow/, /测试流水线/] },
-              { label: 'area: tests', patterns: [/\btest\b/, /pytest/, /unit test/, /integration test/, /e2e/, /测试/] },
-              { label: 'area: kunlun-xpu', patterns: [/kunlun/, /xpu/, /p800/, /mlu/, /昆仑/] }
+              { label: 'performance', patterns: [/performance/, /benchmark/, /latency/, /throughput/, /speedup/, /性能/, /延迟/] },
+              { label: 'dependencies', patterns: [/dependenc/, /requirements/, /install/, /package/, /版本/] },
+              { label: 'ci', patterns: [/\bci\b/, /continuous integration/, /github actions/, /workflow/, /测试流水线/] },
+              { label: 'tests', patterns: [/\btest\b/, /pytest/, /unit test/, /integration test/, /e2e/, /测试/] },
+              { label: 'kunlun-xpu', patterns: [/kunlun/, /xpu/, /p800/, /mlu/, /昆仑/] }
             ];
 
             for (const rule of rules) {

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -76,15 +76,21 @@ jobs:
               { name: 'area: examples', color: '8c959f', description: 'Examples, demos, or community utilities' }
             ];
 
+            // Read the repository labels once per event rather than issuing one
+            // API request per definition. Only missing or drifted labels require
+            // a mutation, which avoids secondary-rate-limit pressure on edits and
+            // synchronize events.
+            const existingLabels = await github.paginate(
+              github.rest.issues.listLabelsForRepo,
+              { owner: context.repo.owner, repo: context.repo.repo, per_page: 100 }
+            );
+            const labelsByName = new Map(existingLabels.map(label => [label.name, label]));
+
             for (const definition of labelDefinitions) {
-              try {
-                const existing = await github.rest.issues.getLabel({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  name: definition.name
-                });
-                if (existing.data.color !== definition.color ||
-                    (existing.data.description || '') !== definition.description) {
+              const existing = labelsByName.get(definition.name);
+              if (existing) {
+                if (existing.color !== definition.color ||
+                    (existing.description || '') !== definition.description) {
                   await github.rest.issues.updateLabel({
                     owner: context.repo.owner,
                     repo: context.repo.repo,
@@ -93,20 +99,20 @@ jobs:
                     description: definition.description
                   });
                 }
+                continue;
+              }
+
+              try {
+                await github.rest.issues.createLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name: definition.name,
+                  color: definition.color,
+                  description: definition.description
+                });
               } catch (error) {
-                if (error.status !== 404) throw error;
-                try {
-                  await github.rest.issues.createLabel({
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    name: definition.name,
-                    color: definition.color,
-                    description: definition.description
-                  });
-                } catch (createError) {
-                  // Another workflow run may have created the label first.
-                  if (createError.status !== 422) throw createError;
-                }
+                // Another run may create the same label after the list request.
+                if (error.status !== 422) throw error;
               }
             }
 

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -53,7 +53,7 @@ jobs:
             const body = (event === 'pull_request_target'
               ? rawBody
                   .replace(/<!--[\s\S]*?-->/g, '')
-                  .split(/\n---\s*\n/, 1)[0]
+                  .split(/(?:^|\r?\n)---[ \t]*(?:\r?\n|$)/, 1)[0]
               : rawBody
             ).toLowerCase();
             const labels = new Set((item.labels || []).map(label => label.name));

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -21,7 +21,8 @@ jobs:
   label-by-files:
     name: Label pull request by changed files
     needs: label-by-content
-    if: github.event_name == 'pull_request_target'
+    # Avoid applying a broad set of area labels to repository-wide refactors.
+    if: github.event_name == 'pull_request_target' && github.event.pull_request.changed_files <= 150
     runs-on: ubuntu-latest
     steps:
       - name: Apply area labels

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -1,0 +1,132 @@
+name: Auto label issues and pull requests
+
+on:
+  issues:
+    types: [opened, edited, reopened]
+  pull_request_target:
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+# Match vLLM's per-item concurrency pattern so edits and pushes cannot race
+# while updating a single Issue or pull request's labels.
+concurrency:
+  group: auto-label-${{ github.event.issue.number || github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  label-by-files:
+    name: Label pull request by changed files
+    needs: label-by-content
+    if: github.event_name == 'pull_request_target'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Apply area labels
+        uses: actions/labeler@b8dd2d9be0f68b860e7dae5dae7d772984eacd6d # v6
+        with:
+          configuration-path: .github/labeler.yml
+          sync-labels: false
+
+  label-by-content:
+    name: Label issue or pull request by content
+    runs-on: ubuntu-latest
+    steps:
+      - name: Apply semantic labels
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        with:
+          script: |
+            const event = context.eventName;
+            const payload = context.payload;
+            const item = payload.issue ?? payload.pull_request;
+            if (!item) return;
+
+            const title = (item.title || '').toLowerCase();
+            const body = (item.body || '').toLowerCase();
+            const labels = new Set((item.labels || []).map(label => label.name));
+            const add = [];
+
+            const labelDefinitions = [
+              { name: 'bug', color: 'd73a4a', description: 'Something is not working' },
+              { name: 'documentation', color: '0075ca', description: 'Improvements or additions to documentation' },
+              { name: 'enhancement', color: 'a2eeef', description: 'New feature or request' },
+              { name: 'question', color: 'd876e3', description: 'Further information is requested' },
+              { name: 'feature request', color: '0e8a16', description: 'New feature proposal submitted through the issue form' },
+              { name: 'needs review', color: 'fbca04', description: 'Issue or pull request is ready for maintainer review' },
+              // Area labels use a distinct, high-contrast palette to make review queues easy to scan.
+              { name: 'area: kunlun-xpu', color: '6f42c1', description: 'Kunlun XPU runtime, build, or integration code' },
+              { name: 'area: ci', color: '0969da', description: 'Continuous integration and repository automation' },
+              { name: 'area: documentation', color: '1a7f37', description: 'Documentation, tutorials, or README changes' },
+              { name: 'area: tests', color: 'bf8700', description: 'Unit, integration, or end-to-end tests' },
+              { name: 'area: dependencies', color: '8250df', description: 'Packaging, dependencies, or installation changes' },
+              { name: 'area: performance', color: 'cf222e', description: 'Performance, benchmark, latency, or throughput changes' },
+              { name: 'area: examples', color: '8c959f', description: 'Examples, demos, or community utilities' }
+            ];
+
+            for (const definition of labelDefinitions) {
+              try {
+                const existing = await github.rest.issues.getLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name: definition.name
+                });
+                if (existing.data.color !== definition.color ||
+                    (existing.data.description || '') !== definition.description) {
+                  await github.rest.issues.updateLabel({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    name: definition.name,
+                    color: definition.color,
+                    description: definition.description
+                  });
+                }
+              } catch (error) {
+                if (error.status !== 404) throw error;
+                try {
+                  await github.rest.issues.createLabel({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    name: definition.name,
+                    color: definition.color,
+                    description: definition.description
+                  });
+                } catch (createError) {
+                  // Another workflow run may have created the label first.
+                  if (createError.status !== 422) throw createError;
+                }
+              }
+            }
+
+            const rules = [
+              { label: 'bug', patterns: [/\bbug\b/, /error/, /exception/, /crash/, /fail/, /regression/] },
+              { label: 'documentation', patterns: [/\bdocs?\b/, /documentation/, /readme/, /tutorial/] },
+              { label: 'feature request', patterns: [/feature request/, /propose a new feature/, /new feature/] },
+              { label: 'enhancement', patterns: [/\benhancement\b/, /\bimprov(e|ement)\b/, /\boptimi[sz](e|ation)\b/, /改进/, /优化/, /support .*model/, /add .*support/] },
+              { label: 'question', patterns: [/\bquestion\b/, /how do i/, /how can i/, /请问/, /咨询/] },
+              { label: 'area: performance', patterns: [/performance/, /benchmark/, /latency/, /throughput/, /speedup/, /性能/, /延迟/] },
+              { label: 'area: dependencies', patterns: [/dependenc/, /requirements/, /install/, /package/, /版本/] },
+              { label: 'area: ci', patterns: [/\bci\b/, /continuous integration/, /github actions/, /workflow/, /测试流水线/] },
+              { label: 'area: tests', patterns: [/\btest\b/, /pytest/, /unit test/, /integration test/, /e2e/, /测试/] },
+              { label: 'area: kunlun-xpu', patterns: [/kunlun/, /xpu/, /p800/, /mlu/, /昆仑/] }
+            ];
+
+            for (const rule of rules) {
+              if (!labels.has(rule.label) && rule.patterns.some(pattern => pattern.test(`${title}\n${body}`))) {
+                add.push(rule.label);
+              }
+            }
+
+            if (event === 'pull_request_target' && !labels.has('needs review')) {
+              add.push('needs review');
+            }
+
+            if (add.length > 0) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: item.number,
+                labels: add
+              });
+            }

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -4,7 +4,7 @@ on:
   issues:
     types: [opened, edited, reopened]
   pull_request_target:
-    types: [opened, edited, reopened, synchronize]
+    types: [opened, edited, reopened, synchronize, ready_for_review, converted_to_draft]
 
 permissions:
   contents: read
@@ -44,9 +44,20 @@ jobs:
             if (!item) return;
 
             const title = (item.title || '').toLowerCase();
-            const body = (item.body || '').toLowerCase();
+            const rawBody = item.body || '';
+            // Pull-request templates contain classifier keywords such as "bug",
+            // "feature", "CI", and "tests". Only the contributor-authored
+            // description above the first template separator is eligible for
+            // content labeling; Issue bodies are analyzed in full.
+            const body = (event === 'pull_request_target'
+              ? rawBody
+                  .replace(/<!--[\s\S]*?-->/g, '')
+                  .split(/\n---\s*\n/, 1)[0]
+              : rawBody
+            ).toLowerCase();
             const labels = new Set((item.labels || []).map(label => label.name));
             const add = [];
+            const remove = [];
 
             const labelDefinitions = [
               { name: 'bug', color: 'd73a4a', description: 'Something is not working' },
@@ -118,8 +129,24 @@ jobs:
               }
             }
 
-            if (event === 'pull_request_target' && !labels.has('needs review')) {
-              add.push('needs review');
+            if (event === 'pull_request_target') {
+              if (!item.draft && !labels.has('needs review')) {
+                add.push('needs review');
+              }
+              if (item.draft && labels.has('needs review')) {
+                remove.push('needs review');
+              }
+            }
+
+            if (remove.length > 0) {
+              for (const label of remove) {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: item.number,
+                  name: label
+                });
+              }
             }
 
             if (add.length > 0) {

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -72,7 +72,6 @@ repos:
     rev: v1.7.7
     hooks:
     - id: actionlint
-      exclude: ^\.github/workflows/.*\.yml$
 
   - repo: local
     hooks:


### PR DESCRIPTION
## Summary

Backport the automated Issue and pull request labeling capability from #455 to `v0.25.1-dev`.

- Labels Issues on `opened`, `edited`, and `reopened`.
- Labels pull requests on `opened`, `edited`, `reopened`, `synchronize`, `ready_for_review`, and `converted_to_draft`.
- Applies semantic labels and path-based component labels without checking out or executing pull-request code.

## Label design

The workflow uses a concise, flat taxonomy. Semantic labels are `bug`, `documentation`, `enhancement`, `question`, and `feature request`. Workflow-managed component labels are `kunlun-xpu`, `ci`, `tests`, `dependencies`, `performance`, and `examples`; they use a high-contrast palette for clear review-queue scanning.

Path labels are synchronized on every PR update, so a component label is removed when its matching files are no longer present. Content-derived labels are kept separate from path labels on PRs, avoiding synchronization conflicts.

## Correctness safeguards

- PR template comments and all content after a standalone `---` separator are excluded from PR content classification. The separator parser supports beginning-of-body placement, LF, and CRLF line endings.
- `needs review` is applied only to non-draft PRs and removed when a PR is converted to draft.
- All required labels are provisioned idempotently before use with one repository-label listing request per event.

## Validation

- Local simulations covered Issue and `pull_request_target` payloads, flat labels, synchronized path labels, template-only PRs, draft-state transitions, and LF/CRLF separators.
- `pre-commit run --files .github/labeler.yml .github/workflows/auto-label.yml` passed, including `actionlint`.
- `git diff --check` passed.
- Commits were created with `git commit -s`.

> Because `pull_request_target` loads workflow code from the target branch, this first backport PR cannot self-test the newly added workflow. It will begin processing subsequent Issue and pull-request events after merge.