### PR TITLE
[Bugfix] Stop probing CUDA-only optional dependencies

### DIFF
--- a/tests/ut/test_compat_patches.py
+++ b/tests/ut/test_compat_patches.py
@@ -114,6 +114,37 @@ class TestTritonPatches:
         assert "Skipping qwen_triton_warmup" in caplog.text
 
 
+class TestOptionalDepProbePatch:
+    """CUDA-only libraries must be reported absent without a trial import."""
+
+    def test_cuda_only_modules_answer_false_without_importing(self, module_factory):
+        probed = []
+
+        def probe(module_name):
+            probed.append(module_name)
+            return True
+
+        module = module_factory(_has_module=probe)
+        assert compat_patches._optional_dep_probe_applied(module) is False
+
+        compat_patches._apply_optional_dep_probe(module)
+
+        assert compat_patches._optional_dep_probe_applied(module) is True
+        for name in compat_patches._CUDA_ONLY_MODULES:
+            assert module._has_module(name) is False
+        assert probed == []
+
+    def test_other_modules_still_reach_the_original_probe(self, module_factory):
+        module = module_factory(_has_module=lambda module_name: True)
+
+        compat_patches._apply_optional_dep_probe(module)
+
+        assert module._has_module("numba") is True
+
+    def test_old_vllm_without_the_probe_needs_nothing(self, module_factory):
+        assert compat_patches._optional_dep_probe_applied(module_factory()) is True
+
+
 class TestInt8MoePatch:
     def test_selector_is_replaced_and_reports_no_backend(self, module_factory):
         module = module_factory(select_int8_moe_backend=lambda config: ("cuda", "impl"))

--- a/vllm_kunlun/registration/compat_patches.py
+++ b/vllm_kunlun/registration/compat_patches.py
@@ -106,6 +106,61 @@ def _apply_mrv2_gate(module: ModuleType) -> None:
     )
 
 
+# --- vllm.utils.import_utils: do not probe CUDA-only optional deps ---------
+#
+# ``_has_module`` decides availability with a trial import and logs a WARNING
+# plus a full traceback when that import fails.  For a library shipped only as
+# CUDA binaries the failure is certain on Kunlun (DeepGEMM dies on
+# ``libcudart.so.13``), so the traceback is noise in every startup log.
+# Answering False without importing is the same verdict, quietly.
+#
+# It cannot be left to ``VLLM_USE_DEEP_GEMM``: upstream evaluates
+# ``envs.VLLM_USE_DEEP_GEMM and has_deep_gemm() and is_supported_arch``
+# (``utils/deep_gemm.py``), so the probe runs before the platform's own
+# ``support_deep_gemm()`` verdict is consulted -- turning the flag off would
+# work, but it means overriding a user-intent switch to state a hardware fact.
+#
+# Patching ``_has_module`` rather than ``has_deep_gemm`` is deliberate: many
+# modules do ``from vllm.utils.import_utils import has_deep_gemm``, so that
+# name is already bound by value in each of them, while ``has_deep_gemm``
+# itself resolves ``_has_module`` from module globals on every call.
+
+_CUDA_ONLY_MODULES = frozenset(
+    {
+        # DeepGEMM: JIT-compiled FP8 CUDA kernels for Hopper/Blackwell.  Kunlun
+        # has vllm_kunlun.ops.deep_gemm, which reuses only the interface.
+        "deep_gemm",
+        "vllm.third_party.deep_gemm",
+    }
+)
+
+
+def _optional_dep_probe_applied(module: ModuleType) -> bool:
+    """Return whether the probe is filtered, or the module predates it."""
+    if not hasattr(module, "_has_module"):
+        return True
+    return getattr(module, "_kunlun_dep_probe_installed", False)
+
+
+def _apply_optional_dep_probe(module: ModuleType) -> None:
+    """Answer False for CUDA-only modules instead of trial-importing them."""
+    original = module._has_module
+
+    @functools.wraps(original)
+    def _kunlun_has_module(module_name: str) -> bool:
+        if module_name in _CUDA_ONLY_MODULES:
+            return False
+        return original(module_name)
+
+    module._has_module = _kunlun_has_module
+    module._kunlun_dep_probe_installed = True
+    logging.getLogger("vllm_kunlun").info(
+        "[KunlunPlugin] Reporting CUDA-only optional dependencies as "
+        "unavailable without importing them: %s",
+        ", ".join(sorted(_CUDA_ONLY_MODULES)),
+    )
+
+
 # --- vllm.v1.worker.utils: replace KVBlockZeroer --------------------------
 
 
@@ -448,6 +503,11 @@ _V2_PATCHES: tuple[tuple[str, str, tuple[str, ...]], ...] = (
 # (target module, is_applied, apply_patch) triples registered by import_hooks.
 DEFAULT_HOOKS = (
     ("vllm.config.vllm", _mrv2_gate_applied, _apply_mrv2_gate),
+    (
+        "vllm.utils.import_utils",
+        _optional_dep_probe_applied,
+        _apply_optional_dep_probe,
+    ),
     ("vllm.v1.worker.utils", _kv_block_zeroer_applied, _apply_kv_block_zeroer),
     (
         "vllm.model_executor.models.qwen3_vl",


### PR DESCRIPTION
## What

Every Kunlun startup log carries this WARNING and a 15-line traceback:

```text
WARNING [import_utils.py:408] Module vllm.third_party.deep_gemm was found but failed to import
...
ImportError: libcudart.so.13: cannot open shared object file: No such file or directory
```

`import_utils._has_module` decides availability by actually importing the module and reports any failure as a warning with `exc_info`. DeepGEMM is a CUDA-only library (JIT-compiled FP8 kernels for Hopper/Blackwell), so the failure is certain on Kunlun and the traceback is pure noise.

## Why the fix goes where it does

The platform already reports the right thing — `support_deep_gemm()` is `False` — but upstream consults it too late:

```python
# vllm/utils/deep_gemm.py
is_supported_arch = current_platform.support_deep_gemm()
return envs.VLLM_USE_DEEP_GEMM and has_deep_gemm() and is_supported_arch
```

`has_deep_gemm()` runs before `is_supported_arch` is ever read, so the probe fires regardless of platform support.

Two things this PR deliberately does not do:

- Default `VLLM_USE_DEEP_GEMM=0`. It works (the flag short-circuits first), but it overrides a user-intent switch to express a hardware fact, and would silently disable DeepGEMM if Kunlun ever gains support. The flag stays user-controlled.
- Patch `has_deep_gemm`. `deep_gemm_moe.py`, `gpu_ubatch_wrapper.py`, `mla/indexer.py` and others do `from vllm.utils.import_utils import has_deep_gemm`, binding it by value, so patching the source module would miss them. `has_deep_gemm` resolves `_has_module` from its own module globals on every call, so hooking `_has_module` covers all callers at once.

## Test plan

`pytest tests/ut/ -q` → **129 passed** (3 new cases: denylisted modules never reach the probe, other modules still do, a vLLM without `_has_module` counts as already applied).

Verified on `gemma-4-E2B-it` on a P800:

|  | default | `VLLM_USE_DEEP_GEMM=1` |
|---|---|---|
| `envs.VLLM_USE_DEEP_GEMM` | True (untouched) | True |
| `has_deep_gemm()` | False | False |
| `is_numba_available()` | True (other probes unaffected) | True |
| `vllm.third_party.deep_gemm` imported | no | no |
| WARNING + traceback | gone | gone |
