### PR TITLE
[Docs] Add Qwen3.8-27B-W8A8 deployment tutorial and register Qwen3.8 in support matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ This plugin provides a hardware-pluggable interface that decouples the integrati
 | Qwen3-Next | ✅ | ✅ | ✅ | ✅ |
 | Qwen3.5 | ✅ | ✅ | | ✅ |
 | Qwen3.5-Moe | ✅ | ✅ | | ✅ |
+| [Qwen3.8](docs/source/tutorials/single_xpu_Qwen3.8-27B-W8A8.md) | ✅ | ✅ | | ✅ |
 | MiMo-V2-Flash | ✅ | ✅ | | ✅ |
 | Llama2 | ✅ | ✅ | ✅ | ✅ |
 | Llama3 | ✅ | ✅ | ✅ | ✅ |

--- a/docs/source/tutorials/index.md
+++ b/docs/source/tutorials/index.md
@@ -5,6 +5,7 @@
 :maxdepth: 1
 single_xpu_Qwen3-8B
 single_xpu_Qwen3-VL-32B
+single_xpu_Qwen3.8-27B-W8A8
 single_xpu_InternVL2_5-26B
 multi_xpu_Qwen2.5-VL-32B
 multi_xpu_GLM-4.5

--- a/docs/source/tutorials/single_xpu_Qwen3.8-27B-W8A8.md
+++ b/docs/source/tutorials/single_xpu_Qwen3.8-27B-W8A8.md
@@ -1,0 +1,151 @@
+# Single XPU (Qwen3.8-27B-W8A8)
+
+Qwen3.8-27B (`Qwen3_5ForConditionalGeneration`) is a hybrid-backbone model:
+64 decoder layers where every 4th layer is full attention (GQA, 24 query / 4 KV
+heads, head_dim 256) and the rest are GatedDeltaNet linear attention (16 KV /
+48 value heads, head_dim 128). The checkpoint ships with a vision tower and an
+MTP shard (`model-mtp.safetensors`), and the language model is quantized with
+compressed-tensors W8A8 (int-quantized, dynamic per-token activations). The
+quantization config is auto-detected from `config.json`, so no extra
+quantization flag is needed.
+
+Verified on a Kunlunxin P800 (96 GiB HBM) with a single XPU (TP=1),
+vLLM-Kunlun 0.25.1: service ready, multimodal warmup passed, CUDA graphs
+captured (piecewise + FULL), and a top-1/top-5 next-token differential against
+an independent CPU reference agreed on all cases.
+
+## Run vllm-kunlun on Single XPU
+
+Setup environment using container:
+
+Please follow the [installation.md](../installation.md) document to set up the environment first.
+
+Create a container
+
+```bash
+# !/bin/bash
+# rundocker.sh
+XPU_NUM=1
+DOCKER_DEVICE_CONFIG=""
+if [ $XPU_NUM -gt 0 ]; then
+    for idx in $(seq 0 $((XPU_NUM-1))); do
+        DOCKER_DEVICE_CONFIG="${DOCKER_DEVICE_CONFIG} --device=/dev/xpu${idx}:/dev/xpu${idx}"
+    done
+    DOCKER_DEVICE_CONFIG="${DOCKER_DEVICE_CONFIG} --device=/dev/xpuctrl:/dev/xpuctrl"
+fi
+
+export build_image="xxxxxxxxxxxxxxxxx"
+
+docker run -itd ${DOCKER_DEVICE_CONFIG} \
+    --net=host \
+    --cap-add=SYS_PTRACE --security-opt seccomp=unconfined \
+    --tmpfs /dev/shm:rw,nosuid,nodev,exec,size=32g \
+    --cap-add=SYS_PTRACE \
+    -v /home/users/vllm-kunlun:/home/vllm-kunlun \
+    -v /usr/local/bin/xpu-smi:/usr/local/bin/xpu-smi \
+    --name "$1" \
+    -w /workspace \
+    "$build_image" /bin/bash
+```
+
+### Preparation Weight
+
+- Download the Qwen3.8-27B-W8A8-INT8-Dynamic weights (HuggingFace format,
+  15 shards + `model-mtp.safetensors`, about 30 GiB)
+
+The `model-mtp.safetensors` shard holds the MTP draft weights. They are not
+parameters of `Qwen3_5ForConditionalGeneration`, so exclude the shard from
+weight loading with `--ignore-patterns`; otherwise the loader rejects the
+unexpected tensors.
+
+### Start the Server on a Single XPU
+
+```bash
+python3 -m vllm.entrypoints.openai.api_server \
+    --host 0.0.0.0 \
+    --port 8390 \
+    --model /models/Qwen3.8-27B-W8A8-INT8-Dynamic \
+    --served-model-name Qwen3.8-27B-Int8 \
+    --tensor-parallel-size 1 \
+    --dtype float16 \
+    --max-model-len 32768 \
+    --block-size 16 \
+    --gpu-memory-utilization 0.9 \
+    --ignore-patterns "model-mtp.safetensors"
+```
+
+Parameter notes:
+
+- `--dtype float16`: the checkpoint itself declares `dtype: float16`.
+- `--max-model-len 32768`: the checkpoint supports 262144 positions; 32768 is
+  what the verification run used. Raise it if your KV budget allows.
+- `--ignore-patterns "model-mtp.safetensors"`: skip the MTP draft shard.
+- Optional: add `--reasoning-parser qwen3 --tool-call-parser hermes` to split
+  reasoning content and parse tool calls (both verified against this model).
+
+### Offline Inference on Single XPU
+
+```{code-block} python
+from vllm import LLM, SamplingParams
+
+def main():
+    model_path = "/models/Qwen3.8-27B-W8A8-INT8-Dynamic"
+
+    llm = LLM(
+        model=model_path,
+        tensor_parallel_size=1,
+        dtype="float16",
+        max_model_len=32768,
+        ignore_patterns=["model-mtp.safetensors"],
+    )
+
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "text",
+                    "text": "tell a joke"
+                }
+            ]
+        }
+    ]
+
+    sampling_params = SamplingParams(max_tokens=200, temperature=1.0)
+
+    outputs = llm.chat(messages, sampling_params=sampling_params)
+    print(outputs[0].outputs[0].text)
+
+if __name__ == "__main__":
+    main()
+```
+
+### Multi XPU Reference
+
+The 24 full-attention query heads and 48 linear-attention value heads are both
+divisible by 8, so an 8-XPU deployment is expected to work with:
+
+```bash
+python3 -m vllm.entrypoints.openai.api_server \
+    --model /models/Qwen3.8-27B-W8A8-INT8-Dynamic \
+    --tensor-parallel-size 8 \
+    --dtype float16 \
+    --max-model-len 32768 \
+    --gpu-memory-utilization 0.9 \
+    --ignore-patterns "model-mtp.safetensors"
+```
+
+TP=8 has not been verified yet; the numbers in this document all come from the
+single-XPU run above.
+
+### Verified Memory Budget (single XPU, TP=1)
+
+Reconciled against `xpu_smi` on the P800:
+
+| Category | MiB | Source |
+| --- | --- | --- |
+| Model weights | 29194 | server log |
+| KV pool (754392 tokens) | 50801 | server log |
+| Graph capture | 123 | server log |
+| Driver / runtime / allocator | 8868 | xpu_smi remainder |
+| Free | 9318 | xpu_smi |

