### PR TITLE
[Doc] Clarify Kunlun XPU environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,18 +165,41 @@ curl http://localhost:8356/v1/chat/completions \
 
 ### Environment Variables
 
+The following values are a starting point for the Mamba-hybrid example below.
+Adjust device visibility and model-specific kernel options for your deployment.
+
 ```bash
-export XPU_VISIBLE_DEVICES=0,1          # physical XPU cards to use
-export CUDA_VISIBLE_DEVICES=0,1         # logical CUDA device mapping
+# Select the physical XPU devices visible to this process.
+export XPU_VISIBLE_DEVICES=0,1
+
+# Keep the CUDA-compatible device view aligned with the selected XPUs.
+export CUDA_VISIBLE_DEVICES=0,1
+
+# Enable the fast SwiGLU implementation in XFT operators.
 export XFT_USE_FAST_SWIGLU=1
+
+# Enable the XMLIR runtime's cuDNN-compatible path.
 export XMLIR_CUDNN_ENABLED=1
+
+# Enable the XMLIR fast fully connected implementation.
 export XMLIR_ENABLE_FAST_FC=true
+
+# Select the SDNN BF16 rounding mode used by XPU kernels.
 export XPUAPI_SDNN_BF16_ROUND_MODE=3
-export XPU_USE_MOE_SORTED_THRES=1
+
+# Use the XPU runtime's default device context.
 export XPU_USE_DEFAULT_CTX=1
+
+# Route CUDA Graph-compatible APIs to XPU Graph capture and replay.
 export XMLIR_FORCE_USE_XPU_GRAPH=1
+
+# Enable the fast SwiGLU implementation in Kunlun MoE operators.
 export XPU_USE_FAST_SWIGLU=1
+
+# Select the newer XPU flash-attention decoder implementation.
 export XPU_FLASH_ATTENTION_DECODER_USE_NEW_IMPL=1
+
+# Select the fast FP16 forward implementation for recurrent gated delta rule.
 export XPU_SET_RECURRENT_GATED_DELTA_RULE_FWDV2_FP16_FAST_OPT=3
 ```
 

--- a/docs/source/developer_guide/performance/performance_benchmark/profiling.md
+++ b/docs/source/developer_guide/performance/performance_benchmark/profiling.md
@@ -74,7 +74,6 @@ class Qwen2Model(nn.Module):
 ```bash
 unset XPU_DUMMY_EVENT
 export XPU_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
-export XPU_USE_MOE_SORTED_THRES=1
 export XFT_USE_FAST_SWIGLU=1
 export XMLIR_CUDNN_ENABLED=1
 export XPU_USE_DEFAULT_CTX=1

--- a/docs/source/tutorials/multi_xpu_DeepSeek-V3.2-Exp-w8a8.md
+++ b/docs/source/tutorials/multi_xpu_DeepSeek-V3.2-Exp-w8a8.md
@@ -110,7 +110,6 @@ export XMLIR_ENABLE_FAST_FC=1 && \
 export XPU_USE_FAST_SWIGLU=1 && \
 export CUDA_GRAPH_OPTIMIZE_STREAM=1 && \
 export XMLIR_ENABLE_MOCK_TORCH_COMPILE=false && \
-export XPU_USE_MOE_SORTED_THRES=1 && \
 export USE_ORI_ROPE=1 && \
 export VLLM_USE_V1=1
 

--- a/docs/source/tutorials/multi_xpu_GLM-5-W8A8-INT8.md
+++ b/docs/source/tutorials/multi_xpu_GLM-5-W8A8-INT8.md
@@ -56,7 +56,6 @@ export XMLIR_ENABLE_FAST_FC=1 && \
 export XPU_USE_FAST_SWIGLU=1 && \
 export CUDA_GRAPH_OPTIMIZE_STREAM=1 && \
 export XMLIR_ENABLE_MOCK_TORCH_COMPILE=false && \
-export XPU_USE_MOE_SORTED_THRES=1 && \
 export USE_ORI_ROPE=1 && \
 export VLLM_USE_V1=1
 

--- a/docs/source/user_guide/configuration/env_vars.md
+++ b/docs/source/user_guide/configuration/env_vars.md
@@ -1,17 +1,20 @@
 # Environment Variables
 
-vllm-kunlun uses the following environment variables to configure the system:
+The following table documents commonly used environment variables. Some are
+consumed by the XMLIR or XPU runtime rather than by vLLM-Kunlun itself, so
+availability and exact behavior can depend on the installed runtime version.
 
-| *Environment Variables*                     | ***\*Recommended value\****  | ***\*Function description\****                                           |
-| ---------------------------------------- | ----------------- | ------------------------------------------------------------ |
-| `unset XPU_DUMMY_EVENT`                  |                   | ***\*Unsets\**** `XPU_DUMMY_EVENT` variable, usually done to ensure real XPU events are used for synchronization and performance measurement. |
-| `export XPU_VISIBLE_DEVICES`             | `0,1,2,3,4,5,6,7` | ***\*Specify visible XPU Devices\****. Here, 8 devices (0 to 7) are specified for inference tasks. This is required for multi-card or distributed inference. |
-| `export XPU_USE_MOE_SORTED_THRES`        | `1`               | Enables the Moe Model ***\*Sort Optimization\****.Setting to `1` usually enables this performance optimization. |
-| `export XFT_USE_FAST_SWIGLU`             | `1`               | Enables the ***\*Fast SwiGLU Ops\****. SwiGLU is a common activation function, and enabling this accelerates model inference. |
-| `export XPU_USE_FAST_SWIGLU`             | `1`               | Enables the ***\*Fast SwiGLU Ops\****. Similar to `XFT_USE_FAST_SWIGLU`, this enables the fast SwiGLU calculation in Fused MoE Fusion Ops. |
-| `export XMLIR_CUDNN_ENABLED`             | `1`               | Enables XMLIR (an intermediate representation/compiler) to use the ***\*cuDNN compatible/optimized path\**** (which may map to corresponding XPU optimized libraries in the KunlunCore environment). |
-| `export XPU_USE_DEFAULT_CTX`             | `1`               | Sets the XPU to use the default context. Typically used to simplify environment configuration and ensure runtime consistency. |
-| `export XMLIR_FORCE_USE_XPU_GRAPH`       | `1`               | ***\*Forces the enablement of XPU Graph mode.\****. This can capture and optimize the model execution graph, significantly boosting inference performance. |
-| `export VLLM_HOST_IP`                    | `$(hostname -i)`  | ***\*Sets the host IP address for the vLLM service\****. This uses a shell command to dynamically get the current host's internal IP. It's used for inter-node communication in a distributed environment. |
-| `export XMLIR_ENABLE_MOCK_TORCH_COMPILE` | `false`           | ***\*Disable Mock Torch Compile Function\****. Set to `false` to ensure the actual compilation and optimization flow is used, rather than mock mode. |
-| `FUSED_QK_ROPE_OP`                           | `0`               | ***\*Control whether to use the Fused QK-Norm and RoPE implementation\****. Default is `0` (use original/standard RoPE). Setting to `1` may be used to enable QWEN3. |
+| Environment variable | Recommended value | Description |
+| --- | --- | --- |
+| `XPU_DUMMY_EVENT` | unset | Uses real XPU events instead of dummy events for synchronization. |
+| `XPU_VISIBLE_DEVICES` | `0,1,2,3,4,5,6,7` | Selects the physical XPU devices visible to the process. Adjust this list to the deployment. |
+| `XPU_USE_MOE_SORTED_THRES` | `512` (runtime default) | Legacy `moe_ffn_block` threshold on token rows (`M`): the sorted path is selected at or above this value. The current vLLM-Kunlun fused MoE path does not read this variable, so it should normally remain unset. |
+| `XFT_USE_FAST_SWIGLU` | `1` | Enables the fast SwiGLU implementation in XFT operators. |
+| `XPU_USE_FAST_SWIGLU` | `1` | Enables the fast SwiGLU implementation in Kunlun MoE operators. |
+| `XMLIR_CUDNN_ENABLED` | `1` | Enables the XMLIR runtime's cuDNN-compatible path. The exact implementation depends on the installed runtime. |
+| `XPU_USE_DEFAULT_CTX` | `1` | Uses the XPU runtime's default device context. |
+| `XMLIR_FORCE_USE_XPU_GRAPH` | `1` | Routes CUDA Graph-compatible APIs to XPU Graph capture and replay. |
+| `VLLM_HOST_IP` | `$(hostname -i)` | Advertises the host address to vLLM workers. On multi-NIC hosts, set one explicit address reachable by every worker. |
+| `XMLIR_ENABLE_MOCK_TORCH_COMPILE` | `false` | Disables the default eager-only `torch.compile` mock so calls use the real compilation path. |
+| `XMLIR_DYNAMO_WORKAROUND` | `1` | Registers `F.linear` as a custom operator to avoid Dynamo tracing issues on Kunlun XPU. |
+| `FUSED_QK_ROPE_OP` | `0` | Controls the fused QK-Norm and RoPE implementation. Keep `0` unless a model-specific setup requires it. |

--- a/openwiki/.claims/build-and-install.json
+++ b/openwiki/.claims/build-and-install.json
@@ -74,12 +74,12 @@
     },
     {
       "id": "build-008",
-      "statement": "setup_env.sh 存在两个已知问题：XPU_USE_MOE_SORTED_THRES 设为 128 与文档推荐值 1 矛盾；VLLM_USE_V1 / USE_ORI_ROPE 被赋值但没有 export，子进程看不到。",
-      "kind": "defect",
+      "statement": "setup_env.sh 不再设置 XPU_USE_MOE_SORTED_THRES；该变量只影响当前主 MoE 路径未调用的 legacy moe_ffn_block。",
+      "kind": "fact",
       "evidence": [
-        "repo://setup_env.sh#L8",
-        "repo://setup_env.sh#L11-L13",
-        "repo://docs/source/user_guide/configuration/env_vars.md#L7-L17"
+        "repo://setup_env.sh",
+        "repo://docs/source/user_guide/configuration/env_vars.md",
+        "repo://vllm_kunlun/ops/_custom_ops.py#L819-L897"
       ],
       "confidence": "high"
     },

--- a/openwiki/.claims/known-gaps.json
+++ b/openwiki/.claims/known-gaps.json
@@ -89,14 +89,12 @@
     },
     {
       "id": "gap-009",
-      "statement": "代码与文档存在九处冲突，包括构建后端（hatchling vs setuptools）、CI 里 pin vllm==0.11.0 与插件 0.25.1、Dockerfile transformers 4.57.1 vs requirements 5.2.0、XPU_USE_MOE_SORTED_THRES 128 vs 1、默认分支 v0.25.1-dev 但各处仍写 main、GLM-4.5 tutorial 标题写 Single XPU 而命令是 TP=8、支持模型数 5 vs 20+、专家并行标绿但零示例命令。",
+      "statement": "代码与文档存在七处冲突，包括构建后端（hatchling vs setuptools）、CI 里 pin vllm==0.11.0 与插件 0.25.1、Dockerfile transformers 4.57.1 vs requirements 5.2.0、默认分支 v0.25.1-dev 但各处仍写 main、GLM-4.5 tutorial 标题写 Single XPU 而命令是 TP=8、支持模型数 5 vs 20+、专家并行标绿但零示例命令。",
       "kind": "caveat",
       "evidence": [
         "repo://README.md",
         "repo://pyproject.toml#L6",
         "repo://requirements.txt",
-        "repo://setup_env.sh#L8",
-        "repo://setup_env.sh#L11-L13",
         "repo://docs/source/tutorials/multi_xpu_GLM-4.5.md",
         "repo://docs/source/user_guide/support_matrix/supported_models.md",
         "repo://docs/source/user_guide/support_matrix/supported_features.md#L8-L14"

--- a/openwiki/.claims/moe-and-ep.json
+++ b/openwiki/.claims/moe-and-ep.json
@@ -90,12 +90,12 @@
     },
     {
       "id": "moe-010",
-      "statement": "ENABLE_VLLM_MOE_FC_SORTED 在 platforms/envs.py 有声明但没有消费者；XPU_USE_MOE_SORTED_THRES 由 torch_xmlir 读取且脚本值（setup_env.sh 设 128）与文档推荐值（1）不一致。",
+      "statement": "ENABLE_VLLM_MOE_FC_SORTED 在 platforms/envs.py 有声明但没有消费者；XPU_USE_MOE_SORTED_THRES 只控制 legacy moe_ffn_block，当前 vLLM-Kunlun fused MoE 路径不读取它。",
       "kind": "caveat",
       "evidence": [
         "repo://vllm_kunlun/platforms/envs.py#L53",
-        "repo://setup_env.sh#L8",
-        "repo://docs/source/user_guide/configuration/env_vars.md#L7-L17"
+        "repo://vllm_kunlun/ops/_custom_ops.py#L819-L897",
+        "repo://docs/source/user_guide/configuration/env_vars.md"
       ],
       "confidence": "high"
     }

--- a/openwiki/architecture.md
+++ b/openwiki/architecture.md
@@ -259,11 +259,14 @@ fake impl `#L255-L257`，调用点 `#L110-L112`）、
 （`mla/common.py#L1152`、`#L1459`、`#L1969`）。9 个里有 6 个没有任何消费者；
 另外 2 个（日志/hook）的消费者在 `vllm_kunlun/utils.py`，而**没有任何模块 import 它**。
 