--- a/docs/source/tutorials/single_xpu_Qwen3.8-27B-W8A8.md
+++ b/docs/source/tutorials/single_xpu_Qwen3.8-27B-W8A8.md
@@ -23,7 +23,7 @@ Please follow the [installation.md](../installation.md) document to set up the e
 Create a container
 
 ```bash
-# !/bin/bash
+#!/bin/bash
 # rundocker.sh
 XPU_NUM=1
 DOCKER_DEVICE_CONFIG=""
@@ -34,13 +34,12 @@ if [ $XPU_NUM -gt 0 ]; then
     DOCKER_DEVICE_CONFIG="${DOCKER_DEVICE_CONFIG} --device=/dev/xpuctrl:/dev/xpuctrl"
 fi
 
-export build_image="xxxxxxxxxxxxxxxxx"
+export build_image="<your-kunlun-vllm-image>"
 
 docker run -itd ${DOCKER_DEVICE_CONFIG} \
     --net=host \
     --cap-add=SYS_PTRACE --security-opt seccomp=unconfined \
     --tmpfs /dev/shm:rw,nosuid,nodev,exec,size=32g \
-    --cap-add=SYS_PTRACE \
     -v /home/users/vllm-kunlun:/home/vllm-kunlun \
     -v /usr/local/bin/xpu-smi:/usr/local/bin/xpu-smi \
     --name "$1" \
@@ -48,7 +47,7 @@ docker run -itd ${DOCKER_DEVICE_CONFIG} \
     "$build_image" /bin/bash
 ```
 
-### Preparation Weight
+### Preparation of Model Weights
 
 - Download the Qwen3.8-27B-W8A8-INT8-Dynamic weights (HuggingFace format,
   15 shards + `model-mtp.safetensors`, about 30 GiB)
@@ -140,12 +139,12 @@ single-XPU run above.
 
 ### Verified Memory Budget (single XPU, TP=1)
 
-Reconciled against `xpu_smi` on the P800:
+Reconciled against `xpu-smi` on the P800:
 
 | Category | MiB | Source |
 | --- | --- | --- |
 | Model weights | 29194 | server log |
 | KV pool (754392 tokens) | 50801 | server log |
 | Graph capture | 123 | server log |
-| Driver / runtime / allocator | 8868 | xpu_smi remainder |
-| Free | 9318 | xpu_smi |
+| Driver / runtime / allocator | 8868 | xpu-smi remainder |
+| Free | 9318 | xpu-smi |

--- a/docs/source/user_guide/support_matrix/supported_models.md
+++ b/docs/source/user_guide/support_matrix/supported_models.md
@@ -7,7 +7,12 @@
 | Qwen3         | ✅       | ✅    | ✅    | ✅               |                 | ✅             | ✅                      |
 | Qwen3-Moe     | ✅       | ✅    | ✅    | ✅               | ✅               | ✅             | ✅                      |
 | Qwen3-Next    | ✅       | ✅    | ✅    | ✅               | ✅               | ✅             | ✅                      |
+| Qwen3.8       | ✅       | ✅    |      |                  |                 |              | ✅                      |
 | Deepseek v3.2 | ✅       | ✅    |      | ✅               |                 | ✅             | ✅                      |
+
+Qwen3.8 (27B-W8A8): verified on a single XPU (`tensor_parallel_size=1`) with a
+compressed-tensors W8A8 checkpoint; multi-XPU tensor parallel is pending
+verification. See the [Qwen3.8 tutorial](../../tutorials/single_xpu_Qwen3.8-27B-W8A8.md).
 
 ## Multimodal Language Models
 | Model    | Support | W8A8 | LoRA | Tensor Parallel | Expert Parallel | Data Parallel | Piecewise Kunlun Graph |

--- a/docs/source/user_guide/support_matrix/supported_models.md
+++ b/docs/source/user_guide/support_matrix/supported_models.md
@@ -11,8 +11,8 @@
 | Deepseek v3.2 | ✅       | ✅    |      | ✅               |                 | ✅             | ✅                      |
 
 Qwen3.8 (27B-W8A8): verified on a single XPU (`tensor_parallel_size=1`) with a
-compressed-tensors W8A8 checkpoint; multi-XPU tensor parallel is pending
-verification. See the [Qwen3.8 tutorial](../../tutorials/single_xpu_Qwen3.8-27B-W8A8.md).
+compressed-tensors W8A8 checkpoint; LoRA and multi-XPU tensor parallel
+are pending verification. See the [Qwen3.8 tutorial](../../tutorials/single_xpu_Qwen3.8-27B-W8A8.md).
 
 ## Multimodal Language Models
 | Model    | Support | W8A8 | LoRA | Tensor Parallel | Expert Parallel | Data Parallel | Piecewise Kunlun Graph |


### PR DESCRIPTION
## What is this PR to do

Register **Qwen3.8-27B-W8A8-INT8-Dynamic** (`Qwen3_5ForConditionalGeneration`) as a supported model and document its verified deployment:

1. **New tutorial** `docs/source/tutorials/single_xpu_Qwen3.8-27B-W8A8.md`
   - container setup, server launch and offline inference scripts
   - the checkpoint's MTP shard (`model-mtp.safetensors`) is not a parameter of `Qwen3_5ForConditionalGeneration` and must be excluded via `--ignore-patterns`
   - compressed-tensors W8A8 is auto-detected from `config.json`, no extra flag needed
   - memory budget reconciled against `xpu_smi`
   - the TP=8 command is included but explicitly marked unverified
2. **README** generative-models table: add Qwen3.8 row (with tutorial link)
3. **docs support matrix** (`supported_models.md`): add Qwen3.8 row; quantization and Piecewise Kunlun Graph marked from the verified run, LoRA / multi-XPU left unmarked with a note

## Verification (single XPU TP=1, one Kunlunxin P800 96 GiB, vLLM-Kunlun 0.25.1)

- Service ready, multimodal warmup passed, CUDA graphs captured (piecewise + FULL)
- Next-token differential vs an independent CPU fp32 reference: 3/3 top-1 agreement, top-5 overlap 4-5/5
- Memory budget (xpu_smi reconciled): weights 29194 MiB, KV pool 50801 MiB (754392 tokens), graph capture 123 MiB, driver/runtime remainder 8868 MiB, free 9318 MiB — BUDGET_ACCEPTABLE
- Launch parameters: `--tensor-parallel-size 1 --dtype float16 --max-model-len 32768 --block-size 16 --gpu-memory-utilization 0.9 --ignore-patterns "model-mtp.safetensors"`

## Notes

- Branch is based on `v0.25.1-dev` (2ee42e52), the revision the verification ran against.
- LoRA and multi-XPU tensor parallel are intentionally **not** claimed: they were not exercised. TP=8 is expected to work (24 full-attention query heads and 48 linear-attention value heads are both divisible by 8) and is listed in the tutorial as pending verification.