-**文档里的集合**：`docs/source/user_guide/configuration/env_vars.md#L7-L17`
-记录了 11 个**完全不同**的 XPU/XMLIR 变量：`XPU_VISIBLE_DEVICES`、
-`XPU_USE_MOE_SORTED_THRES`、`XFT_USE_FAST_SWIGLU`、`XPU_USE_FAST_SWIGLU`、
+**文档里的集合**：`docs/source/user_guide/configuration/env_vars.md`
+记录了 12 个**完全不同**的 XPU/XMLIR 变量：`XPU_VISIBLE_DEVICES`、
+`XPU_USE_MOE_SORTED_THRES`（仅 legacy `moe_ffn_block` 使用）、
+`XFT_USE_FAST_SWIGLU`、`XPU_USE_FAST_SWIGLU`、
 `XMLIR_CUDNN_ENABLED`、`XPU_USE_DEFAULT_CTX`、`XMLIR_FORCE_USE_XPU_GRAPH`、
-`VLLM_HOST_IP`、`XMLIR_ENABLE_MOCK_TORCH_COMPILE`、`FUSED_QK_ROPE_OP`、
+`VLLM_HOST_IP`、`XMLIR_ENABLE_MOCK_TORCH_COMPILE`、
+`XMLIR_DYNAMO_WORKAROUND`（由 torch_xmlir 的 `nn/linear.py` 读取，
+将 `F.linear` 注册为自定义算子以规避 Dynamo tracing 问题）、`FUSED_QK_ROPE_OP`、
 以及 `unset XPU_DUMMY_EVENT`。这些是 `torch_xmlir` 运行时读的，不经过本仓库。
 
 `docs/envs.py` 是从 vllm-ascend 抄来的死代码（`#L5` 自己写着

--- a/openwiki/build-and-install.md
+++ b/openwiki/build-and-install.md
@@ -17,7 +17,7 @@ sources:
 - repo://pyproject.toml#L6-L27
 - repo://setup.py#L25-L81
 - repo://build.sh#L22-L23
-- repo://setup_env.sh#L8-L13
+- repo://setup_env.sh
 - repo://docs/source/installation.md#L100-L106
 claims: .claims/build-and-install.json
 ---
@@ -102,14 +102,10 @@ graph TD
 （这些变量**不经过** `platforms/envs.py`，见
 [architecture.md](architecture.md#7-环境变量两套互不相交的集合)）。
 
-两个已知问题：
-
-- `#L8` 设 `XPU_USE_MOE_SORTED_THRES=128`，而文档推荐 `1`。**两者矛盾。**
-- `#L11-L13` 给 `VLLM_USE_V1` / `USE_ORI_ROPE` 赋值但**没有 `export`**，
-  所以子进程看不到。如果依赖这两个变量，需要自己 export。
-
 `torch_xmlir` 会读的变量清单在
-`docs/source/user_guide/configuration/env_vars.md#L7-L17`（11 个）。
+`docs/source/user_guide/configuration/env_vars.md`。其中
+`XPU_USE_MOE_SORTED_THRES` 只影响未被当前主 MoE 路径调用的 legacy 算子，
+所以启动脚本不设置它。
 
 ## 6. 分支与版本号
 

--- a/openwiki/known-gaps.md
+++ b/openwiki/known-gaps.md
@@ -3,7 +3,7 @@ type: reference
 title: 已知缺口、死代码与文档冲突
 summary: >-
   PD 分离不支持的穷尽证据、名字与行为不符的函数、无消费者的环境变量与死代码、
-  以及代码与文档之间的九处冲突。
+  以及代码与文档之间的七处冲突。
 generated:
   by: hand-authored (Claude Code, OpenWiki OKF v0.2 conventions)
   at: 2026-09-02T00:00:00Z
@@ -19,7 +19,6 @@ sources:
 - repo://vllm_kunlun/quantization/moe_wna16.py#L27-L107
 - repo://vllm_kunlun/models/config.py
 - repo://vllm_kunlun/platforms/envs.py#L34-L71
-- repo://setup_env.sh#L8-L13
 - repo://pyproject.toml#L6-L19
 claims: .claims/known-gaps.json
 ---
@@ -112,19 +111,17 @@ buffer 仍在分配（`#L81-L96`）。
 
 详见 [architecture.md](architecture.md#7-环境变量两套互不相交的集合)。
 
-## 5. 代码与文档的九处冲突
+## 5. 代码与文档的七处冲突
 
 | # | 冲突 | 以哪个为准 |
 | --- | --- | --- |
 | 1 | README 说构建后端是 hatchling；`pyproject.toml#L6` 是 setuptools | 代码 |
 | 2 | CI 里 pin `vllm==0.11.0`，插件版本是 0.25.1 | `faqs.md#L43` 的规则：版本必须相同 → 0.25.1 |
 | 3 | Dockerfile `transformers==4.57.1` vs `requirements.txt` `5.2.0` | requirements |
-| 4 | `setup_env.sh#L8` 设 `XPU_USE_MOE_SORTED_THRES=128`，文档推荐 `1` | 需实测确认 |
-| 5 | `setup_env.sh#L11-L13` 给 `VLLM_USE_V1` / `USE_ORI_ROPE` 赋值但**没 export** | 需自行 export |
-| 6 | 默认分支是 `v0.25.1-dev`，但 CONTRIBUTING / `conf.py` / workflows 都写 `main` | `v0.25.1-dev` |
-| 7 | `multi_xpu_GLM-4.5.md` 标题写 "Single XPU"，命令是 TP=8 | 命令 |
-| 8 | `supported_models.md` 列 5 个模型，README 宣称 20+ | `models/__init__.py` 的 12 个注册项 |
-| 9 | `supported_features.md#L8-L14` 声称专家并行 🟢，但 0 条示例命令，且 EP 是 Python 逐专家循环 | 代码（见 [moe-and-ep.md](moe-and-ep.md#5-ep-路径是-python-逐专家循环)） |
+| 4 | 默认分支是 `v0.25.1-dev`，但 CONTRIBUTING / `conf.py` / workflows 都写 `main` | `v0.25.1-dev` |
+| 5 | `multi_xpu_GLM-4.5.md` 标题写 "Single XPU"，命令是 TP=8 | 命令 |
+| 6 | `supported_models.md` 列 5 个模型，README 宣称 20+ | `models/__init__.py` 的 10 个注册项 |
+| 7 | `supported_features.md#L8-L14` 声称专家并行 🟢，但 0 条示例命令，且 EP 是 Python 逐专家循环 | 代码（见 [moe-and-ep.md](moe-and-ep.md#5-ep-路径是-python-逐专家循环)） |
 
 另外两处版本号自相矛盾：`platforms/version.py#L3` = `0.25.1` vs
 `pyproject.toml#L10` = `0.25.1.dev0`；以及 `main` 分支的 README 仍宣称

--- a/openwiki/moe-and-ep.md
+++ b/openwiki/moe-and-ep.md
@@ -16,7 +16,7 @@ sources:
 - repo://vllm_kunlun/ops/_kunlun_ops.py#L377-L680
 - repo://vllm_kunlun/quantization/compressed_tensors/compressed_tensors_moe.py#L149-L321
 - repo://vllm_kunlun/platforms/kunlun.py#L257-L274
-- repo://setup_env.sh#L8
+- repo://setup_env.sh
 claims: .claims/moe-and-ep.json
 ---
 
@@ -116,9 +116,9 @@ kernel launch 可以融成一次"，都会重新引入高并发下输出乱码�
 - `ENABLE_VLLM_MOE_FC_SORTED`（`platforms/envs.py#L53`，注释
   `fuse sorted op with fused_moe kernel`）——**没有消费者**，见
   [architecture.md](architecture.md#7-环境变量两套互不相交的集合)。
-- `XPU_USE_MOE_SORTED_THRES` —— 由 `torch_xmlir` 读取，不经过本仓库。
-  **文档与脚本给的值不一致**：`setup_env.sh#L8` 设成 `128`，
-  文档推荐 `1`。见 [known-gaps.md](known-gaps.md)。
+- `XPU_USE_MOE_SORTED_THRES` —— 厂商 legacy `moe_ffn_block` 根据 token
+  行数 `M` 选择 sorted 路径的阈值，默认 `512`。当前 vLLM-Kunlun 的
+  `fused_moe` 路径使用内部条件，不读取这个变量，因此启动脚本不再设置它。
 
 ## 相关页面
 

--- a/setup_env.sh
+++ b/setup_env.sh
@@ -1,11 +1,33 @@
+# Baseline environment for an eight-device Kunlun P800 node. Adjust device
+# visibility and host addressing for the deployment environment.
+
+# Use real XPU events instead of dummy events for synchronization.
 unset XPU_DUMMY_EVENT
+
+# Expose all eight XPU devices on a standard P800 node.
 export XPU_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
-export XFT_USE_FAST_SWIGLU=1 #使用快速swiglu实现
-export XPU_USE_FAST_SWIGLU=1 #使用moe算子中快速swiglu实现
+
+# Enable the fast SwiGLU implementation in XFT operators.
+export XFT_USE_FAST_SWIGLU=1
+
+# Enable the fast SwiGLU implementation in Kunlun MoE operators.
+export XPU_USE_FAST_SWIGLU=1
+
+# Enable the XMLIR runtime's cuDNN-compatible path (vendor-recommended value).
 export XMLIR_CUDNN_ENABLED=1
+
+# Use the XPU runtime's default device context.
 export XPU_USE_DEFAULT_CTX=1
-export XMLIR_FORCE_USE_XPU_GRAPH=1 # 优化图间sync
-export XPU_USE_MOE_SORTED_THRES=128 # Moe sort threshold
+
+# Route CUDA Graph-compatible APIs to XPU Graph capture and replay.
+export XMLIR_FORCE_USE_XPU_GRAPH=1
+
+# Advertise this host address to vLLM workers. On multi-NIC hosts, replace
+# hostname -i with one explicit address reachable by every worker.
 export VLLM_HOST_IP=$(hostname -i)
+
+# Use the real torch.compile path instead of the default eager-only mock.
 export XMLIR_ENABLE_MOCK_TORCH_COMPILE=false
-export XMLIR_DYNAMO_WORKAROUND=1 # Register F.linear as a custom operator on Kunlun XPU to work around Dynamo tracing issues
+
+# Register F.linear as a custom op to avoid Dynamo tracing issues on XPU.
+export XMLIR_DYNAMO_WORKAROUND=1


### PR DESCRIPTION
## PR Description

This PR clarifies the Kunlun P800 environment variable configuration and removes an ineffective legacy MoE override from startup examples.

### Environment variable documentation

- Add standalone descriptions for every variable in `setup_env.sh`.
- Clarify that the script provides a baseline configuration for an eight-device Kunlun P800 node.
- Document the roles of:
  - XPU device visibility;
  - fast SwiGLU implementations;
  - the XMLIR cuDNN-compatible path;
  - XPU default device context;
  - XPU Graph capture and replay;
  - real `torch.compile` behavior;
  - the Dynamo `F.linear` workaround.
- Warn that `hostname -i` may return multiple addresses on multi-NIC hosts and should be replaced with an explicit reachable address when necessary.
- Expand the README example with standalone comments and clarify that its values are intended for the Mamba-hybrid example.

### Remove the ineffective MoE threshold override

`XPU_USE_MOE_SORTED_THRES` is a numeric threshold rather than a Boolean switch.

The runtime implementation:

- Defaults to `512` when the variable is unset.
- Parses the configured value as a base-10 integer.
- Compares the threshold against `M`, the number of token rows.
- Does not depend on the expert count or `top_k`.

The variable is only consumed by the legacy `moe_ffn_block` operator. The current vLLM-Kunlun fused MoE path uses its own internal selection condition and does not read this environment variable.

Therefore, this PR:

- Removes `XPU_USE_MOE_SORTED_THRES=128` from `setup_env.sh`.
- Removes `XPU_USE_MOE_SORTED_THRES=1` from the README, tutorials, and profiling example.
- Documents the runtime default and limited scope of the variable.
- Updates related OpenWiki pages and structured claims.
- Removes the resolved `1` versus `128` documentation conflict.

Leaving the variable unset preserves the runtime default of `512` and does not change the active vLLM-Kunlun fused MoE path.

### Documentation cleanup

- Normalize the environment variable reference table.
- Distinguish variables consumed by vLLM-Kunlun from variables consumed by the XMLIR or XPU runtime.
- Remove stale `setup_env.sh` line references and obsolete claims.
- Correct the documented OOT model registration count.

## Testing

- `bash -n setup_env.sh`
- `git diff --check`
- Validated the modified OpenWiki claim files as JSON.
- Confirmed that no startup example still sets `XPU_USE_MOE_SORTED_THRES` to `1` or `128`.

---

## Checklist (Required)

- [ ] All code changes pass the [`pre-commit`](https://github.com/baidu/vLLM-Kunlun/blob/main/CONTRIBUTING.md) checks.
- [x] Commits are signed off using `git commit -s`.
- [x] The PR title is properly classified.
```